### PR TITLE
Add veewee box definitions and Vagrantfile entries for 13.2.

### DIFF
--- a/spec/definitions/vagrant/Vagrantfile
+++ b/spec/definitions/vagrant/Vagrantfile
@@ -80,6 +80,36 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     machinery_131.vm.provision "machinery_rpm"
   end
 
+  config.vm.define :opensuse132 do |opensuse132|
+    opensuse132.vm.box = "base_opensuse13.2_kvm"
+
+    opensuse132.vm.provider :libvirt do |domain|
+      domain.memory = 1024
+      domain.cpus = 1
+      domain.nested = false
+      domain.volume_cache = 'none'
+    end
+
+    inject_test_data(opensuse132)
+  end
+
+  config.vm.define :machinery_132 do |machinery_132|
+    machinery_132.vm.box = "machinery_opensuse13.2_kvm"
+    machinery_132.vm.network :private_network, :network_name => "default"
+
+    machinery_132.vm.provider :libvirt do |domain|
+      domain.memory = 1024
+      domain.cpus = 1
+      domain.nested = false
+      domain.volume_cache = 'none'
+    end
+
+    machinery_132.vm.provision "machinery_rpm",
+      :api     => "https://api.opensuse.org",
+      :project => "systemsmanagement:machinery",
+      :package => "openSUSE_13.2"
+  end
+
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.
   # config.vm.box_url = "http://domain.com/path/to/above.box"

