### PR TITLE
Add rubygem-devel as explicit requirement for 13.1

### DIFF
--- a/machinery.spec.erb
+++ b/machinery.spec.erb
@@ -39,6 +39,7 @@ BuildRequires:  %{rubygem bundler}
 BuildRequires:  %{rubygem <%= require[:name] %> <%= require[:operator] %> <%= require[:version] %>}
 <% end -%>
 %else
+BuildRequires:  ruby-devel
 BuildRequires:  rubygem(gem2rpm)
 BuildRequires:  rubygem(bundler)
 <% build_requires.each do |require| -%>


### PR DESCRIPTION
It seems that the handling of Ruby gems for openSUSE 13.1 was changed. A
backport repository is automatically used and ruby-devel needs to be
required explicitly.
