### PR TITLE
Make unmanaged-files integration tests more stable

### DIFF
--- a/spec/definitions/kiwi/definitions/base_opensuse13.1_kvm/config.sh
+++ b/spec/definitions/kiwi/definitions/base_opensuse13.1_kvm/config.sh
@@ -67,8 +67,9 @@ echo 'solver.onlyRequires = true' >> /etc/zypp/zypp.conf
 rm /var/log/YaST2/config_diff_*.log
 rm /etc/zypp/repos.d/dir-*.repo
 
-# create this file to prevent non-deterministic behavior on rebuilds
+# create these files to prevent non-deterministic behavior on rebuilds or single inspections
 touch /var/lib/zypp/AutoInstalled
+touch /var/lib/zypp/LastDistributionFlavor
 
 # avoid mac address configured into system, this results in getting
 # eth1 instead of eth0 in virtualized environments sometimes

--- a/spec/definitions/kiwi/definitions/base_opensuse13.2_kvm/config.sh
+++ b/spec/definitions/kiwi/definitions/base_opensuse13.2_kvm/config.sh
@@ -67,8 +67,9 @@ echo 'solver.onlyRequires = true' >> /etc/zypp/zypp.conf
 rm /var/log/YaST2/config_diff_*.log
 rm /etc/zypp/repos.d/dir-*.repo
 
-# create this file to prevent non-deterministic behavior on rebuilds
+# create these files to prevent non-deterministic behavior on rebuilds or single inspections
 touch /var/lib/zypp/AutoInstalled
+touch /var/lib/zypp/LastDistributionFlavor
 
 # avoid mac address configured into system, this results in getting
 # eth1 instead of eth0 in virtualized environments sometimes


### PR DESCRIPTION
Create the file /var/lib/zypp/LastDistributionFlavor during image
building because otherwise the unmanaged-file inspector tests could fail
if run alone because this file seems to be created by another zypper
command which is run before during the previous inspection tests.
