### PR TITLE
Fix integration tests

### DIFF
--- a/spec/data/analyze_config_file_diffs/opensuse131
+++ b/spec/data/analyze_config_file_diffs/opensuse131
@@ -1,4 +1,4 @@
-# Changed configuration files [192.168.122.164] (2014-08-14 20:39:10)
+# Changed configuration files (extracted) [192.168.122.164] (2014-08-14 20:39:10)
 
   * /etc/crontab (md5)
     Diff:

--- a/spec/data/changed_managed_files/opensuse131
+++ b/spec/data/changed_managed_files/opensuse131
@@ -1,4 +1,4 @@
-# Changed managed files [192.168.122.238] (2014-05-21 17:00:14)
+# Changed managed files (extracted) [192.168.122.238] (2014-05-21 17:00:14)
 
   * /etc/cron.daily/mdadm (deleted)
   * /sys (mode)

--- a/spec/data/config_files/opensuse131
+++ b/spec/data/config_files/opensuse131
@@ -1,4 +1,4 @@
-# Changed configuration files [192.168.122.238] (2014-05-21 17:00:14)
+# Changed configuration files (extracted) [192.168.122.238] (2014-05-21 17:00:14)
 
   * /etc/crontab (md5)
   * /etc/default/grub (mode, md5)

--- a/spec/data/upgrade-format/format_v1_upgraded
+++ b/spec/data/upgrade-format/format_v1_upgraded
@@ -1,4 +1,4 @@
-# Unmanaged files [10.122.166.77] (2014-08-27 14:00:17)
+# Unmanaged files (not extracted) [10.122.166.77] (2014-08-27 14:00:17)
 
   * /boot/0xfcdaa824 (file)
     User/Group: root:root

--- a/spec/integration/machinery_matcher_spec.rb
+++ b/spec/integration/machinery_matcher_spec.rb
@@ -38,7 +38,7 @@ describe "match_machinery_show_scope matcher" do
 
   it "matches output with timestamps" do
     expected = <<-EOT
-      # Changed configuration files [192.168.0.10] (2014-02-24 16:13:09)
+      # Changed configuration files (extracted) [192.168.0.10] (2014-02-24 16:13:09)
 
       - /etc/crontab (md5)
         Diff:
@@ -48,7 +48,7 @@ describe "match_machinery_show_scope matcher" do
         +-*/15 * * * *   root  echo config_files_integration_test
     EOT
     actual = <<-EOT
-      # Changed configuration files [192.168.0.10] (2014-02-24 16:13:09)
+      # Changed configuration files (extracted) [192.168.0.10] (2014-02-24 16:13:09)
 
       - /etc/crontab (md5)
         Diff:
@@ -58,7 +58,25 @@ describe "match_machinery_show_scope matcher" do
         +-*/15 * * * *   root  echo config_files_integration_test
     EOT
 
+    expect(actual).to match_machinery_show_scope(expected)
   end
+
+  it "matches output with extracted state" do
+    expected = <<-EOT
+      # Changed configuration files (extracted) [192.168.0.10] (2014-02-24 16:13:09)
+
+      - /etc/crontab
+    EOT
+    actual = <<-EOT
+      # Changed configuration files (not extracted) [192.168.0.10] (2014-02-24 16:13:09)
+
+      - /etc/crontab (md5)
+    EOT
+
+    expect(actual).to_not match_machinery_show_scope(expected)
+  end
+
+
 
   it "matches incorrect show output" do
     expected_output = <<-EOT

--- a/spec/integration/support/machinery_matcher.rb
+++ b/spec/integration/support/machinery_matcher.rb
@@ -20,8 +20,8 @@ require 'rspec/expectations'
 RSpec::Matchers.define :match_machinery_show_scope do |expected|
   match do |actual|
     # Remove timestamps which would trigger a failure
-    expected.sub!(/(# [A-Za-z ]+ \[)(.*)(\] \()(.*)(\))/, "\\1\\3\\5").strip!
-    actual.sub!(/(# [A-Za-z ]+ \[)(.*)(\] \()(.*)(\))/, "\\1\\3\\5").strip!
+    expected.sub!(/(# [A-Za-z \(\)]+ \[)(.*)(\] \()(.*)(\))/, "\\1\\3\\5").strip!
+    actual.sub!(/(# [A-Za-z \(\)]+ \[)(.*)(\] \()(.*)(\))/, "\\1\\3\\5").strip!
 
     # Remove ISO 8601 (and similar) timestamps
     expected.gsub!(/\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}.\d+[Z\-\+ ]+\d{2}:*\d{2}/, "")


### PR DESCRIPTION
The matcher that is used to compare the "machinery show" output was not
aware of the new extracted state field in the header.
