### PR TITLE
Use regular methods for json error handling

### DIFF
--- a/lib/system_description_validator.rb
+++ b/lib/system_description_validator.rb
@@ -66,7 +66,7 @@ class SystemDescriptionValidator
           "In scope #{scope}: #{error}"
         end
         issue.map do |error|
-          SystemDescriptionValidator.cleanup_json_error_message(error, scope)
+          cleanup_json_error_message(error, scope)
         end
       else
         []
@@ -130,7 +130,7 @@ class SystemDescriptionValidator
     end
   end
 
-  def self.cleanup_json_error_message(message, scope)
+  def cleanup_json_error_message(message, scope)
     message = cleanup_json_path(message, scope)
     message = remove_json_error_uuid(message)
     message
@@ -138,7 +138,7 @@ class SystemDescriptionValidator
 
   private
 
-  def self.cleanup_json_path(message, scope)
+  def cleanup_json_path(message, scope)
     old_path = message[/The property '#\/(.*?)'/,1]
 
     position = error_position_from_json_path(old_path)
@@ -151,7 +151,7 @@ class SystemDescriptionValidator
     message.gsub(/The property '#\/.*?'/, new_path)
   end
 
-  def self.error_position_from_json_path(path)
+  def error_position_from_json_path(path)
     elements = path.split("/")
 
     position = -1
@@ -164,7 +164,7 @@ class SystemDescriptionValidator
     position
   end
 
-  def self.extract_details_from_json_path(path, scope)
+  def extract_details_from_json_path(path, scope)
     elements = path.split("/")
 
     elements.uniq!
@@ -184,7 +184,7 @@ class SystemDescriptionValidator
     elements.join("/")
   end
 
-  def self.remove_json_error_uuid(message)
+  def remove_json_error_uuid(message)
     message.gsub(/ in schema .*$/, ".")
   end
 end

--- a/spec/unit/system_description_validator_spec.rb
+++ b/spec/unit/system_description_validator_spec.rb
@@ -266,60 +266,61 @@ EOT
   end
 
   describe ".cleanup_json_error_message" do
+    let (:validator)  { SystemDescriptionValidator.new(double) }
     describe "shows the correct position and reduces the clutter" do
       it "for missing attribute in unmanaged-files errors" do
         error = "The property '#/0/type/0/1/2/3/type/4/5' of type Array did not match any of the required schemas in schema 89d6911a-763e-51fd-8e35-257a1f31d377#"
         expected = "The property #5 of type Array did not match any of the required schemas."
-        expect(SystemDescriptionValidator.cleanup_json_error_message(error, "unmanaged_files")).
+        expect(validator.cleanup_json_error_message(error, "unmanaged_files")).
           to eq(expected)
       end
 
       it " for missing attribute in unmanaged_files and filters the type elements" do
         error = "The property '#/0/type/0/1/2/3/type/4/5/type/6/type/7/8/9/10/11/type/12/17/18/19/20/21/22/23/24/25/26/27/28/29/type/30/31/33/34/35/36/37/38/39/40/41/42/43/44/45/46/47/48/49/476/477/478/479/480/481/482/483/484/485/486/487/488/489/490/491/492/493/494/495/496/497/498/499/500/501/504/type/505/type/506/type/507/type/508/type/509/510/511/512/513/514/515/516/517/518/519/520/type/555' of type Array did not match any of the required schemas in schema 89d6911a-763e-51fd-8e35-257a1f31d377#"
         expected = "The property #555 of type Array did not match any of the required schemas."
-        expect(SystemDescriptionValidator.cleanup_json_error_message(error, "unmanaged_files")).
+        expect(validator.cleanup_json_error_message(error, "unmanaged_files")).
           to eq(expected)
       end
 
       it "for missing attribute in services" do
         error = "The property '#/services/2' did not contain a required property of 'state' in schema 73e30722-b9a4-573a-95a9-1f6882dd11a5#"
         expected = "The property #2 (services) did not contain a required property of 'state'."
-        expect(SystemDescriptionValidator.cleanup_json_error_message(error, "services")).
+        expect(validator.cleanup_json_error_message(error, "services")).
           to eq(expected)
       end
 
       it "for wrong status in services" do
         error = "The property '#/services/4/state' was not of a minimum string length of 1 in schema 73e30722-b9a4-573a-95a9-1f6882dd11a5#"
         expected = "The property #4 (services/state) was not of a minimum string length of 1."
-        expect(SystemDescriptionValidator.cleanup_json_error_message(error, "services")).
+        expect(validator.cleanup_json_error_message(error, "services")).
           to eq(expected)
       end
 
       it "for missing attribute in os" do
         error = "The property '#/' did not contain a required property of 'version' in schema 547e11fe-8e4b-574a-bec5-66ada4e5e2ec#"
         expected = "The property did not contain a required property of 'version'."
-        expect(SystemDescriptionValidator.cleanup_json_error_message(error, "os")).
+        expect(validator.cleanup_json_error_message(error, "os")).
           to eq(expected)
       end
 
       it "for wrong attribute type in users" do
         error = "The property '#/3/gid' of type String did not match one or more of the following types: integer, null in schema 769f5514-0330-592b-b538-87df746cb3d3#"
         expected = "The property #3 (gid) of type String did not match one or more of the following types: integer, null."
-        expect(SystemDescriptionValidator.cleanup_json_error_message(error, "users")).
+        expect(validator.cleanup_json_error_message(error, "users")).
           to eq(expected)
       end
 
       it "for unknown repository type and mentions the affected attribute 'type'" do
         error = "The property '#/4/type' value 0 did not match one of the following values: yast2, rpm-md, plaindir, null in schema 5ee44188-86f1-5823-92ac-e1068304cbf2#"
         expected = "The property #4 (type) value 0 did not match one of the following values: yast2, rpm-md, plaindir, null."
-        expect(SystemDescriptionValidator.cleanup_json_error_message(error, "repositories")).
+        expect(validator.cleanup_json_error_message(error, "repositories")).
           to eq(expected)
       end
 
       it "for unknown status in config-files" do
         error = "The property '#/0/1/status' of type Hash did not match any of the required schemas in schema 5257ca96-7f5c-5c72-b44e-80abca5b0f38#"
         expected = "The property #1 (status) of type Hash did not match any of the required schemas."
-        expect(SystemDescriptionValidator.cleanup_json_error_message(error, "config_files")).
+        expect(validator.cleanup_json_error_message(error, "config_files")).
           to eq(expected)
       end
     end


### PR DESCRIPTION
The json error handling was started before the validation was extracted
to its own class, that's why it was implemented as a class method.
Since it is now only used in the same class there is no point in
using class methods.
