### PR TITLE
Use factory method to create Os objects from name

### DIFF
--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -26,6 +26,7 @@ module Machinery
     class MachineryError < StandardError; end
 
     class UnknownScope < MachineryError; end
+    class UnknownOs < MachineryError; end
     class InvalidPager < MachineryError; end
     class InvalidCommandLine < MachineryError; end
 

--- a/lib/os.rb
+++ b/lib/os.rb
@@ -18,6 +18,20 @@
 class Os
   attr_reader :can_build, :name
 
+  def self.descendants
+    ObjectSpace.each_object(::Class).select { |klass| klass < self }
+  end
+
+  def self.for(os_name)
+    descendants.each do |os_class|
+      os_object = os_class.new
+      if os_name == os_object.name
+        return os_object
+      end
+    end
+    raise Machinery::Errors::UnknownOs.new("Unknown OS: '#{os_name}'")
+  end
+
   def can_build?(os)
     if os.is_a?(Class)
       return @can_build.include?(os)

--- a/lib/system_description.rb
+++ b/lib/system_description.rb
@@ -221,15 +221,11 @@ class SystemDescription < Machinery::Object
   def os_object
     assert_scopes("os")
 
-    [OsSles12, OsSles11, OsOpenSuse13_1].each do |os_class|
-      os_object = os_class.new
-      if self.os.name == os_object.name
-        return os_object
-      end
+    begin
+      Os.for(self.os.name)
+    rescue Machinery::Errors::UnknownOs => e
+      raise Machinery::Errors::SystemDescriptionError.new(e)
     end
-
-    raise Machinery::Errors::SystemDescriptionError.new(
-      "Unrecognized operating system '#{self.os.name}")
   end
 
   # Filestore handling

--- a/spec/unit/os_spec.rb
+++ b/spec/unit/os_spec.rb
@@ -63,4 +63,20 @@ describe Os do
       expect(os.module_required_by_package("python-glanceclient")).to eq(nil)
     end
   end
+
+  it "returns list of subclasses" do
+    expect(Os.descendants).to be_a(Array)
+    expect(Os.descendants.count).to be >= 3
+    expect(Os.descendants).to include OsSles12
+    expect(Os.descendants).to include OsOpenSuse13_1
+  end
+
+  it "returns os object for os name string" do
+    expect(Os.for("SUSE Linux Enterprise Server 12")).to be_a(OsSles12)
+    expect(Os.for("openSUSE 13.1 (Bottle)")).to be_a(OsOpenSuse13_1)
+    expect {
+      Os.for("unknow OS name")
+    }.to raise_error(Machinery::Errors::UnknownOs)
+  end
+
 end


### PR DESCRIPTION
This gets rid of the explicit listing of Os classes when creating a new Os object.
