### PR TITLE
Add hint about autoyast2 to AutoYaST export readme

### DIFF
--- a/export_helpers/autoyast_export_readme.md
+++ b/export_helpers/autoyast_export_readme.md
@@ -13,8 +13,14 @@ the installer via network, e.g. by running:
 
   cd /path/to/autoyast_export; python -m SimpleHTTPServer
 
-You can then point the installer to the profile by specifying the "autoyast"
-option on the kernel command line:
+You can then point the installer to the profile by specifying the AutoYaST
+option on the kernel command line.
+
+For SLES12 and openSUSE 13.2:
+
+  autoyast2=http://192.168.121.1:8000/autoinst.xml
+
+For SLES11:
 
   autoyast=http://192.168.121.1:8000/autoinst.xml netsetup=dhcp
 


### PR DESCRIPTION
The kernel parameter autoyast2 makes it easier for the user to activate
this function but is only supported by SLES12 and 13.2 so I have added
it additionally to the original command line.
