### PR TITLE
[Review] Request from 'greygoo' @ 'SUSE/machinery/review_141219_fix_for_non_funtional_network_in_autoyast_installed_sle_systems_'

### DIFF
--- a/export_helpers/unmanaged_files_build_excludes
+++ b/export_helpers/unmanaged_files_build_excludes
@@ -4,3 +4,4 @@ etc/shadow*
 etc/group*
 etc/fstab
 lib/mkinitrd
+etc/udev/rules.d/70-persistent-net.rules


### PR DESCRIPTION
Please review the following changes:
- ba401bc Fix non working network interfaces on autoyast installed sle products.
- 8ae041d Merge pull request #479 from SUSE/support_non_host_analyze_archs
- a7da16b Implement analyse config file diff for non host architectures
- fc26d58 Implement zypper support for non host architectures
