### PR TITLE
Get rid of package_file_flag attribute in changed-managed-files scope

### DIFF
--- a/plugins/inspect/changed_managed_files_inspector.rb
+++ b/plugins/inspect/changed_managed_files_inspector.rb
@@ -91,8 +91,7 @@ class ChangedManagedFilesInspector < Inspector
               name:              file,
               package_name:      package_name,
               package_version:   package_version,
-              changes:           changes,
-              package_file_flag: flag
+              changes:           changes
           )
         end
         # Since errors are also recognized for config-files we have

--- a/spec/data/descriptions/jeos/manifest.json
+++ b/spec/data/descriptions/jeos/manifest.json
@@ -1204,8 +1204,7 @@
       "package_version": "3.2",
       "changes": [
         "deleted"
-      ],
-      "package_file_flag": ""
+      ]
     },
     {
       "name": "/usr/share/bash/helpfiles/read",
@@ -1214,7 +1213,6 @@
       "changes": [
         "md5"
       ],
-      "package_file_flag": "",
       "mode": "644",
       "uid": 0,
       "gid": 0,

--- a/spec/unit/changed_managed_files_inspector_spec.rb
+++ b/spec/unit/changed_managed_files_inspector_spec.rb
@@ -44,7 +44,6 @@ describe ChangedManagedFilesInspector do
             package_name: "hwinfo",
             package_version: "15.50",
             changes: ["md5"],
-            package_file_flag: "",
             uid: 1001,
             gid: 1002,
             user: "wwwrun",
@@ -55,15 +54,13 @@ describe ChangedManagedFilesInspector do
             name: "/etc/apache2/listen.conf",
             package_name: "hwinfo",
             package_version: "15.50",
-            changes: ["md5"],
-            package_file_flag: "d"
+            changes: ["md5"]
         ),
         ChangedManagedFile.new(
             name: "/etc/iscsi/iscsid.conf",
             package_name: "zypper",
             package_version: "1.6.311",
             changes: ["mode", "md5", "user", "group"],
-            package_file_flag: "",
             uid: 0,
             gid: 0,
             user: "root",
@@ -74,15 +71,13 @@ describe ChangedManagedFilesInspector do
             name: "/opt/kde3/lib64/kde3/plugins/styles/plastik.la",
             package_name: "kdelibs3-default-style",
             package_version: "3.5.10",
-            changes: ["deleted"],
-            package_file_flag: ""
+            changes: ["deleted"]
         ),
         ChangedManagedFile.new(
             name: "/usr/share/man/man1/time.1.gz",
             package_name: "hwinfo",
             package_version: "15.50",
-            changes: ["replaced"],
-            package_file_flag: ""
+            changes: ["replaced"]
         )
       ])
       subject.inspect(system, description)

--- a/spec/unit/changed_managed_files_renderer_spec.rb
+++ b/spec/unit/changed_managed_files_renderer_spec.rb
@@ -28,8 +28,7 @@ describe ChangedManagedFilesRenderer do
           "package_version": "2.11.3",
           "changes": [
             "deleted"
-          ],
-          "package_file_flag": "d"
+          ]
         },
         {
           "name": "/changed/file",
@@ -39,7 +38,6 @@ describe ChangedManagedFilesRenderer do
             "md5",
             "mode"
           ],
-          "package_file_flag": "c",
           "mode": "644",
           "uid": 0,
           "gid": 0,


### PR DESCRIPTION
It isn't used anywhere anyway.
