### PR TITLE
Add proc mount to an uncommon directory to test filter

### DIFF
--- a/spec/definitions/vagrant/Vagrantfile
+++ b/spec/definitions/vagrant/Vagrantfile
@@ -47,6 +47,10 @@ def inject_test_data(base)
       /usr/sbin/rcautofs restart
     fi
     mount -t nfs 127.0.0.1:/tmp "/mnt/unmanaged/remote-dir/"
+
+    # mount proc to an uncommon directory for unmanaged-file inspector tests
+    mkdir -p "/mnt/uncommon-proc-mount"
+    mount -t proc proc /mnt/uncommon-proc-mount
   EOF
 
   base.vm.provision "shell", inline: prepare_test_environment_script


### PR DESCRIPTION
Make sure that our unmanaged-file inspector filter works fine and
that our inspector doesn't end up in a loop by adding an uncommon
proc mount.
