### PR TITLE
Add "bundle check || sudo bundle install" into prophet.rb

### DIFF
--- a/prophet/prophet.rb
+++ b/prophet/prophet.rb
@@ -88,7 +88,7 @@ Prophet.setup do |config|
   config.execution do
     log.info 'Running tests ...'
 
-    system("cd ..; rake spec:unit")
+    system("cd ..; (bundle check || sudo bundle install) && rake spec:unit")
     config.success = ($? == 0)
 
     log.info "Tests are #{config.success ? 'passing' : 'failing'}."


### PR DESCRIPTION
These commands ensure that pull requests which add new gems to the
dependencies won't fail when Prophet executes the tests.

I used "sudo" in case of "bundle install" to avoid possible password
prompts. It's not very clean, but we use it already in scripts on
Jenkins without any negative consequences.
