### PR TITLE
Rename "repo_type" attribute of the repositories scope to "type"

### DIFF
--- a/docs/Data-Model.md
+++ b/docs/Data-Model.md
@@ -14,7 +14,7 @@ JSON serialization is used to store and exchange the system configuration.
 
 At the top level, the data consists of a JSON object. Each key in this object corresponds to a configuration scope (e.g. repositories, packages, changed configuration files, etc.). Data under each key is further structured into JSON objects and arrays as needed.
 
-There is one special key `meta`, which is used to collect meta data of the information in the scope sections. 
+There is one special key `meta`, which is used to collect meta data of the information in the scope sections.
 
 For example, a JSON document describing software configuration may look like this:
 
@@ -25,7 +25,7 @@ For example, a JSON document describing software configuration may look like thi
       "alias": "YaST:Head",
       "name": "YaST:Head",
       "url": "http://download.opensuse.org/repositories/YaST:/Head/openSUSE_12.3/",
-      "repo_type": "rpm-md",
+      "type": "rpm-md",
       "priority": 99,
       "enabled": true,
       "autorefresh": true,
@@ -120,7 +120,7 @@ SystemDescription.add_validator "#/software/packages" do |json|
   if json != json.uniq
     raise Machinery::ValidationError,
           "The #{description} contains duplicate packages."
