### PR TITLE
Show package-name and version for changed configuration files

### DIFF
--- a/plugins/show/config_files_renderer.rb
+++ b/plugins/show/config_files_renderer.rb
@@ -39,12 +39,14 @@ class ConfigFilesRenderer < Renderer
       files = @system_description["config_files"].files
       if files
         files.each do |p|
+          item_content = "#{p.name} (#{p.changes.join(", ")}, #{p.package_name}, " \
+            "v#{p.package_version})"
           if @options[:show_diffs] && p.changes.include?("md5")
-            item "#{p.name} (#{p.changes.join(", ")})" do
+            item item_content do
               render_diff_file(diffs_dir, p.name)
             end
           else
-            item ("#{p.name} (#{p.changes.join(", ")})")
+            item item_content
           end
         end
       end

--- a/spec/unit/config_files_renderer_spec.rb
+++ b/spec/unit/config_files_renderer_spec.rb
@@ -115,6 +115,13 @@ describe ConfigFilesRenderer do
           subject.render(system_description, show_diffs: true)
         }.to raise_error(Machinery::Errors::SystemDescriptionError)
       end
+
+      it "shows the package-name and version" do
+        output = subject.render(system_description)
+
+        expect(output).to include("/etc/default/grub (mode, grub2, v2.00)")
+        expect(output).to include("/etc/postfix/main.cf (md5, postfix, v2.9.6)")
+      end
     end
   end
 end


### PR DESCRIPTION
The show command prints the package-name and version for changed
configuration files. This is needed to fix #392.