--- a/spec/definitions/veewee/definitions/base_opensuse13.2_kvm/autoinst.xml
+++ b/spec/definitions/veewee/definitions/base_opensuse13.2_kvm/autoinst.xml
@@ -1,0 +1,210 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <bootloader>
+    <device_map config:type="list">
+      <device_map_entry>
+        <firmware>hd0</firmware>
+        <linux>/dev/vda</linux>
+      </device_map_entry>
+    </device_map>
+    <global>
+      <activate>true</activate>
+      <default>openSUSE 13.2</default>
+      <generic_mbr>true</generic_mbr>
+      <lines_cache_id>2</lines_cache_id>
+      <timeout config:type="integer">8</timeout>
+    </global>
+    <loader_type>grub2</loader_type>
+    <sections config:type="list">
+      <section>
+        <append>resume=/dev/vda1 splash=silent quiet showopts</append>
+        <image>/boot/vmlinuz-3.11.3-1-desktop</image>
+        <lines_cache_id>0</lines_cache_id>
+        <menuentry>openSUSE 13.2</menuentry>
+        <name>openSUSE 13.2</name>
+        <root>/dev/vda2</root>
+        <type>image</type>
+        <usage>Linux</usage>
+      </section>
+      <section>
+        <append>showopts apm=off noresume nosmp maxcpus=0 edd=off powersaved=off nohz=off highres=off processor.max_cstate=1 nomodeset x11failsafe</append>
+        <image>(hd0,1)/boot/vmlinuz-2.6.37.1-1.2-default</image>
+        <initrd>(hd0,1)/boot/initrd-2.6.37.1-1.2-default</initrd>
+        <lines_cache_id>1</lines_cache_id>
+        <name>Failsafe -- openSUSE 11.4 - 2.6.37.1-1.2</name>
+        <original_name>failsafe</original_name>
+        <root>/dev/vda2</root>
+        <type>image</type>
+      </section>
+    </sections>
+  </bootloader>
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+  </general>
+  <scripts>
+    <init-scripts config:type="list">
+      <script>
+        <chrooted config:type="boolean">true</chrooted>
+        <interpreter>shell</interpreter>
+        <source><![CDATA[
+  chkconfig sshd on
+  rcsshd start
+]]></source>
+      </script>
+    </init-scripts>
+  </scripts>
+  <networking>
+    <dhcp_options>
+      <dhclient_client_id></dhclient_client_id>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
+      <domain>vagrantup.com</domain>
+      <hostname>vagrant-opensuse</hostname>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <searchlist config:type="list">
+        <search>vagrantup.com</search>
+      </searchlist>
+      <write_hostname config:type="boolean">true</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp</bootproto>
+        <device>eth0</device>
+        <name>82540EM Gigabit Ethernet Controller</name>
+        <startmode>nfsroot</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+    </interfaces>
+  </networking>
+  <partitioning config:type="list">
+    <drive>
+      <device>/dev/vda</device>
+      <initialize config:type="boolean">true</initialize>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  <software>
+    <install_recommended config:type="boolean">false</install_recommended>
+    <packages config:type="list">
+      <package>aaa_base</package>
+      <package>autofs</package>
+      <package>bash</package>
+      <package>coreutils</package>
+      <package>cracklib-dict-full</package>
+      <package>device-mapper</package>
+      <package>dhcpcd</package>
+      <package>e2fsprogs</package>
+      <package>elfutils</package>
+      <package>filesystem</package>
+      <package>gcc</package>
+      <package>glibc</package>
+      <package>grub2</package>
+      <package>ifplugd</package>
+      <package>initviocons</package>
+      <package>insserv</package>
+      <package>iputils</package>
+      <package>kbd</package>
+      <package>kernel-default</package>
+      <package>klogd</package>
+      <package>less</package>
+      <package>login</package>
+      <package>mkinitrd</package>
+      <package>module-init-tools</package>
+      <package>ncurses-utils</package>
+      <package>nfs-kernel-server</package>
+      <package>openssh</package>
+      <package>pam</package>
+      <package>pam-modules</package>
+      <package>procps</package>
+      <package>pwdutils</package>
+      <package>rpcbind</package>
+      <package>rpm</package>
+      <package>sudo</package>
+      <package>sysconfig</package>
+      <package>tar</package>
+      <package>timezone</package>
+      <package>vim</package>
+      <package>vim-base</package>
+      <package>w3m</package>
+      <package>zypper</package>
+      <package>rsync</package>
+      <package>ca-certificates-mozilla</package>
+      <package>glibc-locale</package>
+      <package>yast2-network</package>
+      <package>yast2-users</package>
+      <package>cronie</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>base</pattern>
+    </patterns>
+    <remove-packages config:type="list">
+      <package>libyui-gtk-pkg5</package>
+      <package>libyui-gtk5</package>
+      <package>Mesa</package>
+      <package>libcairo2</package>
+      <package>libgtk-3-0</package>
+      <package>gtk3-tools</package>
+      <package>libpango-1_0-0</package>
+      <package>libcairo-gobject2</package>
+      <package>pango-tools</package>
+      <package>wallpaper-branding-openSUSE-13.2</package>
+      <package>subversion</package>
+      <package>tcl</package>
+      <package>tk</package>
+      <package>libXft2</package>
+      <package>libtool</package>
+      <package>fontconfig</package>
+      <package>gitk</package>
+      <package>git-gui</package>
+    </remove-packages>
+  </software>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>vagrant</fullname>
+      <gid>100</gid>
+      <home>/home/vagrant</home>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>vagrant</user_password>
+      <username>vagrant</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>vagrant</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/spec/definitions/veewee/definitions/base_opensuse13.2_kvm/base_opensuse13.2_kvm.description
+++ b/spec/definitions/veewee/definitions/base_opensuse13.2_kvm/base_opensuse13.2_kvm.description
@@ -1,0 +1,10 @@
+Documentation for defined boxes
+
+base_opensuse13.2_kvm:
+
+  OS: openSUSE 13.2 (64bit)
+  Disk size: 20GB
+  Memory: 1024MB
+  Credentials:
+    User: root, password: vagrant
+    User: vagrant, password: vagrant

--- a/spec/definitions/veewee/definitions/base_opensuse13.2_kvm/definition.rb
+++ b/spec/definitions/veewee/definitions/base_opensuse13.2_kvm/definition.rb
@@ -1,0 +1,42 @@
+Veewee::Definition.declare(
+  cpu_count: "2",
+  memory_size: "1024",
+  disk_size: "20280",
+  disk_format: "VDI",
+  hostiocache: "off",
+  os_type_id: "OpenSUSE_64",
+  iso_file: "openSUSE-13.2-DVD-x86_64.iso",
+  iso_src: "http://download.opensuse.org/distribution/13.2/iso/openSUSE-13.2-DVD-x86_64.iso",
+  iso_md5: "350b8cb014a4e342cc9a7cc9df891b99",
+  iso_download_timeout: "1000",
+  boot_wait: "10",
+  boot_cmd_sequence: [
+    "<Esc><Enter>",
+    "linux",
+    " netdevice=eth0",
+    " netsetup=dhcp",
+    " instmode=dvd",
+    " textmode=1",
+    " autoyast=http://%IP%:8888/autoinst.xml",
+    "<Enter>"
+   ],
+  ssh_login_timeout: "10000",
+  ssh_user: "vagrant",
+  ssh_password: "vagrant",
+  ssh_key: "",
+  ssh_host_port: "7222",
+  ssh_guest_port: "22",
+  sudo_cmd: "echo '%p'|sudo -S sh '%f'",
+  shutdown_cmd: "shutdown -P now",
+  postinstall_files: [ "postinstall.sh", "postinstall_machinery.sh"],
+  postinstall_timeout: "10000",
+  hooks: {
+    # Before starting the build we spawn a webrick webserver which serves the
+    # autoyast profile to the installer. veewee"s built in webserver solution
+    # doesn"t work reliably with autoyast due to some timing issues.
+    before_create: Proc.new do
+      path = "#{Dir.pwd}/definitions/#{definition.box.name}"
+      Thread.new { WEBrick::HTTPServer.new(Port: 8888, DocumentRoot: path).start }
+    end
+  }
+)

