### PR TITLE
Move unmanaged_files filter message to export_task

### DIFF
--- a/lib/build_task.rb
+++ b/lib/build_task.rb
@@ -28,16 +28,6 @@ class BuildTask
     config = KiwiConfig.new(system_description, options)
     config.write(tmp_config_dir)
 
-    if system_description["unmanaged_files"]
-      filters = File.read(
-        File.join(Machinery::ROOT, "export_helpers/unmanaged_files_build_excludes")
-      )
-      Machinery::Ui.puts "\nUnmanaged files following these patterns are not added " \
-        "to the built image:"
-      Machinery::Ui.puts filters
-      Machinery::Ui.puts "\n"
-    end
-
     FileUtils.mkdir_p(output_path)
     if tmp_image_dir.start_with?("/tmp/") && tmp_config_dir.start_with?("/tmp/")
       tmp_script = write_kiwi_wrapper(tmp_config_dir, tmp_image_dir,

--- a/lib/export_task.rb
+++ b/lib/export_task.rb
@@ -35,6 +35,15 @@ class ExportTask
 
     FileUtils.mkdir_p(output_dir, mode: 0700) if !Dir.exists?(output_dir)
 
+    if @exporter.system_description["unmanaged_files"]
+      filters = File.read(
+        File.join(Machinery::ROOT, "export_helpers/unmanaged_files_build_excludes")
+      )
+      Machinery::Ui.puts(
+        "\nUnmanaged files following these patterns are not exported:\n#{filters}\n"
+      )
+    end
+
     @exporter.write(output_dir)
     Machinery::Ui.puts "Exported to '#{output_dir}'."
   end

--- a/lib/exporter.rb
+++ b/lib/exporter.rb
@@ -17,6 +17,8 @@
 
 # Interface class for exporter
 class Exporter
+  attr_reader :system_description
+
   abstract_method :write
   abstract_method :export_name
 end

--- a/spec/unit/build_task_spec.rb
+++ b/spec/unit/build_task_spec.rb
@@ -143,18 +143,6 @@ describe BuildTask do
         build_task.build(system_description, output_path)
       }.to raise_error(Machinery::Errors::BuildFailed, /kiwi-terminal-output.log/)
     end
-
-    it "shows the unmanaged file filters at the beginning" do
-      system_description.initialize_file_store("unmanaged_files")
-      system_description["unmanaged_files"] = {}
-
-      expect(Machinery::Ui).to receive(:puts).with("\nUnmanaged files following these patterns are not added to the built image:")
-      expect(Machinery::Ui).to receive(:puts) { |s|
-        expect(s).to include("var/lib/rpm")
-      }
-      allow(Machinery::Ui).to receive(:puts)
-      build_task.build(system_description, output_path)
-    end
   end
 
   describe "#write_kiwi_wrapper" do


### PR DESCRIPTION
Instead of showing the unmanaged_files filter list during kiwi_build it
is no shown every time a description with unmanaged_files is exported to
Kiwi or Autoyast.
