### PR TITLE
Fix formatting, so that syntax highlighting works

### DIFF
--- a/lib/local_system.rb
+++ b/lib/local_system.rb
@@ -16,7 +16,7 @@
 # you may find current contact information at www.suse.com
 
 class LocalSystem < System
-  class <<self
+  class << self
     def os_object
       description = SystemDescription.new("localhost")
       inspector = OsInspector.new


### PR DESCRIPTION
At least Kate expects a space before the `<<` to properly highlight syntax in this file.
