### PR TITLE
Improve data format of the "groups" scope

### DIFF
--- a/plugins/inspect/groups_inspector.rb
+++ b/plugins/inspect/groups_inspector.rb
@@ -31,12 +31,14 @@ class GroupsInspector < Inspector
     content.lines.map do |line|
       name, password, gid, users = line.split(":").map(&:chomp)
 
-      Group.new(
+      attrs = {
         name: name,
         password: password,
-        gid: gid,
         users: users.split(",")
-      )
+      }
+      attrs[:gid] = gid.to_i if !gid.empty?
+
+      Group.new(attrs)
     end
   end
 end

--- a/spec/unit/groups_inspector_spec.rb
+++ b/spec/unit/groups_inspector_spec.rb
@@ -47,19 +47,18 @@ EOF
         Group.new(
           name: "+",
           password: "",
-          gid: "",
           users: []
         ),
         Group.new(
           name: "root",
           password: "x",
-          gid: "0",
+          gid: 0,
           users: []
         ),
         Group.new(
           name: "tftp",
           password: "x",
-          gid: "493",
+          gid: 493,
           users: ["dnsmasq", "tftp"]
         ),
 

--- a/spec/unit/groups_renderer_spec.rb
+++ b/spec/unit/groups_renderer_spec.rb
@@ -25,13 +25,13 @@ describe GroupsRenderer do
         {
           "name": "root",
           "password": "x",
-          "gid": "0",
+          "gid": 0,
           "users": []
         },
         {
           "name": "tftp",
           "password": "x",
-          "gid": "7",
+          "gid": 7,
           "users": ["dnsmasq", "tftp"]
         }
       ]

--- a/spec/unit/kiwi_config_spec.rb
+++ b/spec/unit/kiwi_config_spec.rb
@@ -153,13 +153,13 @@ describe KiwiConfig do
           {
             "name": "root",
             "password": "x",
-            "gid": "0",
+            "gid": 0,
             "users": []
           },
           {
             "name": "tftp",
             "password": "x",
-            "gid": "7",
+            "gid": 7,
             "users": ["dnsmasq", "tftp"]
           }
         ],


### PR DESCRIPTION
The gid is stored as an integer now instead of a string.