--- a/spec/definitions/veewee/definitions/base_opensuse13.2_kvm/postinstall.sh
+++ b/spec/definitions/veewee/definitions/base_opensuse13.2_kvm/postinstall.sh
@@ -1,0 +1,29 @@
+#
+# postinstall.sh
+# Taken from https://github.com/jedi4ever/veewee/blob/master/templates/openSUSE-12.3-x86_64-NET_EN/postinstall.sh
+#
+
+date > /etc/vagrant_box_build_time
+echo 'solver.allowVendorChange = true' >> /etc/zypp/zypp.conf
+echo 'solver.onlyRequires = true' >> /etc/zypp/zypp.conf
+
+# remove zypper package locks
+rm -f /etc/zypp/locks
+
+# install vagrant key
+mkdir -pm 700 /home/vagrant/.ssh
+curl -Lo /home/vagrant/.ssh/authorized_keys 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub'
+chmod 0600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant: /home/vagrant/.ssh
+
+# update sudoers
+echo -e "\nupdate sudoers ..."
+echo -e "\n# added by veewee/postinstall.sh" >> /etc/sudoers
+echo -e "vagrant ALL=(ALL) NOPASSWD: ALL\n" >> /etc/sudoers
+
+
+# speed-up remote logins
+echo -e "\nspeed-up remote logins ..."
+echo -e "\n# added by veewee/postinstall.sh" >> /etc/ssh/sshd_config
+echo -e "UseDNS no\n" >> /etc/ssh/sshd_config
+

