### PR TITLE
Fix unit test failure if python-glanceclient is installed

### DIFF
--- a/spec/unit/helper_spec.rb
+++ b/spec/unit/helper_spec.rb
@@ -30,6 +30,7 @@ describe Machinery do
 
     it "explains how to install a missing package from a module on SLES12" do
       allow(LocalSystem).to receive(:os_object).and_return(OsSles12.new)
+      allow(Cheetah).to receive(:run).and_raise(Cheetah::ExecutionFailed.new(nil, nil, nil, nil))
       expect {
         Machinery::check_package("python-glanceclient")
       }.to raise_error(Machinery::Errors::MissingRequirement, /Public Cloud Module/)


### PR DESCRIPTION
Supersedes #77 
