### PR TITLE
Use new Ruby packaging schema for 13.2

### DIFF
--- a/machinery.spec.erb
+++ b/machinery.spec.erb
@@ -31,7 +31,7 @@ BuildRequires:  ruby-macros >= 5
 BuildRequires:  libxml2-devel
 BuildRequires:  libxslt-devel
 BuildRequires:  fdupes
-%if %suse_version == 1315
+%if %suse_version > 1310
 %define rb_build_versions %{rb_default_ruby}
 BuildRequires:  %{rubydevel}
 BuildRequires:  %{rubygem gem2rpm}


### PR DESCRIPTION
This does prevent an rpmlint warning (SLES 12 version 1315 is unknown)
and also makes sure that the new Ruby packaging schema is used for
13.2.