--- a/spec/definitions/veewee/definitions/base_opensuse13.2_kvm/postinstall_machinery.sh
+++ b/spec/definitions/veewee/definitions/base_opensuse13.2_kvm/postinstall_machinery.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Add 13.2 repositories as they can not be added via
+# autoyast due to some bug.
+zypper --gpg-auto-import-keys ar --refresh --name "Main Repository (OSS)" http://download.opensuse.org/distribution/13.2/repo/oss/ download.opensuse.org-oss
+zypper --gpg-auto-import-keys ar --refresh --name "Main Repository (NON-OSS)" http://download.opensuse.org/distribution/13.2/repo/non-oss/ download.opensuse.org-non-oss
+
+zypper --gpg-auto-import-keys ar --refresh --name "Main Update Repository" http://download.opensuse.org/update/13.2/ download.opensuse.org-update
+zypper --gpg-auto-import-keys ar --refresh --name "Update Repository (Non-Oss)" http://download.opensuse.org/update/13.2-non-oss/ download.opensuse.org-13.2-non-oss
+
+zypper --gpg-auto-import-keys ar --disable --refresh --name "openSUSE-13.2-Debug" http://download.opensuse.org/debug/distribution/13.2/repo/oss/ repo-debug
+zypper --gpg-auto-import-keys ar --disable --refresh --name "openSUSE-13.2-Update-Debug" http://download.opensuse.org/debug/update/13.2/ repo-debug-update
+zypper --gpg-auto-import-keys ar --disable --refresh --name "openSUSE-13.2-Update-Debug-Non-Oss" http://download.opensuse.org/debug/update/13.2-non-oss/ repo-debug-update-non-oss
+
+zypper --gpg-auto-import-keys ar --disable --refresh --name "openSUSE-13.2-Source" http://download.opensuse.org/source/distribution/13.2/repo/oss/ repo-source
+
+# remove non-static files which break the tests on rebuilds
+rm /var/log/YaST2/config_diff_*.log
+rm /etc/zypp/repos.d/dir-*.repo
+
+# avoid mac address configured into system, this results in getting
+# eth1 instead of eth0 in virtualized environments sometimes
+rm -f /etc/udev/rules.d/70-persistent-net.rules
+
+# Disable cron jobs in order to prevent created files breaking the tests
+rm /etc/cron.daily/*
+
+# Make sure that everything's written to disk, otherwise we sometimes get
+# empty files in the image
+sync

--- a/spec/definitions/veewee/definitions/machinery_opensuse13.2_kvm/autoinst.xml
+++ b/spec/definitions/veewee/definitions/machinery_opensuse13.2_kvm/autoinst.xml
@@ -1,0 +1,207 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <bootloader>
+    <device_map config:type="list">
+      <device_map_entry>
+        <firmware>hd0</firmware>
+        <linux>/dev/vda</linux>
+      </device_map_entry>
+    </device_map>
+    <global>
+      <activate>true</activate>
+      <default>openSUSE 13.2</default>
+      <generic_mbr>true</generic_mbr>
+      <lines_cache_id>2</lines_cache_id>
+      <timeout config:type="integer">8</timeout>
+    </global>
+    <loader_type>grub2</loader_type>
+    <sections config:type="list">
+      <section>
+        <append>resume=/dev/vda1 splash=silent quiet showopts</append>
+        <image>/boot/vmlinuz-3.11.3-1-desktop</image>
+        <lines_cache_id>0</lines_cache_id>
+        <menuentry>openSUSE 13.2</menuentry>
+        <name>openSUSE 13.2</name>
+        <root>/dev/vda2</root>
+        <type>image</type>
+        <usage>Linux</usage>
+      </section>
+      <section>
+        <append>showopts apm=off noresume nosmp maxcpus=0 edd=off powersaved=off nohz=off highres=off processor.max_cstate=1 nomodeset x11failsafe</append>
+        <image>(hd0,1)/boot/vmlinuz-2.6.37.1-1.2-default</image>
+        <initrd>(hd0,1)/boot/initrd-2.6.37.1-1.2-default</initrd>
+        <lines_cache_id>1</lines_cache_id>
+        <name>Failsafe -- openSUSE 11.4 - 2.6.37.1-1.2</name>
+        <original_name>failsafe</original_name>
+        <root>/dev/vda2</root>
+        <type>image</type>
+      </section>
+    </sections>
+  </bootloader>
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+  </general>
+  <scripts>
+    <init-scripts config:type="list">
+      <script>
+        <chrooted config:type="boolean">true</chrooted>
+        <interpreter>shell</interpreter>
+        <source><![CDATA[
+  chkconfig sshd on
+  rcsshd start
+]]></source>
+      </script>
+    </init-scripts>
+  </scripts>
+  <networking>
+    <dhcp_options>
+      <dhclient_client_id></dhclient_client_id>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
+      <domain>vagrantup.com</domain>
+      <hostname>vagrant-opensuse</hostname>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <searchlist config:type="list">
+        <search>vagrantup.com</search>
+      </searchlist>
+      <write_hostname config:type="boolean">true</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp</bootproto>
+        <device>eth0</device>
+        <name>82540EM Gigabit Ethernet Controller</name>
+        <startmode>nfsroot</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+    </interfaces>
+  </networking>
+  <partitioning config:type="list">
+    <drive>
+      <device>/dev/vda</device>
+      <initialize config:type="boolean">true</initialize>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  <software>
+    <install_recommended config:type="boolean">false</install_recommended>
+    <packages config:type="list">
+      <package>aaa_base</package>
+      <package>bash</package>
+      <package>coreutils</package>
+      <package>cracklib-dict-full</package>
+      <package>device-mapper</package>
+      <package>dhcpcd</package>
+      <package>e2fsprogs</package>
+      <package>elfutils</package>
+      <package>filesystem</package>
+      <package>gcc</package>
+      <package>glibc</package>
+      <package>grub2</package>
+      <package>ifplugd</package>
+      <package>initviocons</package>
+      <package>insserv</package>
+      <package>iputils</package>
+      <package>kbd</package>
+      <package>kernel-default</package>
+      <package>klogd</package>
+      <package>less</package>
+      <package>login</package>
+      <package>mkinitrd</package>
+      <package>module-init-tools</package>
+      <package>ncurses-utils</package>
+      <package>openssh</package>
+      <package>pam</package>
+      <package>pam-modules</package>
+      <package>procps</package>
+      <package>pwdutils</package>
+      <package>rpcbind</package>
+      <package>rpm</package>
+      <package>sudo</package>
+      <package>sysconfig</package>
+      <package>tar</package>
+      <package>timezone</package>
+      <package>vim</package>
+      <package>vim-base</package>
+      <package>w3m</package>
+      <package>zypper</package>
+      <package>rsync</package>
+      <package>ca-certificates-mozilla</package>
+      <package>glibc-locale</package>
+      <package>yast2-network</package>
+      <package>yast2-users</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>base</pattern>
+    </patterns>
+    <remove-packages config:type="list">
+      <package>libyui-gtk-pkg5</package>
+      <package>libyui-gtk5</package>
+      <package>Mesa</package>
+      <package>libcairo2</package>
+      <package>libgtk-3-0</package>
+      <package>gtk3-tools</package>
+      <package>libpango-1_0-0</package>
+      <package>libcairo-gobject2</package>
+      <package>pango-tools</package>
+      <package>wallpaper-branding-openSUSE-13.2</package>
+      <package>subversion</package>
+      <package>tcl</package>
+      <package>tk</package>
+      <package>libXft2</package>
+      <package>libtool</package>
+      <package>fontconfig</package>
+      <package>gitk</package>
+      <package>git-gui</package>
+    </remove-packages>
+  </software>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>vagrant</fullname>
+      <gid>100</gid>
+      <home>/home/vagrant</home>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>vagrant</user_password>
+      <username>vagrant</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>vagrant</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/spec/definitions/veewee/definitions/machinery_opensuse13.2_kvm/definition.rb
+++ b/spec/definitions/veewee/definitions/machinery_opensuse13.2_kvm/definition.rb
@@ -1,0 +1,42 @@
+Veewee::Definition.declare(
+  cpu_count: "2",
+  memory_size: "384",
+  disk_size: "20280",
+  disk_format: "VDI",
+  hostiocache: "off",
+  os_type_id: "OpenSUSE_64",
+  iso_file: "openSUSE-13.2-DVD-x86_64.iso",
+  iso_src: "http://download.opensuse.org/distribution/13.2/iso/openSUSE-13.2-DVD-x86_64.iso",
+  iso_md5: "350b8cb014a4e342cc9a7cc9df891b99",
+  iso_download_timeout: "1000",
+  boot_wait: "10",
+  boot_cmd_sequence: [
+    "<Esc><Enter>",
+    "linux",
+    " netdevice=eth0",
+    " netsetup=dhcp",
+    " instmode=dvd",
+    " textmode=1",
+    " autoyast=http://%IP%:8888/autoinst.xml",
+    "<Enter>"
+   ],
+  ssh_login_timeout: "10000",
+  ssh_user: "vagrant",
+  ssh_password: "vagrant",
+  ssh_key: "",
+  ssh_host_port: "7222",
+  ssh_guest_port: "22",
+  sudo_cmd: "echo '%p'|sudo -S sh \%f'",
+  shutdown_cmd: "shutdown -P now",
+  postinstall_files: [ "postinstall.sh", "postinstall_machinery.sh"],
+  postinstall_timeout: "10000",
+  hooks: {
+    # Before starting the build we spawn a webrick webserver which serves the
+    # autoyast profile to the installer. veewee"s built in webserver solution
+    # doesn"t work reliably with autoyast due to some timing issues.
+    before_create: Proc.new do
+      path = "#{Dir.pwd}/definitions/#{definition.box.name}"
+      Thread.new { WEBrick::HTTPServer.new(Port: 8888, DocumentRoot: path).start }
+    end
+  }
+)

--- a/spec/definitions/veewee/definitions/machinery_opensuse13.2_kvm/machinery_opensuse13.2_kvm.description
+++ b/spec/definitions/veewee/definitions/machinery_opensuse13.2_kvm/machinery_opensuse13.2_kvm.description
@@ -1,0 +1,10 @@
+Documentation for defined boxes
+
+machinery_opensuse13.2_kvm:
+
+  OS: openSUSE 13.2 (64bit)
+  Disk size: 20GB
+  Memory: 1024MB
+  Credentials:
+    User: root, password: vagrant
+    User: vagrant, password: vagrant

--- a/spec/definitions/veewee/definitions/machinery_opensuse13.2_kvm/postinstall.sh
+++ b/spec/definitions/veewee/definitions/machinery_opensuse13.2_kvm/postinstall.sh
@@ -1,0 +1,38 @@
+#
+# postinstall.sh
+# Taken from https://github.com/jedi4ever/veewee/blob/master/templates/openSUSE-12.3-x86_64-NET_EN/postinstall.sh
+#
+
+date > /etc/vagrant_box_build_time
+
+# remove zypper package locks
+rm -f /etc/zypp/locks
+
+# install required packages
+packages=( gcc-c++ less make bison libtool ruby-devel vim )
+zypper --non-interactive install --no-recommends --force-resolution ${packages[@]}
+
+# install vagrant key
+mkdir -pm 700 /home/vagrant/.ssh
+curl -Lo /home/vagrant/.ssh/authorized_keys 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub'
+chmod 0600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant: /home/vagrant/.ssh
+
+# set vagrant sudo
+printf "%b" "
+# added by veewee/postinstall.sh
+vagrant ALL=(ALL) NOPASSWD: ALL
+" >> /etc/sudoers
+
+# speed-up remote logins
+printf "%b" "
+# added by veewee/postinstall.sh
+UseDNS no
+" >> /etc/ssh/sshd_config
+
+# disable gem docs
+echo "gem: --no-ri --no-rdoc" >/etc/gemrc
+
+# install chef and puppet
+gem install chef
+gem install puppet

--- a/spec/definitions/veewee/definitions/machinery_opensuse13.2_kvm/postinstall_machinery.sh
+++ b/spec/definitions/veewee/definitions/machinery_opensuse13.2_kvm/postinstall_machinery.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Add 13.2 repositories as they can not be added via
+# autoyast due to some bug.
+zypper --gpg-auto-import-keys ar --refresh --name "Main Repository (OSS)" http://download.opensuse.org/distribution/13.2/repo/oss/ download.opensuse.org-oss
+zypper --gpg-auto-import-keys ar --refresh --name "Main Repository (NON-OSS)" http://download.opensuse.org/distribution/13.2/repo/non-oss/ download.opensuse.org-non-oss
+
+zypper --gpg-auto-import-keys ar --refresh --name "Main Update Repository" http://download.opensuse.org/update/13.2/ download.opensuse.org-update
+zypper --gpg-auto-import-keys ar --refresh --name "Update Repository (Non-Oss)" http://download.opensuse.org/update/13.2-non-oss/ download.opensuse.org-13.2-non-oss
+
+zypper --gpg-auto-import-keys ar --disable --refresh --name "openSUSE-13.2-Debug" http://download.opensuse.org/debug/distribution/13.2/repo/oss/ repo-debug
+zypper --gpg-auto-import-keys ar --disable --refresh --name "openSUSE-13.2-Update-Debug" http://download.opensuse.org/debug/update/13.2/ repo-debug-update
+zypper --gpg-auto-import-keys ar --disable --refresh --name "openSUSE-13.2-Update-Debug-Non-Oss" http://download.opensuse.org/debug/update/13.2-non-oss/ repo-debug-update-non-oss
+
+zypper --gpg-auto-import-keys ar --disable --refresh --name "openSUSE-13.2-Source" http://download.opensuse.org/source/distribution/13.2/repo/oss/ repo-source
+
+zypper --non-interactive up
+
+# Install git for checking out the machinery code and other machinery dependencies
+zypper --non-interactive install --no-recommends git libxslt1 libxslt-devel zlib-devel libxml2-devel libvirt-devel expect patch
+
+# Install kiwi and dependencies for building
+zypper --non-interactive install --no-recommends kiwi kiwi-desc-vmxboot kiwi-tools db45-utils db-utils grub
+
+# Make sure that everything's written to disk, otherwise we sometimes get
+# empty files in the image
+sync


### PR DESCRIPTION
- Add machinery_opensuse13.2_kvm veewee definition files
- Add machinery_opensuse13.2_kvm veewee definition files
- Add entry for opensuse132_kvm to Vagrantfile
- Add entry for machinery_opensuse13.2_kvm to Vagrantfile
