### PR TITLE
Adapt to new repository structure

### DIFF
--- a/spec/integration/support/kiwi_export_examples.rb
+++ b/spec/integration/support/kiwi_export_examples.rb
@@ -19,7 +19,7 @@ shared_examples "kiwi export" do
   describe "export-kiwi" do
     it "creates a kiwi description" do
       @machinery.inject_directory(
-        "spec/data/descriptions/jeos/",
+        File.join(Machinery::ROOT, "spec/data/descriptions/jeos/"),
         "/home/vagrant/.machinery/",
         owner: "vagrant",
         group: "users"


### PR DESCRIPTION
Using an absolute path here allows to reuse the shared_examples outside
of this repository as well.
