### PR TITLE
Prevent missing_scope comparison messages if both descriptions lack them

### DIFF
--- a/lib/renderer.rb
+++ b/lib/renderer.rb
@@ -148,16 +148,17 @@ class Renderer
     @stack = []
     missing_descriptions = Array.new
 
-    @buffer += "# #{display_name}\n"
-
-   if !description1[scope]
+    if !description1[scope]
       missing_descriptions << description1.name
     end
     if !description2[scope]
       missing_descriptions << description2.name
     end
 
-    indent { puts "Unable to compare, no data in '#{missing_descriptions.join("', '")}'" }
+    if missing_descriptions.count == 1
+      @buffer += "# #{display_name}\n"
+      indent { puts "Unable to compare, no data in '#{missing_descriptions.join("', '")}'" }
+    end
     @buffer += "\n" unless @buffer.empty? || @buffer.end_with?("\n\n")
 
     @buffer

--- a/spec/unit/compare_task_spec.rb
+++ b/spec/unit/compare_task_spec.rb
@@ -177,9 +177,6 @@ Common to both systems:
 # Bar
   Unable to compare, no data in 'name4'
 
-# Baz
-  Unable to compare, no data in 'name3', 'name4'
-
 # Foobar
 
 Only in 'name3':
@@ -194,12 +191,6 @@ Only in 'name4':
     let(:output_missing_same) {
       <<-EOT
 Compared descriptions are identical.
-# Foo
-  Unable to compare, no data in 'name3', 'name3'
-
-# Baz
-  Unable to compare, no data in 'name3', 'name3'
-
       EOT
     }
 


### PR DESCRIPTION
In doesn't make much sense in case of a comparison to inform about
missing scopes if both don't have them.
It also looks weird to inform about missing_scopes in case of an
identical comparison.
With this commit the missing scope message is only shown if it is
missing from only on scope.

Fixes #498