### PR TITLE
Expected inspection errors should be indented

### DIFF
--- a/lib/inspect_task.rb
+++ b/lib/inspect_task.rb
@@ -30,7 +30,7 @@ class InspectTask
       Machinery::Ui.puts "\n"
       message = failed_inspections.map { |scope, msg|
         "Errors while inspecting " \
-          "#{Machinery::Ui.internal_scope_list_to_string(scope)}:\n#{msg}" }.join("\n\n")
+          "#{Machinery::Ui.internal_scope_list_to_string(scope)}:\n -> #{msg}" }.join("\n\n")
       raise Machinery::Errors::InspectionFailed.new(message)
     end
     description
@@ -77,8 +77,7 @@ class InspectTask
       begin
         summary = inspector.inspect(system, description, options)
       rescue Machinery::Errors::MachineryError => e
-        Machinery::Ui.puts "Inspection of scope " \
-          "#{Machinery::Ui.internal_scope_list_to_string(inspector.scope)} failed!"
+        Machinery::Ui.puts " -> Inspection failed!"
         failed_inspections[inspector.scope] = e
         next
       end

--- a/spec/support/machinery_output.rb
+++ b/spec/support/machinery_output.rb
@@ -15,7 +15,7 @@
 # To contact SUSE about this file by physical or electronic mail,
 # you may find current contact information at www.suse.com
 
-module MachineryOutputSilencer
+module MachineryOutput
   def self.included(klass)
     klass.extend(self)
   end

--- a/spec/support/machinery_output.rb
+++ b/spec/support/machinery_output.rb
@@ -27,4 +27,54 @@ module MachineryOutput
       end
     end
   end
+
+  def capture_machinery_output
+    before(:each) do
+      stub_const(
+        "Machinery::Ui", Class.new(Machinery::Ui) do
+          def self.puts(s)
+            @output ||= ""
+            @stdout ||= ""
+            @output += "\n" + s
+            @stdout += "\n" + s
+          end
+
+          def self.warn(s)
+            @output ||= ""
+            @stderr ||= ""
+            @output += "\n" + s
+            @stderr += "\n" + s
+          end
+
+          def self.error(s)
+            warn(s)
+          end
+
+          def self.output
+            @output
+          end
+
+          def self.stdout
+            @stdout
+          end
+
+          def self.stderr
+            @stderr
+          end
+        end
+      )
+    end
+  end
+
+  def captured_machinery_output
+    Machinery::Ui.output || ""
+  end
+
+  def captured_machinery_stdout
+    Machinery::Ui.stdout || ""
+  end
+
+  def captured_machinery_stderr
+    Machinery::Ui.stderr || ""
+  end
 end

--- a/spec/unit/inspect_task_spec.rb
+++ b/spec/unit/inspect_task_spec.rb
@@ -97,13 +97,25 @@ describe InspectTask, "#inspect_system" do
   end
 
   describe "in case of inspection errors" do
+    capture_machinery_output
+
     it "raises Machinery::Errors::ScopeFailed on 'expected errors'" do
       expect_any_instance_of(FooInspector).to receive(:inspect).
-        and_raise(Machinery::Errors::SshConnectionFailed)
+        and_raise(Machinery::Errors::SshConnectionFailed, "This is an SSH error")
 
       expect {
         inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"])
-      }.to raise_error(Machinery::Errors::InspectionFailed)
+      }.to raise_error(
+        Machinery::Errors::InspectionFailed,
+        /Errors while inspecting foo:\n -> This is an SSH error/
+      )
+      expect(captured_machinery_output).to include(
+        <<-EOF
+
+Inspecting foo...
+ -> Inspection failed!
+        EOF
+      )
     end
 
     it "bubbles up 'unexpected errors'" do

--- a/spec/unit/spec_helper.rb
+++ b/spec/unit/spec_helper.rb
@@ -21,7 +21,7 @@ require "given_filesystem/spec_helpers"
 require File.expand_path('../../../lib/machinery', __FILE__)
 
 require_relative "../support/system_description_factory"
-require_relative "../support/machinery_output_silencer"
+require_relative "../support/machinery_output"
 Dir[File.join(Machinery::ROOT, "/spec/unit/support/*.rb")].each { |f| require f }
 
 bin_path = File.expand_path( "../../../bin/", __FILE__ )
@@ -35,7 +35,7 @@ Machinery.initialize_logger("/tmp/machinery_test.log")
 
 RSpec.configure do |config|
   config.include(SystemDescriptionFactory)
-  config.include(MachineryOutputSilencer)
+  config.include(MachineryOutput)
 
   config.before(:each) do
     allow_any_instance_of(System).to receive(:check_requirement)


### PR DESCRIPTION
To make it easier for the user to match the error message it is indented
in a similar way as the success messages.

Fixes #496

Is:
```
Inspecting packages...
 -> Found 988 packages.
Inspecting patterns...
Inspection of scope patterns failed!
Inspecting config-files...
 -> Found 17 changed configuration files.

Errors while inspecting patterns:
Zypper is locked.
```

Should
```
Inspecting packages...
 -> Found 988 packages.
Inspecting patterns...
 -> Inspection failed!
Inspecting config-files...
 -> Found 17 changed configuration files.

Errors while inspecting patterns:
 -> Zypper is locked.
```