### PR TITLE
Consolidate exception classes

### DIFF
--- a/lib/analyze_config_file_diffs_task.rb
+++ b/lib/analyze_config_file_diffs_task.rb
@@ -19,7 +19,7 @@ class AnalyzeConfigFileDiffsTask
   def analyze(description)
     description.assert_scopes("repositories", "config-files")
     if !description.file_store("config-files")
-      raise Machinery::Errors::SystemDescriptionIncomplete.new(
+      raise Machinery::Errors::SystemDescriptionError.new(
         "Missing extracted config files.\n" \
         "You can extract them using 'machinery inspect -s config-files -x'."
       )

--- a/lib/deploy_task.rb
+++ b/lib/deploy_task.rb
@@ -19,14 +19,14 @@ class DeployTask
   def deploy(description, cloud_config, options = {})
     Machinery::check_package("python-glanceclient")
     if !File.exists?(cloud_config)
-      raise(Machinery::Errors::FileNotFound,
+      raise(Machinery::Errors::DeployFailed,
         "The cloud config file '#{cloud_config}' could not be found."
       )
     end
 
     if options[:image_dir]
       if !Dir.exists?(options[:image_dir])
-        raise(Machinery::Errors::FileNotFound,
+        raise(Machinery::Errors::DeployFailed,
           "The image directory does not exist."
         )
       end
@@ -48,7 +48,7 @@ class DeployTask
     end
 
     if !File.exists?(image_file)
-      raise(Machinery::Errors::FileNotFound,
+      raise(Machinery::Errors::DeployFailed,
         "The image file '#{image_file}' does not exist."
       )
     end
@@ -72,7 +72,7 @@ class DeployTask
   def load_meta_data(meta_dir)
       meta_file = File.join(meta_dir, Machinery::IMAGE_META_DATA_FILE)
       if !File.exists?(meta_file)
-        raise(Machinery::Errors::FileNotFound,
+        raise(Machinery::Errors::DeployFailed,
           "The meta data file '#{meta_file}' could not be found."
         )
       end
@@ -80,7 +80,7 @@ class DeployTask
       meta_data = YAML.load_file(meta_file)
 
       if !meta_data[:image_file] || !meta_data[:description]
-        raise(Machinery::Errors::BrokenMetaData,
+        raise(Machinery::Errors::DeployFailed,
           "The meta data file '#{meta_file}' is broken."
         )
       end

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -25,32 +25,22 @@ module Machinery
     # showing a backtrace.
     class MachineryError < StandardError; end
 
-    class SystemDescriptionValidationFailed < MachineryError; end
-    class SystemDescriptionNotFound < MachineryError; end
-    class SystemDescriptionAlreadyExists < MachineryError; end
-    class SystemDescriptionIncomplete < MachineryError; end
-    class SystemDescriptionNameInvalid < MachineryError; end
-    class SystemDescriptionInvalid < MachineryError; end
-
     class UnknownInspector < MachineryError; end
     class UnknownRenderer < MachineryError; end
-    class ScopeFailed < MachineryError; end
+    class InvalidPager < MachineryError; end
+    class InvalidCommandLine < MachineryError; end
 
-    class MissingSystemRequirement < MachineryError; end
-    class UnsupportedOperatingSystem < MachineryError; end
     class MissingRequirement < MachineryError; end
 
+    class SystemDescriptionError < MachineryError; end
+    class SystemDescriptionNotFound < SystemDescriptionError; end
+
     class BuildFailed < MachineryError; end
-    class UnsupportedBuildTarget < MachineryError; end
+    class DeployFailed < MachineryError; end
+    class InspectionFailed < MachineryError; end
+    class KiwiExportFailed < MachineryError; end
 
     class SshConnectionFailed < MachineryError; end
     class RsyncFailed < MachineryError; end
-
-    class FileNotFound < MachineryError; end
-    class DirectoryAlreadyExists < MachineryError; end
-    class BrokenMetaData < MachineryError; end
-    class UnknownSystemdUnitState < MachineryError; end
-    class InvalidPager < MachineryError; end
-    class InvalidCommandLine < MachineryError; end
   end
 end

--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -31,7 +31,7 @@ module Machinery
         " Supported image build target(s) on buildhost " +
         "'#{system_description.buildhost.os_name}' are: " +
         "'#{system_description.buildhost.can_build}'"
-      raise(Machinery::Errors::UnsupportedBuildTarget.new(message))
+      raise(Machinery::Errors::BuildFailed.new(message))
     end
   end
 end

--- a/lib/inspect_task.rb
+++ b/lib/inspect_task.rb
@@ -31,7 +31,7 @@ class InspectTask
     if !failed_inspections.empty?
       puts "\n"
       message = failed_inspections.map { |scope, msg| "Errors while inspecting #{scope}:\n#{msg}" }.join("\n\n")
-      raise Machinery::Errors::ScopeFailed.new(message)
+      raise Machinery::Errors::InspectionFailed.new(message)
     end
     description
   end
@@ -40,7 +40,7 @@ class InspectTask
 
   def check_root(system, current_user)
     if system.requires_root? && !current_user.is_root?
-      raise Machinery::Errors::MissingSystemRequirement,
+      raise Machinery::Errors::MissingRequirement,
             "Need to be root to inspect local system."
     end
   end

--- a/lib/kiwi_config.rb
+++ b/lib/kiwi_config.rb
@@ -128,7 +128,7 @@ class KiwiConfig
     end
 
     if !scopes.empty?
-      raise Machinery::Errors::SystemDescriptionIncomplete.new(
+      raise Machinery::Errors::SystemDescriptionError.new(
         "Cannot create kiwi config. " \
         "The following scopes #{scopes.join(",")} are part of the system " \
         "description but the corresponding files weren't extracted during " \
@@ -155,7 +155,7 @@ EOF
         boot = "vmxboot/suse-SLES11"
         bootloader = "grub"
       else
-        raise Machinery::Errors::UnsupportedOperatingSystem.new(
+        raise Machinery::Errors::KiwiExportFailed.new(
           "Building is not possible because the operating system " \
           "'#{@system_description.os.name}' is not supported."
         )
@@ -295,7 +295,7 @@ EOF
                 # Don't do anything because these states are not supposed
                 # to be permanent.
               else
-                raise Machinery::Errors::UnknownSystemdUnitState.new(
+                raise Machinery::Errors::KiwiExportFailed.new(
                   "The systemd unit state #{service.state} is unknown."
                 )
             end

--- a/lib/kiwi_export_task.rb
+++ b/lib/kiwi_export_task.rb
@@ -21,7 +21,7 @@ class KiwiExportTask
       if options[:force]
         FileUtils.rm_r(kiwi_dir)
       else
-        raise Machinery::Errors::DirectoryAlreadyExists.new(
+        raise Machinery::Errors::KiwiExportFailed.new(
           "The output directory '#{kiwi_dir}' already exists." \
           " You can force overwriting it with the '--force' option."
         )

--- a/lib/system.rb
+++ b/lib/system.rb
@@ -40,7 +40,7 @@ class System
     begin
       run_command(command, *args)
     rescue Cheetah::ExecutionFailed
-      raise Machinery::Errors::MissingSystemRequirement.new(
+      raise Machinery::Errors::MissingRequirement.new(
         "Need binary '#{command}' to be available on the inspected system."
       )
     end

--- a/lib/system_description.rb
+++ b/lib/system_description.rb
@@ -34,7 +34,7 @@ class SystemDescription < Machinery::Object
     json_hash = JSON.parse(json)
 
     if !json_hash.is_a?(Hash)
-      raise Machinery::Errors::SystemDescriptionInvalid.new(
+      raise Machinery::Errors::SystemDescriptionError.new(
         "System descriptions must have a hash as the root element"
       )
     end
@@ -89,7 +89,7 @@ class SystemDescription < Machinery::Object
     end
 
     unless missing.empty?
-      raise Machinery::Errors::SystemDescriptionIncomplete.new(
+      raise Machinery::Errors::SystemDescriptionError.new(
         "The system description misses the following section(s): #{missing.join(", ")}."
       )
     end
@@ -130,7 +130,7 @@ class SystemDescription < Machinery::Object
       message = "Unsupported build host distribution " +
         "'#{buildhost_os_name}'. " +
         "Supported are '#{OsBuild.supported_buildhost}'"
-      raise(Machinery::Errors::UnsupportedBuildTarget.new(message))
+      raise(Machinery::Errors::BuildFailed.new(message))
     end
 
     OsBuild.instance_for(buildhost_os_name, self.os.name)

--- a/lib/system_description_store.rb
+++ b/lib/system_description_store.rb
@@ -81,7 +81,7 @@ class SystemDescriptionStore
     end
 
     if list.include?(to)
-      raise Machinery::Errors::SystemDescriptionAlreadyExists.new(
+      raise Machinery::Errors::SystemDescriptionError.new(
         "A System description with the name \"#{to}\" does already exist."
       )
     end
@@ -126,13 +126,13 @@ class SystemDescriptionStore
 
   def validate_name(name)
     if ! /^[\w\.:-]*$/.match(name)
-      raise Machinery::Errors::SystemDescriptionNameInvalid.new(
+      raise Machinery::Errors::SystemDescriptionError.new(
         "System description name \"#{name}\" is invalid. Only \"a-zA-Z0-9_:.-\" are valid characters."
       )
     end
 
     if name.start_with?(".")
-      raise Machinery::Errors::SystemDescriptionNameInvalid.new(
+      raise Machinery::Errors::SystemDescriptionError.new(
         "System description name \"#{name}\" is invalid. A dot is not allowed as first character."
       )
     end

--- a/plugins/show/config_files_renderer.rb
+++ b/plugins/show/config_files_renderer.rb
@@ -25,7 +25,7 @@ class ConfigFilesRenderer < Renderer
     end
 
     if !diffs_dir && @options[:show_diffs]
-      raise Machinery::Errors::SystemDescriptionIncomplete.new(
+      raise Machinery::Errors::SystemDescriptionError.new(
         "Diffs can not be shown because they were not generated yet.\n" \
         "You can generate them with 'machinery analyze #{@system_description.name} -o config-file-diffs'."
       )

--- a/spec/unit/analyze_config_file_diffs_task_spec.rb
+++ b/spec/unit/analyze_config_file_diffs_task_spec.rb
@@ -125,7 +125,7 @@ describe AnalyzeConfigFileDiffsTask do
       task = AnalyzeConfigFileDiffsTask.new
       expect {
         task.analyze(SystemDescription.new("foo"))
-      }.to raise_error(Machinery::Errors::SystemDescriptionIncomplete)
+      }.to raise_error(Machinery::Errors::SystemDescriptionError)
     end
   end
 

--- a/spec/unit/config_files_inspector_spec.rb
+++ b/spec/unit/config_files_inspector_spec.rb
@@ -238,11 +238,11 @@ EOF
       system = double
       expect(system).to receive(:check_requirement).with(
         "rpm", "--version"
-      ).and_raise(Machinery::Errors::MissingSystemRequirement)
+      ).and_raise(Machinery::Errors::MissingRequirement)
 
       inspector = ConfigFilesInspector.new
       expect{inspector.inspect(system, description)}.to raise_error(
-        Machinery::Errors::MissingSystemRequirement)
+        Machinery::Errors::MissingRequirement)
     end
 
     it "extracts changed configuration files" do

--- a/spec/unit/config_files_renderer_spec.rb
+++ b/spec/unit/config_files_renderer_spec.rb
@@ -108,7 +108,7 @@ describe ConfigFilesRenderer do
 
         expect {
           subject.render(system_description, show_diffs: true)
-        }.to raise_error(Machinery::Errors::SystemDescriptionIncomplete)
+        }.to raise_error(Machinery::Errors::SystemDescriptionError)
       end
     end
   end

--- a/spec/unit/deploy_task_spec.rb
+++ b/spec/unit/deploy_task_spec.rb
@@ -85,7 +85,7 @@ describe DeployTask do
       expect(File.exists?(image_dir)).to be(false)
       expect{
         deploy_task.deploy(system_description, cloud_config_file, image_dir: "/tmp/doesnotexist")
-      }.to raise_error(Machinery::Errors::FileNotFound, /image dir/)
+      }.to raise_error(Machinery::Errors::DeployFailed, /image dir/)
     end
 
     it "raises an exception if system description doesn't equal the meta data" do
@@ -97,13 +97,13 @@ describe DeployTask do
     it "raises an exception if the image mentioned in the meta data doesn't exist" do
       expect{
         deploy_task.deploy(system_description, cloud_config_file, image_dir: "/image_is_missing")
-      }.to raise_error(Machinery::Errors::FileNotFound, /image file '.*' does not exist/)
+      }.to raise_error(Machinery::Errors::DeployFailed, /image file '.*' does not exist/)
     end
 
     it "raises an exception if the cloud config file is missing" do
       expect{
         deploy_task.deploy(system_description, "/tmp/doesnotexist.sh", image_dir: image_dir)
-      }.to raise_error(Machinery::Errors::FileNotFound, /cloud config file.*could not be found/)
+      }.to raise_error(Machinery::Errors::DeployFailed, /cloud config file.*could not be found/)
     end
   end
 end

--- a/spec/unit/helper_spec.rb
+++ b/spec/unit/helper_spec.rb
@@ -68,7 +68,7 @@ describe Machinery do
     }
 
     it "raises an Machinery::UnsupportedHostForImageError error if the host for image build combination is unsupported" do
-      expect { Machinery::check_build_compatible_host(system_description) }.to raise_error(Machinery::Errors::UnsupportedBuildTarget, /#{system_description.os.name}/)
+      expect { Machinery::check_build_compatible_host(system_description) }.to raise_error(Machinery::Errors::BuildFailed, /#{system_description.os.name}/)
     end
 
     it "doesn't raise if host and image builds a valid combination" do

--- a/spec/unit/inspect_task_spec.rb
+++ b/spec/unit/inspect_task_spec.rb
@@ -98,7 +98,7 @@ describe InspectTask, "#inspect_system" do
 
       expect {
         inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"])
-      }.to raise_error(Machinery::Errors::ScopeFailed)
+      }.to raise_error(Machinery::Errors::InspectionFailed)
     end
 
     it "bubbles up 'unexpected errors'" do
@@ -119,7 +119,7 @@ describe InspectTask, "#inspect_system" do
       it "raises an exception we don't run as root" do
         expect {
           inspect_task.inspect_system(store, "localhost", name, current_user_non_root, ["foo"])
-        }.to raise_error(Machinery::Errors::MissingSystemRequirement)
+        }.to raise_error(Machinery::Errors::MissingRequirement)
       end
 
       it "doesn't raise an exception when we run as root" do

--- a/spec/unit/kiwi_config_spec.rb
+++ b/spec/unit/kiwi_config_spec.rb
@@ -412,7 +412,7 @@ describe KiwiConfig do
       expect {
         KiwiConfig.new(system_description_with_content)
       }.to raise_error(
-         Machinery::Errors::UnsupportedOperatingSystem,
+         Machinery::Errors::KiwiExportFailed,
          /Unknown Operating System/
       )
     end
@@ -507,7 +507,7 @@ describe KiwiConfig do
       system_description_with_systemd_services.services.services.first["state"] = "not_known"
       expect {
         KiwiConfig.new(system_description_with_systemd_services)
-      }.to raise_error(Machinery::Errors::UnknownSystemdUnitState, /not_known/)
+      }.to raise_error(Machinery::Errors::KiwiExportFailed, /not_known/)
     end
 
     it "sets the target distribution and bootloader for SLES11" do
@@ -540,7 +540,7 @@ describe KiwiConfig do
       system_description_with_modified_files.remove_file_store(scope)
       expect {
         KiwiConfig.new(system_description_with_modified_files)
-      }.to raise_error(Machinery::Errors::SystemDescriptionIncomplete, /#{scope}/)
+      }.to raise_error(Machinery::Errors::SystemDescriptionError, /#{scope}/)
     end
 
     it "throws an error if changed managed files are part of the system description but don't exist on the filesystem" do
@@ -548,7 +548,7 @@ describe KiwiConfig do
       system_description_with_modified_files.remove_file_store(scope)
       expect {
         KiwiConfig.new(system_description_with_modified_files)
-      }.to raise_error(Machinery::Errors::SystemDescriptionIncomplete, /#{scope}/)
+      }.to raise_error(Machinery::Errors::SystemDescriptionError, /#{scope}/)
     end
 
     it "throws an error if unmanaged files are part of the system description but don't exist on the filesystem" do
@@ -556,7 +556,7 @@ describe KiwiConfig do
       system_description_with_modified_files.remove_file_store(scope)
       expect {
         KiwiConfig.new(system_description_with_modified_files)
-      }.to raise_error(Machinery::Errors::SystemDescriptionIncomplete, /#{scope}/)
+      }.to raise_error(Machinery::Errors::SystemDescriptionError, /#{scope}/)
     end
 
     it "applies 'pre-process' config" do

--- a/spec/unit/kiwi_export_task_spec.rb
+++ b/spec/unit/kiwi_export_task_spec.rb
@@ -46,7 +46,7 @@ describe KiwiExportTask do
       it "raises an error when --force is not given" do
         expect {
           subject.export(nil, kiwi_dir, force: false)
-        }.to raise_error(Machinery::Errors::DirectoryAlreadyExists)
+        }.to raise_error(Machinery::Errors::KiwiExportFailed)
       end
 
       it "overwrites existing directory when --force is given" do

--- a/spec/unit/repositories_inspector_spec.rb
+++ b/spec/unit/repositories_inspector_spec.rb
@@ -180,11 +180,11 @@ password=0a0918c876ef4a1d9c352e5c47421235
       system = double
       expect(system).to receive(:check_requirement).with(
         "zypper", "--version"
-      ).and_raise(Machinery::Errors::MissingSystemRequirement)
+      ).and_raise(Machinery::Errors::MissingRequirement)
 
       inspector = RepositoriesInspector.new
       expect{inspector.inspect(system, description)}.to raise_error(
-        Machinery::Errors::MissingSystemRequirement)
+        Machinery::Errors::MissingRequirement)
     end
 
     it "returns sorted data" do

--- a/spec/unit/services_inspector_spec.rb
+++ b/spec/unit/services_inspector_spec.rb
@@ -103,11 +103,11 @@ EOF
         and_raise(Cheetah::ExecutionFailed.new(nil, nil, nil, nil))
       expect(system).to receive(:check_requirement).
         with("chkconfig", "--help").
-        and_raise(Machinery::Errors::MissingSystemRequirement)
+        and_raise(Machinery::Errors::MissingRequirement)
 
       expect {
         inspector.inspect(system, description)
-      }.to raise_error(Machinery::Errors::MissingSystemRequirement)
+      }.to raise_error(Machinery::Errors::MissingRequirement)
     end
   end
 end

--- a/spec/unit/system_description_spec.rb
+++ b/spec/unit/system_description_spec.rb
@@ -117,19 +117,19 @@ describe SystemDescription do
     class SystemDescriptionFooConfig < Machinery::Object; end
     expect { SystemDescription.from_json(@name,
       '[ "system-description-foo", "xxx" ]'
-    )}.to raise_error(Machinery::Errors::SystemDescriptionInvalid)
+    )}.to raise_error(Machinery::Errors::SystemDescriptionError)
   end
 
   it "raises ValidationError if json validator find duplicate packages" do
     SystemDescription.add_validator "/packages" do |json|
       if json != json.uniq
-        raise Machinery::Errors::SystemDescriptionValidationFailed,
+        raise Machinery::Errors::SystemDescriptionError,
           "The description contains duplicate packages."
       end
     end
     expect { SystemDescription.from_json(@name,
       @duplicate_description
-    )}.to raise_error(Machinery::Errors::SystemDescriptionValidationFailed)
+    )}.to raise_error(Machinery::Errors::SystemDescriptionError)
   end
 
   describe "#scopes" do
@@ -154,7 +154,7 @@ describe SystemDescription do
           end
           description.assert_scopes("repositories", "packages")
         }.to raise_error(
-           Machinery::Errors::SystemDescriptionIncomplete,
+           Machinery::Errors::SystemDescriptionError,
            /: #{missing.join(", ")}\./)
       end
     end
@@ -170,7 +170,7 @@ describe SystemDescription do
 
       expect {
         description.short_os_version
-      }.to raise_error(Machinery::Errors::SystemDescriptionIncomplete)
+      }.to raise_error(Machinery::Errors::SystemDescriptionError)
     end
 
     it "parses openSUSE versions" do
@@ -281,7 +281,7 @@ describe SystemDescription do
           description.os = system_description.os
         end
       end
-      expect { description.buildhost }.to raise_error(Machinery::Errors::UnsupportedBuildTarget, /Unsupported build host distribution/)
+      expect { description.buildhost }.to raise_error(Machinery::Errors::BuildFailed, /Unsupported build host distribution/)
     end
   end
 end

--- a/spec/unit/system_description_store_spec.rb
+++ b/spec/unit/system_description_store_spec.rb
@@ -94,8 +94,8 @@ describe SystemDescriptionStore do
 
     it "raises Errors::SystemDescriptionInvalid if the system description name is invalid" do
       store = SystemDescriptionStore.new
-      expect { store.save(SystemDescription.from_json("invalid/slash", test_manifest)) }.to raise_error(Machinery::Errors::SystemDescriptionNameInvalid)
-      expect { store.save(SystemDescription.from_json(".invalid_dot", test_manifest)) }.to raise_error(Machinery::Errors::SystemDescriptionNameInvalid)
+      expect { store.save(SystemDescription.from_json("invalid/slash", test_manifest)) }.to raise_error(Machinery::Errors::SystemDescriptionError)
+      expect { store.save(SystemDescription.from_json(".invalid_dot", test_manifest)) }.to raise_error(Machinery::Errors::SystemDescriptionError)
     end
   end
 
@@ -169,7 +169,7 @@ describe SystemDescriptionStore do
       expect(store.list).to include(new_name)
       expect {
         store.copy(test_name, new_name)
-      }.to raise_error(Machinery::Errors::SystemDescriptionAlreadyExists, /#{new_name}/)
+      }.to raise_error(Machinery::Errors::SystemDescriptionError, /#{new_name}/)
     end
   end
 

--- a/spec/unit/unmanaged_files_inspector_spec.rb
+++ b/spec/unit/unmanaged_files_inspector_spec.rb
@@ -331,11 +331,11 @@ describe UnmanagedFilesInspector do
       system = double
       expect(system).to receive(:check_requirement).with(
         "rpm", "--version"
-      ).and_raise(Machinery::Errors::MissingSystemRequirement)
+      ).and_raise(Machinery::Errors::MissingRequirement)
 
       inspector = UnmanagedFilesInspector.new
       expect{inspector.inspect(system, description)}.to raise_error(
-        Machinery::Errors::MissingSystemRequirement)
+        Machinery::Errors::MissingRequirement)
     end
 
     it "extracts unmanaged files" do


### PR DESCRIPTION
Our rationale for exception classes is to have exception classes for
cross-cutting concerns (system description, connection erros,
command-line) and then for specific areas (building, kiwi export,
deploying, inspection). Inside these we try to not introduce too many
similar classes.
