### PR TITLE
Data format cleanup: Introduce "status" for config_files

### DIFF
--- a/plugins/inspect/config_files_inspector.rb
+++ b/plugins/inspect/config_files_inspector.rb
@@ -76,6 +76,7 @@ class ConfigFilesInspector < Inspector
         name:            path,
         package_name:    package_name,
         package_version: package_version,
+        status:          "changed",
         changes:         changes
       )
     end

--- a/spec/data/descriptions/jeos/manifest.json
+++ b/spec/data/descriptions/jeos/manifest.json
@@ -982,6 +982,7 @@
       "name": "/etc/crontab",
       "package_name": "cron",
       "package_version": "4.1",
+      "status": "changed",
       "changes": [
         "md5"
       ],

--- a/spec/unit/analyze_config_file_diffs_task_spec.rb
+++ b/spec/unit/analyze_config_file_diffs_task_spec.rb
@@ -48,6 +48,7 @@ describe AnalyzeConfigFileDiffsTask do
             "name": "/etc/pam.d/login",
             "package_name": "login",
             "package_version": "3.41",
+            "status": "changed",
             "changes": [
               "md5"
             ]
@@ -56,6 +57,7 @@ describe AnalyzeConfigFileDiffsTask do
             "name": "/etc/modprobe.d/unsupported-modules",
             "package_name": "aaa_base",
             "package_version": "3.11.1",
+            "status": "changed",
             "changes": [
               "md5"
             ]
@@ -64,6 +66,7 @@ describe AnalyzeConfigFileDiffsTask do
             "name": "/etc/inittab",
             "package_name": "aaa_base",
             "package_version": "3.11.1",
+            "status": "changed",
             "changes": [
               "md5"
             ]
@@ -72,6 +75,7 @@ describe AnalyzeConfigFileDiffsTask do
             "name": "/etc/mode_changed_only",
             "package_name": "mode_changed_only",
             "package_version": "1",
+            "status": "changed",
             "changes": [
               "mode"
             ]

--- a/spec/unit/config_files_inspector_spec.rb
+++ b/spec/unit/config_files_inspector_spec.rb
@@ -166,6 +166,7 @@ EOF
         name:            "",
         package_name:    "apache2",
         package_version: "2.4.6",
+        status:          "changed",
         changes:         ["md5"],
         uid:             0,
         gid:             0,
@@ -187,12 +188,14 @@ EOF
         name:            "/usr/share/info/dir",
         package_name:    "apache2",
         package_version: "2.4.6",
+        status:          "changed",
         changes:         ["deleted"]
       )
       apache_5 = ConfigFile.new(
         name:            "/usr/share/man/man1/time.1.gz",
         package_name:    "apache2",
         package_version: "2.4.6",
+        status:          "changed",
         changes:         ["replaced"]
       )
 

--- a/spec/unit/config_files_renderer_spec.rb
+++ b/spec/unit/config_files_renderer_spec.rb
@@ -26,6 +26,7 @@ describe ConfigFilesRenderer do
         "name": "/etc/default/grub",
         "package_name": "grub2",
         "package_version": "2.00",
+        "status": "changed",
         "changes": [
           "mode"
         ],


### PR DESCRIPTION
Introduce a "status" attribute for files in the config_files scope. This
mimics a similar attribute in the changed_managed_files scope. For now,
the value is always "changed" as we don't detect errors in
ConfigFilesInspector in the same way as in ChangedManagedFilesInspector.
