### PR TITLE
Fix openSUSE 13.2 integration tests

### DIFF
--- a/spec/data/unmanaged_files/opensuse132
+++ b/spec/data/unmanaged_files/opensuse132
@@ -497,11 +497,6 @@
     Mode: 644
     Size: 36 B
 
-  * /var/lib/zypp/AutoInstalled (file)
-    User/Group: root:root
-    Mode: 644
-    Size: 2.1 KiB
-
   * /var/lib/zypp/LastDistributionFlavor (file)
     User/Group: root:root
     Mode: 644


### PR DESCRIPTION
My test image had the file /var/lib/zypp/AutoInstalled which doesn't
exist in the newly created images anymore.
