### PR TITLE
Data format cleanup: Change error reporting for changed_managed_files

### DIFF
--- a/plugins/inspect/changed_managed_files_inspector.rb
+++ b/plugins/inspect/changed_managed_files_inspector.rb
@@ -79,7 +79,8 @@ class ChangedManagedFilesInspector < Inspector
             name:              $1,
             package_name:      package_name,
             package_version:   package_version,
-            error:             $2
+            status:            "error",
+            error_message:     $2
           )
         else
           file, changes, flag = parse_rpm_changes_line(changed_file)
@@ -91,6 +92,7 @@ class ChangedManagedFilesInspector < Inspector
               name:              file,
               package_name:      package_name,
               package_version:   package_version,
+              status:            "changed",
               changes:           changes
           )
         end

--- a/plugins/show/changed_managed_files_renderer.rb
+++ b/plugins/show/changed_managed_files_renderer.rb
@@ -20,7 +20,7 @@ class ChangedManagedFilesRenderer < Renderer
     return unless @system_description["changed-managed-files"]
 
     files, errors = @system_description["changed-managed-files"].partition do |file|
-      file.error.nil?
+      file.status != "error"
     end
 
     if !files.empty?
@@ -34,7 +34,7 @@ class ChangedManagedFilesRenderer < Renderer
     if !errors.empty?
       list("Errors") do
         errors.each do |p|
-          item "#{p.name}: #{p.error}"
+          item "#{p.name}: #{p.error_message}"
         end
       end
     end

--- a/spec/data/descriptions/jeos/manifest.json
+++ b/spec/data/descriptions/jeos/manifest.json
@@ -1202,6 +1202,7 @@
       "name": "/usr/share/bash/helpfiles/cd",
       "package_name": "bash",
       "package_version": "3.2",
+      "status": "changed",
       "changes": [
         "deleted"
       ]
@@ -1210,6 +1211,7 @@
       "name": "/usr/share/bash/helpfiles/read",
       "package_name": "bash",
       "package_version": "3.2",
+      "status": "changed",
       "changes": [
         "md5"
       ],

--- a/spec/unit/changed_managed_files_inspector_spec.rb
+++ b/spec/unit/changed_managed_files_inspector_spec.rb
@@ -43,6 +43,7 @@ describe ChangedManagedFilesInspector do
             name: "/etc/apache2/de:fault server.conf",
             package_name: "hwinfo",
             package_version: "15.50",
+            status: "changed",
             changes: ["md5"],
             uid: 1001,
             gid: 1002,
@@ -54,12 +55,14 @@ describe ChangedManagedFilesInspector do
             name: "/etc/apache2/listen.conf",
             package_name: "hwinfo",
             package_version: "15.50",
+            status: "changed",
             changes: ["md5"]
         ),
         ChangedManagedFile.new(
             name: "/etc/iscsi/iscsid.conf",
             package_name: "zypper",
             package_version: "1.6.311",
+            status: "changed",
             changes: ["mode", "md5", "user", "group"],
             uid: 0,
             gid: 0,
@@ -71,12 +74,14 @@ describe ChangedManagedFilesInspector do
             name: "/opt/kde3/lib64/kde3/plugins/styles/plastik.la",
             package_name: "kdelibs3-default-style",
             package_version: "3.5.10",
+            status: "changed",
             changes: ["deleted"]
         ),
         ChangedManagedFile.new(
             name: "/usr/share/man/man1/time.1.gz",
             package_name: "hwinfo",
             package_version: "15.50",
+            status: "changed",
             changes: ["replaced"]
         )
       ])

--- a/spec/unit/changed_managed_files_renderer_spec.rb
+++ b/spec/unit/changed_managed_files_renderer_spec.rb
@@ -26,6 +26,7 @@ describe ChangedManagedFilesRenderer do
           "name": "/deleted/file",
           "package_name": "glibc",
           "package_version": "2.11.3",
+          "status": "changed",
           "changes": [
             "deleted"
           ]
@@ -34,6 +35,7 @@ describe ChangedManagedFilesRenderer do
           "name": "/changed/file",
           "package_name": "login",
           "package_version": "3.41",
+          "status": "changed",
           "changes": [
             "md5",
             "mode"
@@ -49,7 +51,8 @@ describe ChangedManagedFilesRenderer do
           "name": "/usr/sbin/vlock-main",
           "package_name": "vlock",
           "package_version": "2.2.3",
-          "error": "cannot verify root:root 0755 - not listed in /etc/permissions"
+          "status": "error",
+          "error_message": "cannot verify root:root 0755 - not listed in /etc/permissions"
         }
       ]
     }

--- a/spec/unit/kiwi_config_spec.rb
+++ b/spec/unit/kiwi_config_spec.rb
@@ -343,6 +343,7 @@ describe KiwiConfig do
             "name": "/tmp/managed/one",
             "package_name": "xorg-x11-fonts-core",
             "package_version": "7.4",
+            "status": "changed",
             "changes": [
               "md5"
             ],
@@ -356,6 +357,7 @@ describe KiwiConfig do
             "name": "/var/managed_two",
             "package_name": "aaa_base",
             "package_version": "11",
+            "status": "changed",
             "changes": [
               "md5"
             ],
@@ -369,6 +371,7 @@ describe KiwiConfig do
             "name": "/tmp/deleted_changed_managed",
             "package_name": "aaa_base",
             "package_version": "11",
+            "status": "changed",
             "changes": [
               "deleted"
             ]


### PR DESCRIPTION
Introduce a "status" attribute for files in changed_managed_files scope.
Its value is either "changed" (in which case the changes are described
in the "changes" attribute) or "error" (in which case the error
encountered when detecting changes is described in the "error_message"
attribute).

This replaces previous "error" attribute. The advantage is that readers
don't have to rely on its presence/absence to determine file state.
