### PR TITLE
Fix *-files inspectors to adhere to format version v2

### DIFF
--- a/plugins/inspect/changed_managed_files_inspector.rb
+++ b/plugins/inspect/changed_managed_files_inspector.rb
@@ -35,7 +35,7 @@ class ChangedManagedFilesInspector < Inspector
 
     description["changed_managed_files"] = ChangedManagedFilesScope.new(
       extracted: !!options[:extract_changed_managed_files],
-      files: result.sort_by(&:name)
+      files: ChangedManagedFileList.new(result.sort_by(&:name))
     )
     summary
   end

--- a/plugins/inspect/config_files_inspector.rb
+++ b/plugins/inspect/config_files_inspector.rb
@@ -110,7 +110,7 @@ class ConfigFilesInspector < Inspector
 
     description["config_files"] = ConfigFilesScope.new(
       extracted: !!do_extract,
-      files: result.sort_by(&:name)
+      files: ConfigFileList.new(result.sort_by(&:name))
     )
     summary
   end

--- a/plugins/inspect/unmanaged_files_inspector.rb
+++ b/plugins/inspect/unmanaged_files_inspector.rb
@@ -355,7 +355,7 @@ class UnmanagedFilesInspector < Inspector
 
     description["unmanaged_files"] = UnmanagedFilesScope.new(
       extracted: !!do_extract,
-      files: osl.sort_by(&:name)
+      files: UnmanagedFileList.new(osl.sort_by(&:name))
     )
     summary
   end

--- a/spec/unit/changed_managed_files_inspector_spec.rb
+++ b/spec/unit/changed_managed_files_inspector_spec.rb
@@ -40,7 +40,7 @@ describe ChangedManagedFilesInspector do
     it "returns a list of all changed files" do
       expected_result = ChangedManagedFilesScope.new(
         extracted: false,
-        files: [
+        files: ChangedManagedFileList.new([
           ChangedManagedFile.new(
               name: "/etc/apache2/de:fault server.conf",
               package_name: "hwinfo",
@@ -82,7 +82,7 @@ describe ChangedManagedFilesInspector do
               status: "changed",
               changes: ["replaced"]
           )
-        ]
+        ])
       )
       subject.inspect(system, description)
 

--- a/spec/unit/config_files_inspector_spec.rb
+++ b/spec/unit/config_files_inspector_spec.rb
@@ -208,7 +208,7 @@ EOF
 
       expected_data = ConfigFilesScope.new(
         extracted: false,
-        files: [apache_1, apache_2, iscsi_1, apache_3, apache_4, apache_5]
+        files: ConfigFileList.new([apache_1, apache_2, iscsi_1, apache_3, apache_4, apache_5])
       )
 
       expect_inspect_configfiles(system, false)
@@ -234,7 +234,7 @@ EOF
 
       expected = ConfigFilesScope.new(
         extracted: false,
-        files: []
+        files: ConfigFileList.new()
       )
       expect(description["config_files"]).to eq(expected)
     end

--- a/spec/unit/unmanaged_files_inspector_spec.rb
+++ b/spec/unit/unmanaged_files_inspector_spec.rb
@@ -27,7 +27,7 @@ describe UnmanagedFilesInspector do
     let(:expected_data) {
       UnmanagedFilesScope.new(
         extracted: false,
-        files: [
+        files: UnmanagedFileList.new([
           UnmanagedFile.new( name: "/etc/etc_mydir/", type: "dir" ),
           UnmanagedFile.new( name: "/etc/etc_myfile", type: "file" ),
           UnmanagedFile.new( name: "/my link", type: "link" ),
@@ -42,7 +42,7 @@ describe UnmanagedFilesInspector do
           UnmanagedFile.new( name: "/other_dir/", type: "dir" ),
           UnmanagedFile.new( name: "/usr/X11R6/x11_mydir/", type: "dir" ),
           UnmanagedFile.new( name: "/usr/X11R6/x11_myfile", type: "file" )
-        ]
+        ])
       )
     }
 
@@ -83,7 +83,7 @@ describe UnmanagedFilesInspector do
       end
       UnmanagedFilesScope.new(
         extracted: true,
-        files: files
+        files: UnmanagedFileList.new(files)
       )
     }
 
@@ -309,7 +309,7 @@ describe UnmanagedFilesInspector do
 
       expected = UnmanagedFilesScope.new(
         extracted: false,
-        files: []
+        files: UnmanagedFileList.new
       )
       expect(description["unmanaged_files"]).to eq(expected)
       expect(summary).to include("Found 0 unmanaged files and trees")


### PR DESCRIPTION
The inspectors generated normal Arrays as the file lists instead of
using the according model classes. That caused problems when serializing
the descriptions to JSON.
