### PR TITLE
Remove custom validators mechanism from the SystemDescription class

### DIFF
--- a/docs/Data-Model.md
+++ b/docs/Data-Model.md
@@ -176,24 +176,6 @@ method. It recusively walks the tree and serializes all the nodes.
 
 The object tree is deserialized from JSON by the `SystemDescription.from_json` method.
 
-In order to validate incoming data, the `SystemDescription` class allows to
-define custom validators using the `SystemDescription#add_validator` method:
-
-```ruby
-SystemDescription.add_validator "#/packages" do |json|
-  if json != json.uniq
-    raise Machinery::Errors::SystemDescriptionError,
-          "The #{description} contains duplicate packages."
-  end
-end
-```
-
-The method is passed a [JSON Pointer](http://tools.ietf.org/html/rfc6901) and
-a block. The block will be called for the JSON node specified by the pointer
-when deserializing. If code inside this method encounters invalid JSON, it can
-raise the `Machinery::Errors::SystemDescriptionError` exception and the
-deserialization will fail.
-
 ### File Data
 
 Some scopes contain file data. The files are not serialized to the JSON, but

--- a/lib/machinery.rb
+++ b/lib/machinery.rb
@@ -17,7 +17,6 @@
 
 require 'ostruct'
 require 'json'
-require 'json-pointer'
 require "abstract_method"
 require "cheetah"
 require "tmpdir"

--- a/lib/system_description.rb
+++ b/lib/system_description.rb
@@ -23,10 +23,6 @@ class SystemDescription < Machinery::Object
   attr_accessor :format_version
 
   class << self
-    def add_validator(json_path, &block)
-      @@json_validator[json_path] = block
-    end
-
     def from_json(name, json, store = nil)
       begin
         json_hash = JSON.parse(json)
@@ -180,11 +176,6 @@ class SystemDescription < Machinery::Object
 
       if !errors.empty?
         raise Machinery::Errors::SystemDescriptionError.new(errors.join("\n"))
-      end
-
-      @@json_validator.each do |json_path, block|
-        pointer = JsonPointer.new(json, json_path, :symbolize_keys => false)
-        block.yield pointer.value if pointer.exists?
       end
     end
   end

--- a/machinery.gemspec
+++ b/machinery.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "cheetah", ">=0.4.0"
   s.add_dependency "json", ">=1.8.0"
-  s.add_dependency "json-pointer", ">=0.0.1"
   s.add_dependency "abstract_method", ">=1.2.1"
   s.add_dependency "nokogiri", ">=1.6.0"
   s.add_dependency "gli", "~> 2.11.0"

--- a/spec/unit/system_description_spec.rb
+++ b/spec/unit/system_description_spec.rb
@@ -162,18 +162,6 @@ describe SystemDescription do
     }.not_to raise_error
   end
 
-  it "raises ValidationError if json validator find duplicate packages" do
-    SystemDescription.add_validator "/packages" do |json|
-      if json != json.uniq
-        raise Machinery::Errors::SystemDescriptionError,
-          "The description contains duplicate packages."
-      end
-    end
-    expect { SystemDescription.from_json(@name,
-      @duplicate_description
-    )}.to raise_error(Machinery::Errors::SystemDescriptionError)
-  end
-
   describe "json parser error handling" do
     let(:path) { "spec/data/schema/invalid_json/" }
 


### PR DESCRIPTION
The custom validators mechanism was unused for many months. Effectively
it is dead code. Now it started complicating one of my refactorings, so
I decided to remove it. If custom validators are ever needed, they can
be trivially restored.
