### PR TITLE
Schemas: Don't check if file names begin with "/"

### DIFF
--- a/plugins/schema/v1/system-description-changed-managed-files.schema.json
+++ b/plugins/schema/v1/system-description-changed-managed-files.schema.json
@@ -7,8 +7,7 @@
     "required": ["name", "package_name", "package_version"],
     "properties": {
       "name": {
-        "type": "string",
-        "pattern": "^/"
+        "type": "string"
       },
       "package_name": {
         "type": "string",

--- a/plugins/schema/v1/system-description-config-files.schema.json
+++ b/plugins/schema/v1/system-description-config-files.schema.json
@@ -7,8 +7,7 @@
     "required": ["name", "package_name", "package_version"],
     "properties": {
       "name": {
-        "type": "string",
-        "pattern": "^/"
+        "type": "string"
       },
       "package_name": {
         "type": "string",

--- a/plugins/schema/v1/system-description-unmanaged-files.schema.json
+++ b/plugins/schema/v1/system-description-unmanaged-files.schema.json
@@ -26,8 +26,7 @@
       "required": ["name"],
       "properties": {
         "name": {
-          "type": "string",
-          "pattern": "^/"
+          "type": "string"
         }
       }
     },


### PR DESCRIPTION
We decided on a policy of flexibility (as opposed to strictness), so I
think we should rather treat file names as opaque strings in the schemas
and not require any format.
