### PR TITLE
Apply ignore list to remote dirs

### DIFF
--- a/plugins/inspect/unmanaged_files_inspector.rb
+++ b/plugins/inspect/unmanaged_files_inspector.rb
@@ -218,8 +218,16 @@ class UnmanagedFilesInspector < Inspector
     final_file_store = "unmanaged_files"
 
 
-    ignore_list = [ "tmp", "var/tmp", "lost+found", "var/run", "var/lib/rpm",
-      ".snapshots", description.store.base_path.sub(/^\//, "")]
+    ignore_list = [
+      "tmp",
+      "var/tmp",
+      "lost+found",
+      "var/run",
+      "var/lib/rpm",
+      ".snapshots",
+      description.store.base_path.sub(/^\//, ""),
+      "proc"
+    ]
 
     # Information about users and groups are extracted by the according inspector
     ignore_list += [
@@ -252,6 +260,9 @@ class UnmanagedFilesInspector < Inspector
     excluded_files = []
     unmanaged_links = {}
     remote_dirs = mount_points.remote
+    ignore_list.each do |ignore|
+      remote_dirs.delete_if { |e| e.start_with?(File.join("/", ignore, "/")) }
+    end
     dirs_todo = [ "/" ]
     start = start_depth
     max = max_depth

--- a/spec/data/unmanaged_files/opensuse131
+++ b/spec/data/unmanaged_files/opensuse131
@@ -1968,8 +1968,6 @@
 
   * /mnt/unmanaged/remote-dir/ (remote_dir)
 
-  * /proc/sys/fs/binfmt_misc/ (remote_dir)
-
   * /remote-dir/ (remote_dir)
 
   * /root/.bash_history (file)


### PR DESCRIPTION
Make sure that we don't warn the user about remote_dirs in directories
which we are ignoring anyway.
