### PR TITLE
[Review] Request from 'tgoettlicher' @ 'SUSE/machinery/review_141014_fixes_for_work_flow_hints'

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -36,7 +36,7 @@ class Cli
   end
 
   post do |global_options,command,options,args|
-    if command.is_a?(GLI::Commands::Help) && global_options[:help]
+    if command.is_a?(GLI::Commands::Help) && !global_options[:version]
       Hint.get_started
     end
   end


### PR DESCRIPTION
Please review the following changes:
- 1d21261 Show hint for `machinery help` but not for `machinery --version`
- 77ccb27 Show hint after partial scope inspect with file extraction
