### PR TITLE
Fix file store rename for integration test

### DIFF
--- a/lib/system_description_store.rb
+++ b/lib/system_description_store.rb
@@ -107,9 +107,10 @@ class SystemDescriptionStore
   end
 
   def rename_file_store(description_name, store_old, store_new)
-    FileUtils.cd(description_path(description_name)) do
-      FileUtils.mv(store_old, store_new)
-    end
+    FileUtils.mv(
+      File.join(description_path(description_name), store_old),
+      File.join(description_path(description_name), store_new)
+    )
   end
 
   def create_file_store_sub_dir(description_name, store_name, sub_dir)


### PR DESCRIPTION
Renaming of the file store failed during the integretation test because
of permission issues besides working locally and also when the
inspection was started manually in Pennyworth.
It might be related to the vagrant environment, anyway these changes fix
the issue during the integration tests.
