### PR TITLE
Implement backup helper for SystemDescriptionStore

### DIFF
--- a/lib/system_description_store.rb
+++ b/lib/system_description_store.rb
@@ -93,6 +93,20 @@ class SystemDescriptionStore
     FileUtils.cp_r(description_path(from), description_path(to))
   end
 
+  def backup(description_name)
+    SystemDescription.validate_name(description_name)
+    if !list.include?(description_name)
+      raise Machinery::Errors::SystemDescriptionNotFound.new(
+        "System description \"#{description_name}\" does not exist."
+      )
+    end
+
+    backup_name = get_backup_name(description_name)
+
+    FileUtils.cp_r(description_path(description_name), description_path(backup_name))
+    backup_name
+  end
+
   def initialize_file_store(description_name, store_name)
     dir = File.join(description_path(description_name), store_name)
     create_dir(dir, new_dir_mode(description_name))
@@ -147,5 +161,17 @@ class SystemDescriptionStore
     unless Dir.exists?(dir)
       FileUtils.mkdir_p(dir, :mode => mode)
     end
+  end
+
+  def get_backup_name(description_name)
+    backup_name = "#{description_name}.backup"
+    number = 1
+
+    while list.include?(backup_name)
+      backup_name = "#{description_name}.backup.#{number}"
+      number += 1
+    end
+
+    backup_name
   end
 end

--- a/spec/unit/system_description_store_spec.rb
+++ b/spec/unit/system_description_store_spec.rb
@@ -185,6 +185,34 @@ describe SystemDescriptionStore do
     end
   end
 
+  describe "#backup" do
+    let(:store) { SystemDescriptionStore.new(test_base_path) }
+
+    before(:each) do
+      create_machinery_dir
+    end
+
+    it "backups an existing SystemDescription" do
+      expect(store.list).to eq([test_name])
+      store.backup(test_name)
+      expect(store.list).to match_array([test_name, test_name + ".backup"])
+    end
+
+    it "it raises the backup number if a backup already exists" do
+      expect(store.list).to eq([test_name])
+      3.times do
+        store.backup(test_name)
+      end
+      expect(store.list).to match_array(
+        [test_name, test_name + ".backup", test_name + ".backup.1", test_name + ".backup.2"]
+      )
+    end
+
+    it "returns the backup name" do
+      expect(store.backup(test_name)).to eq(test_name + ".backup")
+    end
+  end
+
   describe "file store methods" do
     before(:each) do
       create_machinery_dir


### PR DESCRIPTION
This method creates a full backup from a given system description and
returns the new name. If a system description already has a backup then
the new backup gets a number at the end.
