### PR TITLE
[Review] Request from 'aduffeck' @ 'SUSE/machinery/review_140805_fix_unmanaged_files_inspector'

### DIFF
--- a/plugins/inspect/unmanaged_files_inspector.rb
+++ b/plugins/inspect/unmanaged_files_inspector.rb
@@ -155,7 +155,7 @@ class UnmanagedFilesInspector < Inspector
     dirs = {}
 
     # compute command line
-    cmd = "find #{dir} -xdev -maxdepth 1 -maxdepth #{depth} "
+    cmd = "find #{dir.shellescape} -xdev -maxdepth 1 -maxdepth #{depth} "
     cmd += '-printf "%y\0%P\0%l\0"'
 
     # Cheetah seems to be unable to handle binary zeroes "\0" in parameters

--- a/spec/data/unmanaged_files/find_root
+++ b/spec/data/unmanaged_files/find_root
@@ -89,7 +89,7 @@ d
 etc/ppp
 
 d
-etc/ppp/ip-down.d
+etc/ppp/ip 'down.d
 
 d
 etc/ppp/ip-up.d

--- a/spec/data/unmanaged_files/rpm_qlav
+++ b/spec/data/unmanaged_files/rpm_qlav
@@ -28,7 +28,7 @@ d /etc/news
 d /etc/opt
 d /etc/permissions.d
 d /etc/ppp
-d /etc/ppp/ip-down.d
+d /etc/ppp/ip 'down.d
 d /etc/ppp/ip-up.d
 d /etc/profile.d
 l /etc/rc.d -> init.d

--- a/spec/unit/unmanaged_files_inspector_spec.rb
+++ b/spec/unit/unmanaged_files_inspector_spec.rb
@@ -123,7 +123,7 @@ describe UnmanagedFilesInspector do
     def expect_find_commands(system,add_files)
       dirs = [
         "/",
-        "/etc/ppp/ip-down.d",
+        "/etc/ppp/ip 'down.d",
         "/etc/ppp/ip-up.d",
         "/etc/skel/.config",
         "/etc/skel/.fonts",
@@ -223,7 +223,7 @@ describe UnmanagedFilesInspector do
         "/usr/share/info"                => "sinfo"
       }
       dirs.each do |d|
-        cmd = "find #{d} -xdev -maxdepth 1 -maxdepth 3 -printf \"%y\\0%P\\0%l\\0\""
+        cmd = "find #{d.shellescape} -xdev -maxdepth 1 -maxdepth 3 -printf \"%y\\0%P\\0%l\\0\""
 
         # non_empty_dirs maps dirs to extension names where content of dir is stored
         # files with test content is saved in find_#{ext}


### PR DESCRIPTION
Please review the following changes:
- 86a61a9 Shellescape directory names in order to not choke on special chars
