### PR TITLE
Rescue name error when loading system description

### DIFF
--- a/lib/system_description.rb
+++ b/lib/system_description.rb
@@ -48,7 +48,14 @@ class SystemDescription < Machinery::Object
       block.yield pointer.value if pointer.exists?
     end
 
-    description = self.new(name, self.create_attrs(json_hash), store)
+    begin
+      description = self.new(name, self.create_attrs(json_hash), store)
+    rescue NameError
+      raise Machinery::Errors::SystemDescriptionError.new(
+        "The system description #{name} has an incompatible data format and can" \
+        " not be read."
+      )
+    end
 
     json_format_version = json_hash["meta"]["format_version"] if json_hash["meta"]
     description.format_version = json_format_version


### PR DESCRIPTION
  Old descriptions might contain characters which cause
  failures when writing from json to our description format.
  As our compatibility check happens after that, this caused
  unexpected errors when using commands.
