### PR TITLE
Transform include_scope matcher into include_file_scop matcher

### DIFF
--- a/spec/integration/machinery_matcher_spec.rb
+++ b/spec/integration/machinery_matcher_spec.rb
@@ -260,78 +260,82 @@ describe "match_scope matcher" do
   end
 end
 
-describe "include_scope matcher" do
-  it "matches scope with included subset of entries" do
+describe "include_file_scope matcher" do
+  it "matches file scope with included subset of entries" do
     expected_description = create_test_description(json: <<-EOT)
     {
-      "packages": [
-        {
-          "name": "aaa-base",
-          "version": "0.1"
-        },
-        {
-          "name": "at",
-          "version": "0.1"
-        }
-      ]
+      "unmanaged_files": {
+        "extracted": true,
+        "files": [
+          {
+            "name": "/boot/grub/default",
+            "user": "root"
+          }
+        ]
+      }
     }
     EOT
 
     actual_description = create_test_description(json: <<-EOT)
     {
-      "packages": [
-        {
-          "name": "aaa-base",
-          "version": "0.1"
-        },
-        {
-          "name": "at",
-          "version": "0.1"
-        },
-        {
-          "name": "audit",
-          "version": "0.1"
-        }
-      ]
+      "unmanaged_files": {
+        "extracted": true,
+        "files": [
+          {
+            "name": "/boot/backup_mbr",
+            "user": "root"
+          },
+          {
+            "name": "/boot/grub/default",
+            "user": "root"
+          }
+        ]
+      }
     }
     EOT
 
-    expect(actual_description).to include_scope(expected_description,
-      "packages")
+    expect(actual_description).to include_file_scope(expected_description,
+      "unmanaged_files")
   end
 
   it "doesn't match scope with non-included subset of entries" do
     expected_description = create_test_description(json: <<-EOT)
     {
-      "packages": [
-        {
-          "name": "aaa-base",
-          "version": "0.1"
-        },
-        {
-          "name": "at",
-          "version": "0.1"
-        }
-      ]
+      "unmanaged_files": {
+        "extracted": true,
+        "files": [
+          {
+            "name": "/boot/backup_mbr",
+            "user": "nobody"
+          },
+          {
+            "name": "/boot/grub/default",
+            "user": "root"
+          }
+        ]
+      }
     }
     EOT
 
     actual_description = create_test_description(json: <<-EOT)
     {
-      "packages": [
-        {
-          "name": "aaa-base",
-          "version": "0.2"
-        },
-        {
-          "name": "at",
-          "version": "0.1"
-        }
-      ]
+      "unmanaged_files": {
+        "extracted": true,
+        "files": [
+          {
+            "name": "/boot/backup_mbr",
+            "user": "root"
+          },
+          {
+            "name": "/boot/grub/default",
+            "user": "root"
+          }
+        ]
+      }
     }
     EOT
 
-    expect(actual_description).to_not include_scope(expected_description,
-      "packages")
+    expect(actual_description).to_not include_file_scope(expected_description,
+      "unmanaged_files")
   end
 end

--- a/spec/integration/support/build_examples.rb
+++ b/spec/integration/support/build_examples.rb
@@ -107,7 +107,7 @@ shared_examples "build" do |distribution|
         end
 
         it "contains the changed config-files from the system description" do
-          expect(@new_description).to include_scope(@system_description,
+          expect(@new_description).to include_file_scope(@system_description,
             "config_files")
         end
 
@@ -135,7 +135,7 @@ shared_examples "build" do |distribution|
         end
 
         it "contains the changed managed-files from the system description" do
-          expect(@new_description).to include_scope(@system_description,
+          expect(@new_description).to include_file_scope(@system_description,
             "config_files")
         end
 
@@ -149,7 +149,7 @@ shared_examples "build" do |distribution|
 
       it "contains the unmanaged files from the system description" do
         # Check meta data
-        expect(@new_description).to include_scope(@system_description,
+        expect(@new_description).to include_file_scope(@system_description,
           "unmanaged_files")
 
         # Check file content

--- a/spec/integration/support/machinery_matcher.rb
+++ b/spec/integration/support/machinery_matcher.rb
@@ -52,14 +52,14 @@ RSpec::Matchers.define :match_scope do |expected, scope|
   end
 end
 
-RSpec::Matchers.define :include_scope do |expected, scope|
+RSpec::Matchers.define :include_file_scope do |expected, scope|
   match do |actual|
-    if actual[scope].is_a?(Machinery::Object) ||
-       actual[scope].is_a?(Machinery::Array)
-      expected[scope].all? { |e| actual[scope].include?(e) }
-    else
-      raise "Scope '#{scope}' has unsupported type '#{actual[scope].class}'"
+    if !["config_files", "changed_managed_files", "unmanaged_files"].include?(scope)
+      raise "Scope '#{scope}' is not supported by the 'include_files_scope' matcher." \
+        "Only use it with file scopes."
     end
+
+    expected[scope].files.all? { |e| actual[scope].files.include?(e) }
   end
 
   failure_message do |actual|
@@ -71,7 +71,7 @@ RSpec::Matchers.define :include_scope do |expected, scope|
   end
 
   description do
-    "takes two system descriptions and a scope and checks if the actual " +
+    "takes two system descriptions and a file scope and checks if the actual " +
     "scope includes the data of the expected scope"
   end
 end


### PR DESCRIPTION
The include_scope matcher seemed to be applicable to both
Machinery::Arrays and Machinery::Objects, but it actually only worked
for Machinery::Arrays. It was also only used to match file scopes which
were changed to Machinery::Objects recently so it broke there as well.

This commit fixes the matcher for the file scopes and makes it clear
that it only works for file scopes from the name.
