### PR TITLE
Cache Os info in LocalSystem

### DIFF
--- a/lib/local_system.rb
+++ b/lib/local_system.rb
@@ -16,13 +16,18 @@
 # you may find current contact information at www.suse.com
 
 class LocalSystem < System
+  @@os = nil
+
   class << self
     def os
-      description = SystemDescription.new("localhost",
-        SystemDescriptionMemoryStore.new)
-      inspector = OsInspector.new
-      inspector.inspect(System.for("localhost"), description)
-      description.os
+      if !@@os
+        description = SystemDescription.new("localhost",
+          SystemDescriptionMemoryStore.new)
+        inspector = OsInspector.new
+        inspector.inspect(System.for("localhost"), description)
+        @@os = description.os
+      end
+      @@os
     end
 
     def validate_existence_of_package(package)


### PR DESCRIPTION
The method os of LocalSystem is access several times during build
prepration for example which would always result in a localhost os
inspection. To prevent this the result of the os inspection is cached so
it is only called once.