### PR TITLE
Make Rakefile work with RSpec 3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,6 @@ source "https://rubygems.org"
 gemspec
 
 group :test do
-  gem "rspec"
+  gem "rspec", ">= 3.1.0"
   gem "fakefs"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,7 @@ require "packaging"
 
 desc "Run RSpec code examples in spec/unit"
 RSpec::Core::RakeTask.new("spec:unit") do |t|
-  t.pattern = ["spec/unit/**/*_spec.rb", "spec/helper/**/*_spec.rb"]
+  t.exclude_pattern = "spec/integration/**/*"
 end
 
 desc "Run RSpec code examples in spec/integration"


### PR DESCRIPTION
RakeTask in RSpec 3.1 does no longer allow to specify an array of paths
as the pattern. Since the purpose of the problematic rake task is only
to exclude the integration test we use the new "exclude_pattern" method
to achieve the same result instead.
