### PR TITLE
Add list_file_store_content method

### DIFF
--- a/lib/system_description_store.rb
+++ b/lib/system_description_store.rb
@@ -111,6 +111,14 @@ class SystemDescriptionStore
     create_dir(dir, new_dir_mode(description_name))
   end
 
+  def list_file_store_content(description_name, store_name)
+    dir = File.join(description_path(description_name), store_name)
+
+    files = Dir.glob(File.join(dir, "**/*"), File::FNM_DOTMATCH)
+    # filter parent directories because they should not be listed separately
+    files.reject { |f| files.index { |e| e =~ /^#{f}\/.+/ } }
+  end
+
   def new_dir_mode(name)
     mode = 0700
     if Dir.exists?(description_path(name))

--- a/spec/unit/system_description_store_spec.rb
+++ b/spec/unit/system_description_store_spec.rb
@@ -291,5 +291,22 @@ describe SystemDescriptionStore do
         expect(store.new_dir_mode(test_name)).to eq(0700)
       end
     end
+
+    describe "#list_file_store_content" do
+      it "returns a list of files and dirs in the file store" do
+        store.initialize_file_store(test_name, file_store_name)
+        store.create_file_store_sub_dir(test_name, file_store_name, "foo/bar")
+        FileUtils.touch(File.join(file_store_path, "foo", "baz"))
+        FileUtils.touch(File.join(file_store_path, "foo", ".baz"))
+
+        expect(store.list_file_store_content(test_name, file_store_name)).to match_array(
+          [
+            File.join(file_store_path, "foo", "bar"),
+            File.join(file_store_path, "foo", "baz"),
+            File.join(file_store_path, "foo", ".baz")
+          ]
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
Returns a list with the absolute paths of the files and dirs in the
file store. It doesn't list the parent directories.
