### PR TITLE
Replace string-scrub gem with our own implementation

### DIFF
--- a/lib/machinery.rb
+++ b/lib/machinery.rb
@@ -28,7 +28,6 @@ require "erb"
 require "yaml"
 require "uri"
 require "gli"
-require "string-scrub"
 
 require_relative 'machinery_logger'
 require_relative 'zypper'

--- a/machinery.gemspec
+++ b/machinery.gemspec
@@ -39,7 +39,6 @@ Gem::Specification.new do |s|
   s.add_dependency "abstract_method", ">=1.2.1"
   s.add_dependency "nokogiri", ">=1.6.0"
   s.add_dependency "gli", "~> 2.11.0"
-  s.add_dependency "string-scrub", "~> 0.0.3"
 
   s.files        = Dir["lib/**/*.rb", "plugins/**/*.rb", "bin/*", "man/**/*", "NEWS", "COPYING", "helpers/*", "kiwi_helpers/*"]
   s.executables  = "machinery"


### PR DESCRIPTION
In UnmanagedFilesInspector, we need to clean invalid UTF-8 byte
sequences. This would be a job for String#scrub in Ruby 2.1, but because
we have to be Ruby 2.0 compatible, we couldn't use it directly and we
had to resort to the string-scrub gem.

This gem had to be packaged for both openSUSE and SLES so that our gem
bundling mecahnism works. However packaging for SLES was met with some
resistance as Ruby 2.1 is available there and the gem isn't strictly
needed. Instead of fighting we decided to just implement the scrubbing
ourselves, which turned out to be relatively simple in our case (only
UTF-8).
