### PR TITLE
[Review] Request from 'tgoettlicher' @ 'SUSE/machinery/review_150112_fix_error_message_when_architecture_is_not_supported_issue_515_'

### DIFF
--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -110,5 +110,6 @@ module Machinery
     class OpenInBrowserFailed < MachineryError; end
     class ZypperFailed < MachineryError; end
     class UnknownConfig < MachineryError; end
+    class UnsupportedArchitecture < MachineryError; end
   end
 end

--- a/lib/local_system.rb
+++ b/lib/local_system.rb
@@ -69,7 +69,7 @@ class LocalSystem < System
 
     def validate_architecture(arch)
       if os.architecture != arch
-        raise(Machinery::Errors::IncompatibleHost.new(
+        raise(Machinery::Errors::UnsupportedArchitecture.new(
           "This operation is not supported on architecture '#{os.architecture}'."
         ))
       end

--- a/spec/unit/build_task_spec.rb
+++ b/spec/unit/build_task_spec.rb
@@ -148,7 +148,7 @@ describe BuildTask do
 
       expect {
         build_task.build(system_description, output_path)
-      }.to raise_error(Machinery::Errors::IncompatibleHost,
+      }.to raise_error(Machinery::Errors::UnsupportedArchitecture,
         /operation is not supported on architecture 'i586'/)
     end
 

--- a/spec/unit/deploy_task_spec.rb
+++ b/spec/unit/deploy_task_spec.rb
@@ -114,7 +114,7 @@ describe DeployTask do
       allow_any_instance_of(Os).to receive(:architecture).and_return("i586")
       expect {
         deploy_task.deploy(system_description, cloud_config_file, image_dir: image_dir)
-      }.to raise_error(Machinery::Errors::IncompatibleHost,
+      }.to raise_error(Machinery::Errors::UnsupportedArchitecture,
         /operation is not supported on architecture 'i586'/)
     end
 


### PR DESCRIPTION
Please review the following changes:
  * b7b41f2 Fix error message when architecture is not supported (issue #515)
  * db2dd38 Merge pull request #514 from SUSE/review_150112_extract_provisioning_code
  * 9cc8272 Extract subject image provisioning code into an external script