### PR TITLE
Add option to list descriptions without details

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -479,6 +479,8 @@ class Cli
   command :list do |c|
     c.switch :verbose, :required => false, :negatable => false,
       :desc => "Display additional information about origin of scopes"
+    c.switch :quick, :required => false, :negatable => false,
+      :desc => "Show quick list without details"
 
     c.action do |global_options,options,args|
       store = SystemDescriptionStore.new

--- a/spec/unit/list_task_spec.rb
+++ b/spec/unit/list_task_spec.rb
@@ -141,5 +141,11 @@ describe ListTask do
       store.save(system_description_with_incompatible_data_format)
       list_task.list(store)
     end
+
+    it "shows list without details" do
+      store.save(system_description)
+      expect(Machinery::Ui).to receive(:puts).with(" #{name}")
+      list_task.list(store, quick: true)
+    end
   end
 end


### PR DESCRIPTION
The `list` command gets the `--quick` option to list all system
descriptions without listing any details. This is much quicker.
It is useful when looking up names of descriptions without being
interested in any details.
