### PR TITLE
Schemas: Remove the "type" keyword where "enum" is used

### DIFF
--- a/plugins/schema/v1/system-description-changed-managed-files.schema.json
+++ b/plugins/schema/v1/system-description-changed-managed-files.schema.json
@@ -29,7 +29,6 @@
       "required": ["status"],
       "properties": {
         "status": {
-          "type": "string",
           "enum": ["changed"]
         }
       },
@@ -44,7 +43,6 @@
         "changes": {
           "type": "array",
           "items": {
-            "type": "string",
             "enum": ["mode", "md5", "group", "user", "replaced"]
           },
           "minItems": 1
@@ -67,7 +65,6 @@
       "required": ["changes"],
       "properties": {
         "changes": {
-          "type": "array",
           "enum": [["deleted"]]
         }
       }
@@ -76,7 +73,6 @@
       "required": ["status", "error_message"],
       "properties": {
         "status": {
-          "type": "string",
           "enum": ["error"]
         },
         "error_message": {

--- a/plugins/schema/v1/system-description-config-files.schema.json
+++ b/plugins/schema/v1/system-description-config-files.schema.json
@@ -29,7 +29,6 @@
       "required": ["status"],
       "properties": {
         "status": {
-          "type": "string",
           "enum": ["changed"]
         }
       },
@@ -44,7 +43,6 @@
         "changes": {
           "type": "array",
           "items": {
-            "type": "string",
             "enum": ["mode", "md5", "group", "user", "replaced"]
           },
           "minItems": 1
@@ -67,7 +65,6 @@
       "required": ["changes"],
       "properties": {
         "changes": {
-          "type": "array",
           "enum": [["deleted"]]
         }
       }
@@ -76,7 +73,6 @@
       "required": ["status", "error_message"],
       "properties": {
         "status": {
-          "type": "string",
           "enum": ["error"]
         },
         "error_message": {

--- a/plugins/schema/v1/system-description-repositories.schema.json
+++ b/plugins/schema/v1/system-description-repositories.schema.json
@@ -15,7 +15,6 @@
         "minLength": 1
       },
       "type": {
-        "type": ["string", "null"],
         "enum": ["yast2", "rpm-md", "plaindir", null]
       },
       "url": {

--- a/plugins/schema/v1/system-description-unmanaged-files.schema.json
+++ b/plugins/schema/v1/system-description-unmanaged-files.schema.json
@@ -35,7 +35,6 @@
       "required": ["type"],
       "properties": {
         "type": {
-          "type": "string",
           "enum": ["file", "dir", "link"]
         }
       },
@@ -63,7 +62,6 @@
       "required": ["type", "size", "mode"],
       "properties": {
         "type": {
-          "type": "string",
           "enum": ["file"]
         },
         "size": {
@@ -80,7 +78,6 @@
       "required": ["type", "size", "mode", "files"],
       "properties": {
         "type": {
-          "type": "string",
           "enum": ["dir"]
         },
         "size": {
@@ -101,7 +98,6 @@
       "required": ["type"],
       "properties": {
         "type": {
-          "type": "string",
           "enum": ["link"]
         }
       }


### PR DESCRIPTION
Having the "type" keyword present in cases where "enum" is used is
redundant, so I removed it.
