### PR TITLE
Add man page for `machinery validate`

### DIFF
--- a/man/machinery-validate.1.md
+++ b/man/machinery-validate.1.md
@@ -1,0 +1,33 @@
+
+# validate — Validate System Description
+
+### SYNOPSIS
+
+`machinery validate` NAME
+
+`machinery` help validate
+
+
+### DESCRIPTION
+
+The `validate` subcommand validates an existing system description.
+It checks, that the description has the correct structure and the data stored
+there conforms to the required schema.
+
+In case of issues errors are shown with additional information.
+
+The main purpose of this command is to verify the system description after
+manually editing it.
+
+
+### ARGUMENTS
+
+  * `NAME` (required):
+    Name of the system description.
+
+
+### EXAMPLES
+
+ * Validate the system description with the name `myhost`:
+
+   $ `machinery` validate myhost


### PR DESCRIPTION
I am not sure if we should mention in the man page that the errors are some times not precise, because of technical restrictions.
