### PR TITLE
Add create_test_description to integration tests

### DIFF
--- a/spec/helper/shared_test_methods.rb
+++ b/spec/helper/shared_test_methods.rb
@@ -1,0 +1,23 @@
+# Copyright (c) 2013-2014 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
+def create_test_description(json, options = {})
+  name  = options[:name] || "description"
+  store = options[:store]
+
+  SystemDescription.from_json(name, json, store)
+end

--- a/spec/integration/integration_spec_helper.rb
+++ b/spec/integration/integration_spec_helper.rb
@@ -18,6 +18,7 @@
 require_relative "../../lib/machinery"
 require_relative "../../../pennyworth/lib/spec"
 require_relative "../../../pennyworth/lib/ssh_keys_importer"
+require_relative "../helper/shared_test_methods"
 
 def prepare_machinery_for_host(system, ip, opts = {})
   opts = {

--- a/spec/unit/spec_helper.rb
+++ b/spec/unit/spec_helper.rb
@@ -19,6 +19,8 @@ require "fakefs/spec_helpers"
 
 require File.expand_path('../../../lib/machinery', __FILE__)
 
+require_relative "../helper/shared_test_methods"
+
 bin_path = File.expand_path( "../../../bin/", __FILE__ )
 
 if ENV['PATH'] !~ /#{bin_path}/
@@ -109,11 +111,4 @@ module FakeFS
       end
     end
   end
-end
-
-def create_test_description(json, options = {})
-  name  = options[:name] || "description"
-  store = options[:store]
-
-  SystemDescription.from_json(name, json, store)
 end


### PR DESCRIPTION
The helper method create_test_description was only available for the unit
tests, not the integration tests.
