### PR TITLE
Schemas: Make the "meta" section required

### DIFF
--- a/schema/v1/system-description-global.schema.json
+++ b/schema/v1/system-description-global.schema.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
 
   "type": "object",
+  "required": ["meta"],
   "properties": {
     "meta": {
       "required": ["format_version"],


### PR DESCRIPTION
The "meta" section should be required because we need the format version
stored inside it.
