### PR TITLE
Add migration path from 1 to 2 for missing gid

### DIFF
--- a/schema/migrations/migrate1to2.rb
+++ b/schema/migrations/migrate1to2.rb
@@ -24,6 +24,8 @@ class Migrate1To2 < Migration
     It also introduces a "remote_dir" type for the unmanaged_files scope
     indicating that the directory is a remote mount point and that the
     content is not checked or extracted.
+
+    Add the missing GID key for NIS placeholder entries in groups.
   EOT
 
   def migrate
@@ -41,6 +43,14 @@ class Migrate1To2 < Migration
         "extracted" => is_extracted,
         "files"     => files
       }
+    end
+
+    if @hash.has_key?("groups")
+      @hash["groups"].each do |element|
+        if !element["gid"]
+          element["gid"] = nil
+        end
+      end
     end
   end
 end

--- a/spec/unit/migrations/migrate1to2_spec.rb
+++ b/spec/unit/migrations/migrate1to2_spec.rb
@@ -84,6 +84,13 @@ describe Migrate1To2 do
             "files": 2
           }
         ],
+        "groups": [
+          {
+            "name": "+",
+            "password": "",
+            "users": []
+          }
+        ],
         "meta": {
           "format_version": 1
         }
@@ -129,5 +136,14 @@ describe Migrate1To2 do
     expect(description_hash["config_files"]["files"]).to match_array(config_files)
     expect(description_hash["changed_managed_files"]["files"]).to match_array(changed_managed_files)
     expect(description_hash["unmanaged_files"]["files"]).to match_array(unmanaged_files)
+  end
+
+  it "makes sure that NIS group placeholders have a GID" do
+    expect(description_hash["groups"].first.has_key?("gid")).to be(false)
+
+    migration = Migrate1To2.new(description_hash, description_base)
+    migration.migrate
+
+    expect(description_hash["groups"].first.has_key?("gid")).to be(true)
   end
 end


### PR DESCRIPTION
Add migration path from 1 to 2 for missing gid
NIS placeholders didn't have a GID in json in v0.19*. To support
upgrading without issues we add the GID now to comply with our schema.

Our schema was added in v0.20 were the GID issue was also fixed but
there was no migration added for old manifest files.
