### PR TITLE
Revert "Convert scope name in schema error message"

### DIFF
--- a/lib/system_description.rb
+++ b/lib/system_description.rb
@@ -136,8 +136,7 @@ class SystemDescription < Machinery::Object
 
         if schema
           issue = JSON::Validator.fully_validate(schema, json[scope]).map do |error|
-            "In scope #{Machinery::Ui.internal_scope_list_to_string(scope)}:" \
-              " #{error}"
+            "In scope #{scope}: #{error}"
           end
 
           # filter duplicates

--- a/spec/unit/system_description_spec.rb
+++ b/spec/unit/system_description_spec.rb
@@ -212,7 +212,7 @@ EOF
     describe "json validation error handling" do
       it "raises an error when encountering invalid enum values" do
         expected = <<EOF
-In scope config-files: The element #0 of type Hash did not match one or more of the required schemas.
+In scope config_files: The element #0 of type Hash did not match one or more of the required schemas.
  The schema specific errors were:
  - The element #0 value "invalid" did not match one of the following values: mode, md5, group, user, replaced.
 EOF
@@ -284,7 +284,7 @@ EOF
 
       it "raises in case of missing package_version" do
         expected = <<EOF
-In scope config-files: The element #0 of type Hash did not match one or more of the required schemas.
+In scope config_files: The element #0 of type Hash did not match one or more of the required schemas.
  The schema specific errors were:
  - The element #0 did not contain a required property of 'package_version'.
 EOF
@@ -297,7 +297,7 @@ EOF
 
       it "raises in case of an unknown status" do
         expected = <<EOF
-In scope config-files: The element #0 of type Hash did not match one or more of the required schemas.
+In scope config_files: The element #0 of type Hash did not match one or more of the required schemas.
  The schema specific errors were:
  - The property 'status' of element #0 value "unknown_status" did not match one of the following values: changed, error.
 EOF
@@ -310,7 +310,7 @@ EOF
 
       it "raises in case of a pattern mismatch" do
         expected = <<EOF
-In scope config-files: The element #0 of type Hash did not match one or more of the required schemas.
+In scope config_files: The element #0 of type Hash did not match one or more of the required schemas.
  The schema specific errors were:
  - The property 'mode' of element #0 value "900" did not match the regex '^[0-4]{0,1}[0-7]{3}$'.
 EOF
@@ -323,7 +323,7 @@ EOF
 
       it "raises for a deleted file in case of an empty changes array" do
         expected = <<EOF
-In scope config-files: The element #0 of type Hash did not match one or more of the required schemas.
+In scope config_files: The element #0 of type Hash did not match one or more of the required schemas.
  The schema specific errors were:
  - The property 'changes' of element #0 did not contain a minimum number of items 1.
  - The element #0 did not contain a required property of 'group'.
@@ -344,7 +344,7 @@ EOF
 
       it "raises for extracted in case of unknown type" do
         expected = <<EOF
-In scope unmanaged-files: The element #0 of type Array did not match any of the required schemas.
+In scope unmanaged_files: The element #0 of type Array did not match any of the required schemas.
 EOF
         expected.chomp!
         expect { SystemDescription.


### PR DESCRIPTION
It doesn't make sense to transform scope names from underscore-separated
form to dash-separated form in JSON validation error messages. The scope
names should be exactly the same as in the JSON file to prevent any
confusion, make it possible to grep in manifest.json directly from the
error message, etc.

Beside this, the Machinery::UI.internal_scope_list_to_string method
wasn't the right tool for the job. It is a UI-level method, not a
utility one, and it is supposed to convert a list of scopes, not one.

This reverts commit fcd017936b7ef5da8a9f7cc805e49ba66449e4b8.

Conflicts:
    lib/system_description.rb
