### PR TITLE
Allow unmanaged-files schema to detect mixed json

### DIFF
--- a/plugins/schema/v1/system-description-unmanaged-files.schema.json
+++ b/plugins/schema/v1/system-description-unmanaged-files.schema.json
@@ -2,18 +2,22 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
 
   "type": "array",
-  "items": {
-    "anyOf": [
-      { "$ref": "#/definitions/not_extracted" },
-      {
+  "oneOf": [
+    {
+      "items": {
+        "$ref": "#/definitions/not_extracted"
+      }
+    },
+    {
+      "items": {
         "anyOf": [
           { "$ref": "#/definitions/extracted_dir" },
           { "$ref": "#/definitions/extracted_file" },
           { "$ref": "#/definitions/extracted_link" }
         ]
       }
-    ]
-  },
+    }
+  ],
   "definitions": {
     "not_extracted": {
       "type": "object",


### PR DESCRIPTION
  The unmanaged-files schema now detects if its scope
  in the system description contains a mix of extracted
  and unextracted date and fails accordingly.

The downside to this is that most error messages this gives only show the object in which the error occured and not the specific property which caused the failure.
