### PR TITLE
Get rid of prima donna methods

### DIFF
--- a/lib/system_description.rb
+++ b/lib/system_description.rb
@@ -111,7 +111,7 @@ class SystemDescription < Machinery::Object
       format_version == SystemDescription::CURRENT_FORMAT_VERSION
   end
 
-  def ensure_compatibility!
+  def validate_compatibility
     if !compatible?
       raise Machinery::Errors::SystemDescriptionError.new(
         "The system description #{name} has an incompatible data format and can" \
@@ -201,8 +201,8 @@ class SystemDescription < Machinery::Object
     files - file_list
   end
 
-  def validate_file_data!
-    SystemDescriptionValidator.new(self).validate_file_data!
+  def validate_file_data
+    SystemDescriptionValidator.new(self).validate_file_data
   end
 
   # Filestore handling

--- a/lib/system_description_store.rb
+++ b/lib/system_description_store.rb
@@ -49,8 +49,8 @@ class SystemDescriptionStore
   def load(name)
     json = load_json(name)
     description = SystemDescription.from_json(name, json, self)
-    description.ensure_compatibility!
-    description.validate_file_data!
+    description.validate_compatibility
+    description.validate_file_data
     description
   end
 

--- a/lib/system_description_validator.rb
+++ b/lib/system_description_validator.rb
@@ -135,7 +135,7 @@ class SystemDescriptionValidator
     "Scope '#{scope}':\n" + errors.join("\n")
   end
 
-  def validate_file_data!
+  def validate_file_data
     errors = []
 
     ["config_files", "changed_managed_files", "unmanaged_files"].each do |scope|

--- a/spec/unit/list_task_spec.rb
+++ b/spec/unit/list_task_spec.rb
@@ -122,7 +122,7 @@ describe ListTask do
 
     it "marks scopes with exctracted files as such" do
       allow(store).to receive(:file_store).and_return(double)
-      allow_any_instance_of(SystemDescription).to receive(:validate_file_data!)
+      allow_any_instance_of(SystemDescription).to receive(:validate_file_data)
       expect(Machinery::Ui).to receive(:puts) { |s|
         expect(s).to include(name)
         expect(s).to include("config-files (extracted)")

--- a/spec/unit/system_description_spec.rb
+++ b/spec/unit/system_description_spec.rb
@@ -205,18 +205,18 @@ EOF
     end
   end
 
-  describe "#ensure_compatibility!" do
+  describe "#validate_compatibility" do
     it "does not raise an exception if the description is compatible" do
       subject.format_version = SystemDescription::CURRENT_FORMAT_VERSION
       expect {
-        subject.ensure_compatibility!
+        subject.validate_compatibility
       }.to_not raise_error
     end
 
     it "raises an exception if the description is incompatible" do
       subject.format_version = SystemDescription::CURRENT_FORMAT_VERSION - 1
       expect {
-        subject.ensure_compatibility!
+        subject.validate_compatibility
       }.to raise_error
     end
   end

--- a/spec/unit/system_description_store_spec.rb
+++ b/spec/unit/system_description_store_spec.rb
@@ -78,8 +78,8 @@ describe SystemDescriptionStore do
       expect(description.name).to eq(test_name)
     end
 
-    it "ensures that the system description is compatible" do
-      expect_any_instance_of(SystemDescription).to receive(:ensure_compatibility!)
+    it "validates that the system description is compatible" do
+      expect_any_instance_of(SystemDescription).to receive(:validate_compatibility)
 
       @store.load(test_name)
     end

--- a/spec/unit/system_description_validator_spec.rb
+++ b/spec/unit/system_description_validator_spec.rb
@@ -180,7 +180,7 @@ EOF
     end
   end
 
-  describe "#validate_file_data!" do
+  describe "#validate_file_data" do
     before(:each) do
       path = "spec/data/descriptions/validation"
       @store = SystemDescriptionStore.new(path)


### PR DESCRIPTION
Remove the methods which use the exclamation mark suffix without
another method without the suffix being available.

Also use consistent naming for the validation functions.

See also: https://github.com/troessner/reek/wiki/Prima-Donna-Method
