### PR TITLE
Use correct exception

### DIFF
--- a/lib/system_description.rb
+++ b/lib/system_description.rb
@@ -128,7 +128,7 @@ class SystemDescription < Machinery::Object
       end
     end
 
-    raise Machinery::Errors::SystemDescriptionInvalid.new(
+    raise Machinery::Errors::SystemDescriptionError.new(
       "Unrecognized operating system '#{self.os.name}")
   end
 

--- a/spec/unit/system_description_spec.rb
+++ b/spec/unit/system_description_spec.rb
@@ -269,5 +269,19 @@ describe SystemDescription do
 
       expect(description.os_object).to be_a(OsOpenSuse13_1)
     end
+
+    it "raises exception for invalid os name" do
+      json = <<-EOF
+        {
+          "os": {
+            "name": "invalid name"
+          }
+        }
+      EOF
+      description = SystemDescription.from_json("name", json)
+
+      expect{ description.os_object }.to(
+        raise_error(Machinery::Errors::SystemDescriptionError))
+    end
   end
 end


### PR DESCRIPTION
The exception cleanup introduced a general exception for error with
the system description. Using this here now.