-  end  
+  end
 end
 ```
 

--- a/lib/kiwi_config.rb
+++ b/lib/kiwi_config.rb
@@ -214,21 +214,21 @@ EOF
     if @system_description.repositories
       @system_description.repositories.each do |repo|
         # only use accessible repositories as source for kiwi build
-        parameters = { type: repo.repo_type, priority: repo.priority }
+        parameters = { type: repo.type, priority: repo.priority }
         if repo.username && repo.password
           parameters[:username] = repo.username
           parameters[:password] = repo.password
         end
         is_external_medium = repo.url.start_with?("cd://") ||
           repo.url.start_with?("dvd://")
-        if repo.enabled && !repo.repo_type.nil? && !is_external_medium
+        if repo.enabled && !repo.type.nil? && !is_external_medium
           xml.repository(parameters) do
             xml.source(path: repo.url)
           end
         end
         if !repo.url.match(/^https:\/\/nu.novell.com|^https:\/\/update.suse.com/)
           @sh << "zypper -n ar --name='#{repo.name}' "
-          @sh << "--type='#{repo.repo_type}' " if repo.repo_type
+          @sh << "--type='#{repo.type}' " if repo.type
           @sh << "--refresh " if repo.autorefresh
           @sh << "--disable " unless repo.enabled
           @sh << "'#{repo.url}' '#{repo.alias}'\n"

--- a/plugins/inspect/repositories_inspector.rb
+++ b/plugins/inspect/repositories_inspector.rb
@@ -73,7 +73,7 @@ class RepositoriesInspector < Inspector
         repository = Repository.new(
           alias:       rep["alias"],
           name:        rep["name"],
-          repo_type:   rep["type"],
+          type:        rep["type"],
           url:         rep.at_xpath("./url").text,
           enabled:     rep["enabled"] == "1",
           autorefresh: rep["autorefresh"] == "1",

--- a/spec/data/descriptions/jeos/manifest.json
+++ b/spec/data/descriptions/jeos/manifest.json
@@ -950,7 +950,7 @@
     {
       "alias": "SUSE-Linux-Enterprise-Server-11-SP3 11.3.3-1.138",
       "name": "SUSE-Linux-Enterprise-Server-11-SP3 11.3.3-1.138",
-      "repo_type": "yast2",
+      "type": "yast2",
       "url": "http://example.com/SLES11-SP3",
       "enabled": true,
       "autorefresh": true,

--- a/spec/unit/analyze_config_file_diffs_task_spec.rb
+++ b/spec/unit/analyze_config_file_diffs_task_spec.rb
@@ -26,7 +26,7 @@ describe AnalyzeConfigFileDiffsTask do
           {
             "alias": "repo-debug",
             "name": "openSUSE-13.1-Debug",
-            "repo_type": null,
+            "type": null,
             "url": "http://download.opensuse.org/debug/distribution/13.1/repo/oss/",
             "enabled": false,
             "autorefresh": true,
@@ -36,7 +36,7 @@ describe AnalyzeConfigFileDiffsTask do
           {
             "alias": "dvd_entry_alias",
             "name": "dvd_entry",
-            "repo_type": "yast2",
+            "type": "yast2",
             "url": "dvd:///?devices=/dev/disk/by-id/ata-Optiarc_DVD+_-RW_AD-7200S,/dev/sr0",
             "enabled": true,
             "autorefresh": false,

--- a/spec/unit/build_task_spec.rb
+++ b/spec/unit/build_task_spec.rb
@@ -33,7 +33,7 @@ describe BuildTask do
           {
             "alias": "nodejs",
             "name": "nodejs",
-            "repo_type": "rpm-md",
+            "type": "rpm-md",
             "url": "http://download.opensuse.org/repositories/devel:/languages:/nodejs/openSUSE_13.1/"
           }
         ],

--- a/spec/unit/kiwi_config_spec.rb
+++ b/spec/unit/kiwi_config_spec.rb
@@ -40,7 +40,7 @@ describe KiwiConfig do
           {
             "alias": "nodejs_alias",
             "name": "nodejs",
-            "repo_type": "rpm-md",
+            "type": "rpm-md",
             "url": "http://download.opensuse.org/repositories/devel:/languages:/nodejs/openSUSE_13.1/",
             "enabled": true,
             "autorefresh": false,
@@ -50,7 +50,7 @@ describe KiwiConfig do
           {
             "alias": "openSUSE-13.1-1.7_alias",
             "name": "openSUSE-13.1-1.7",
-            "repo_type": "yast2",
+            "type": "yast2",
             "url": "cd:///?devices=/dev/disk/by-id/ata-Optiarc_DVD+_-RW_AD-7200S,/dev/sr0",
             "enabled": false,
             "autorefresh": false,
@@ -60,7 +60,7 @@ describe KiwiConfig do
           {
             "alias": "repo_without_type_alias",
             "name": "repo_without_type",
-            "repo_type": null,
+            "type": null,
             "url": "http://repo_without_type",
             "enabled": true,
             "autorefresh": false,
@@ -70,7 +70,7 @@ describe KiwiConfig do
           {
             "alias": "disabled_repo_alias",
             "name": "disabled_repo",
-            "repo_type": null,
+            "type": null,
             "url": "http://disabled_repo",
             "enabled": false,
             "autorefresh": false,
@@ -80,7 +80,7 @@ describe KiwiConfig do
           {
             "alias": "autorefresh_enabled_alias",
             "name": "autorefresh_enabled",
-            "repo_type": null,
+            "type": null,
             "url": "http://autorefreshed_repo",
             "enabled": true,
             "autorefresh": true,
@@ -90,7 +90,7 @@ describe KiwiConfig do
           {
             "alias": "dvd_entry_alias",
             "name": "dvd_entry",
-            "repo_type": "yast2",
+            "type": "yast2",
             "url": "dvd:///?devices=/dev/disk/by-id/ata-Optiarc_DVD+_-RW_AD-7200S,/dev/sr0",
             "enabled": true,
             "autorefresh": false,
@@ -100,7 +100,7 @@ describe KiwiConfig do
           {
             "alias": "NCCRepo",
             "name": "NCC Repository",
-            "repo_type": "yast2",
+            "type": "yast2",
             "url": "https://nu.novell.com/repo/$RCE/SLES11-SP3-Pool/sle-11-x86_64?credentials=NCCcredentials",
             "enabled": true,
             "autorefresh": true,
@@ -186,7 +186,7 @@ describe KiwiConfig do
           {
             "alias": "nodejs_alias",
             "name": "nodejs",
-            "repo_type": "rpm-md",
+            "type": "rpm-md",
             "url": "http://download.opensuse.org/repositories/devel:/languages:/nodejs/openSUSE_13.1/",
             "enabled": true,
             "autorefresh": false,
@@ -231,7 +231,7 @@ describe KiwiConfig do
           {
             "alias": "nodejs_alias",
             "name": "nodejs",
-            "repo_type": "rpm-md",
+            "type": "rpm-md",
             "url": "http://download.opensuse.org/repositories/devel:/languages:/nodejs/openSUSE_13.1/",
             "enabled": true,
             "autorefresh": false,
@@ -299,7 +299,7 @@ describe KiwiConfig do
           {
             "alias": "nodejs_alias",
             "name": "nodejs",
-            "repo_type": "rpm-md",
+            "type": "rpm-md",
             "url": "http://download.opensuse.org/repositories/devel:/languages:/nodejs/openSUSE_13.1/",
             "enabled": true,
             "autorefresh": false,

--- a/spec/unit/repositories_inspector_spec.rb
+++ b/spec/unit/repositories_inspector_spec.rb
@@ -56,7 +56,7 @@ Weird zypper warning message which shouldn't mess up the repository parsing.
         Repository.new(
           alias: "nu_novell_com:SLES11-SP3-Pool",
           name: "SLES11-SP3-Pool",
-          repo_type: "rpm-md",
+          type: "rpm-md",
           enabled: true,
           autorefresh: true,
           gpgcheck: true,
@@ -68,7 +68,7 @@ Weird zypper warning message which shouldn't mess up the repository parsing.
           Repository.new(
           alias: "repo-oss",
           name: "openSUSE-Oss",
-          repo_type: "yast2",
+          type: "yast2",
           enabled: true,
           autorefresh: true,
           gpgcheck: true,
@@ -78,7 +78,7 @@ Weird zypper warning message which shouldn't mess up the repository parsing.
           Repository.new(
           alias: "repo-update",
           name: "openSUSE-Update",
-          repo_type: "rpm-md",
+          type: "rpm-md",
           enabled: false,
           autorefresh: false,
           gpgcheck: false,

--- a/spec/unit/repositories_renderer_spec.rb
+++ b/spec/unit/repositories_renderer_spec.rb
@@ -25,7 +25,7 @@ describe PackagesRenderer do
       {
         "alias": "openSUSE-13.1-1.10",
         "name": "openSUSE-13.1-1.10",
-        "repo_type": "yast2",
+        "type": "yast2",
         "url": "cd:///?devices=/dev/disk/by-id/ata-HL-DT-ST_DVD+_-RW_GHA2N_KEID27K1340,/dev/sr0",
         "enabled": true,
         "autorefresh": false,
@@ -35,7 +35,7 @@ describe PackagesRenderer do
       {
         "alias": "repo-debug",
         "name": "openSUSE-13.1-Debug",
-        "repo_type": null,
+        "type": null,
         "url": "http://download.opensuse.org/debug/distribution/13.1/repo/oss/",
         "enabled": false,
         "autorefresh": true,


### PR DESCRIPTION
When the scope was initially implemented we were running on Ruby 1.8 and
"type" conflicted with Object#type so we had to name the attribute
differently. Since we're only supporting Ruby 2+ now "type" can be used
instead.
