### PR TITLE
Fix `machinery remove` return code

### DIFF
--- a/lib/remove_task.rb
+++ b/lib/remove_task.rb
@@ -28,15 +28,21 @@ class RemoveTask
       end
     end
 
+    errors = []
+
     Array(names).each do |name|
       if !store.list.include?(name)
-        Machinery::Ui.warn("System description \"#{name}\" does not exist.")
+        errors.push("System description \"#{name}\" does not exist.")
       else
         store.remove(name)
         if options[:verbose]
           Machinery::Ui.puts "System description \"#{name}\" successfully removed."
         end
       end
+    end
+
+    if !errors.empty?
+      raise Machinery::Errors::SystemDescriptionNotFound.new(errors.join("\n"))
     end
   end
 end

--- a/spec/unit/remove_task_spec.rb
+++ b/spec/unit/remove_task_spec.rb
@@ -47,12 +47,19 @@ describe RemoveTask do
       remove_task.remove(store, test_name, { :verbose => true })
     end
 
-    it "show a warning when SystemDescription does not exist" do
-      expect(Machinery::Ui).to receive(:warn).with(
-        "System description \"foo_bar_does_not_exist\" does not exist."
-      )
+    it "throws an error when SystemDescription does not exist" do
+      expect {
+        remove_task.remove(store, "foo_bar_does_not_exist")
+      }.to raise_error(Machinery::Errors::SystemDescriptionNotFound)
+    end
 
-      remove_task.remove(store, "foo_bar_does_not_exist")
+    it "throws an error when SystemDescription does not exist but deletes all given" do
+      create_machinery_dir("description1")
+      expect(store.list).to match_array(["description1"])
+      expect {
+        remove_task.remove(store, ["foo_bar_does_not_exist", "description1"])
+      }.to raise_error(Machinery::Errors::SystemDescriptionNotFound)
+      expect(store.list).to be_empty
     end
 
     it "removes all given SystemDescription directorys" do


### PR DESCRIPTION
Machinery should exit with return code != 0 when a description does
not exists.

Fixes #553