### PR TITLE
Improvements regarding hints and configuration

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -36,7 +36,7 @@ class Cli
   end
 
   post do |global_options,command,options,args|
-    if command.is_a?(GLI::Commands::Help)
+    if command.is_a?(GLI::Commands::Help) && global_options[:help]
       Hint.get_started
     end
   end

--- a/lib/config_base.rb
+++ b/lib/config_base.rb
@@ -50,17 +50,18 @@ class ConfigBase
     @entries[key][:value]
   end
 
-  def set(key, value)
+  def set(key, value, options = {auto_save: true} )
     ensure_config_exists(key)
 
-    # Check if data type if correct. true and false are not of the same type which makes the check complex
+    # Check if data type is correct. true and false are not of the same type which makes the check complex
     if value.class != @entries[key][:value].class &&
       ! ( ( value == true || value == false ) && ( @entries[key][:value].class == TrueClass || @entries[key][:value].class == FalseClass ) )
       raise Machinery::Errors::MachineryError.new("The value \"#{value}\" for configuration key \"#{key}\" is of an invalid data type.")
     end
 
     @entries[key][:value] = value
-    save
+
+    save if options[:auto_save]
   end
 
 
@@ -87,7 +88,7 @@ class ConfigBase
 
     content.each do |key, value|
       begin
-        set(key, value)
+        set(key, value, :auto_save => false )
       rescue => e
         Machinery::Ui.warn "Warning: The machinery config file \"#{file}\" contains an invalid entry \"#{key}\":\n#{e}"
       end

--- a/lib/hint.rb
+++ b/lib/hint.rb
@@ -32,6 +32,8 @@ class Hint
   private
 
   def self.output(text)
-    Machinery::Ui.puts "\nHint: #{text}\n"
+    if Machinery::Config.new.hints
+      Machinery::Ui.puts "\nHint: #{text}\n"
+    end
   end
 end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -86,7 +86,7 @@ describe Machinery::Config do
   end
 
   describe "#save" do
-    it "writes the config to the config file" do
+    it "writes the config to the file when the set method is called" do
       allow_any_instance_of(Machinery::Config).to receive(:define_entries)
       subject.default_config_file(Machinery::DEFAULT_CONFIG_FILE)
       subject.entry("configkey", default: false, description: "configtext")
@@ -95,6 +95,18 @@ describe Machinery::Config do
       expect(File.readlines(Machinery::DEFAULT_CONFIG_FILE)).to eq(["---\n", "configkey: true\n"])
 
       subject.set("configkey", false)
+      expect(File.readlines(Machinery::DEFAULT_CONFIG_FILE)).to eq(["---\n", "configkey: false\n"])
+    end
+
+    it "writes the config to the file when the generated accessors are called" do
+      allow_any_instance_of(Machinery::Config).to receive(:define_entries)
+      subject.default_config_file(Machinery::DEFAULT_CONFIG_FILE)
+      subject.entry("configkey", default: false, description: "configtext")
+
+      subject.configkey = true
+      expect(File.readlines(Machinery::DEFAULT_CONFIG_FILE)).to eq(["---\n", "configkey: true\n"])
+
+      subject.configkey = false
       expect(File.readlines(Machinery::DEFAULT_CONFIG_FILE)).to eq(["---\n", "configkey: false\n"])
     end
   end

--- a/spec/unit/hints_spec.rb
+++ b/spec/unit/hints_spec.rb
@@ -19,22 +19,43 @@ require_relative "spec_helper"
 
 describe Hint do
   describe "#get_started" do
-    it "prints a hint how to get started" do
-      expect_any_instance_of(IO).to receive(:puts).with(/inspect HOSTNAME/)
+    it "prints a hint how to get started if hints are enabled" do
+      expect_any_instance_of(Machinery::Config).to receive(:get).with("hints").and_return(true)
+      expect_any_instance_of(IO).to receive(:puts).with(/Hint:.*\n.*inspect HOSTNAME/)
+      Hint.get_started
+    end
+
+    it "doesn't print a hint how to get started if hints are disabled" do
+      expect_any_instance_of(Machinery::Config).to receive(:get).with("hints").and_return(false)
+      expect_any_instance_of(IO).to_not receive(:puts).with(/Hint:.*\n.*inspect HOSTNAME/)
       Hint.get_started
     end
   end
 
   describe "#show_data" do
-    it "prints a hint how to show data" do
-      expect_any_instance_of(IO).to receive(:puts).with(/show/)
+    it "prints a hint how to show data if hints are enabled" do
+      expect_any_instance_of(Machinery::Config).to receive(:get).with("hints").and_return(true)
+      expect_any_instance_of(IO).to receive(:puts).with(/Hint:.*\n.*show/)
+      Hint.show_data(:name => "foo")
+    end
+
+    it "doesn't print a hint how to show data if hints are disabled" do
+      expect_any_instance_of(Machinery::Config).to receive(:get).with("hints").and_return(false)
+      expect_any_instance_of(IO).to_not receive(:puts).with(/Hint:.*\n.*show/)
       Hint.show_data(:name => "foo")
     end
   end
 
   describe "#do_complete_inspection" do
-    it "prints a hint how to do a complete inspection" do
-      expect_any_instance_of(IO).to receive(:puts).with(/inspect foo --name bar --extract-files/)
+    it "prints a hint how to do a complete inspection if hints are enabled" do
+      expect_any_instance_of(Machinery::Config).to receive(:get).with("hints").and_return(true)
+      expect_any_instance_of(IO).to receive(:puts).with(/Hint:.*\n.*inspect foo --name bar --extract-files/)
+      Hint.do_complete_inspection(:name => "bar", :host => "foo")
+    end
+
+    it "doesn't print a hint how to do a complete inspection if hints are disabled" do
+      expect_any_instance_of(Machinery::Config).to receive(:get).with("hints").and_return(false)
+      expect_any_instance_of(IO).to_not receive(:puts).with(/Hint:.*\n.*inspect foo --name bar --extract-files/)
       Hint.do_complete_inspection(:name => "bar", :host => "foo")
     end
   end


### PR DESCRIPTION
Save config file to disk only when needed
Show hints only when enabled
Don't show hint for `machinery --version`
