### PR TITLE
[Review] Request from 'greygoo' @ 'SUSE/machinery/review_140919_add_system_description_documentation_link_to_man_page'

### DIFF
--- a/man/machinery_main.1.md
+++ b/man/machinery_main.1.md
@@ -187,6 +187,11 @@ Machinery supports the following scopes:
   Contains information about the system groups such as group attributes and the
   list of group members.
 
+### System Description
+
+The System Description format and file structure is documented in the machinery wiki: [https://github.com/SUSE/machinery/wiki/System-Description-Format](https://github.com/SUSE/machinery/wiki/System-Description-Format)
+
+
 
 ### Use Cases
 


### PR DESCRIPTION
Please review the following changes:
- 26fb1e6 Add a link pointing to the system description format documentation to the man page.
- a6b08ff Merge pull request #244 from SUSE/review_140919_fix_missing_line_break_between_missing_and_additional_file_errors
- cb458ca Fix missing line break between missing and additional file errors
