### PR TITLE
Use opt instead of tmp for integration test remote-dirs

### DIFF
--- a/spec/definitions/provision.sh
+++ b/spec/definitions/provision.sh
@@ -23,10 +23,10 @@ echo "+:::" >> /etc/group
 # enable NFS and autofs server for remote file system filtering tests
 mkdir -p "/remote-dir/"
 mkdir -p "/mnt/unmanaged/remote-dir/"
-echo "/tmp     127.0.0.0/8(sync,no_subtree_check)" >> /etc/exports
+echo "/opt     127.0.0.0/8(sync,no_subtree_check)" >> /etc/exports
 /usr/sbin/exportfs -a
 echo "/remote-dir   /etc/auto.remote_dir" >> /etc/auto.master
-echo "server -fstype=nfs 127.0.0.1:/tmp" >> /etc/auto.remote_dir
+echo "server -fstype=nfs 127.0.0.1:/opt" >> /etc/auto.remote_dir
 if [ -x /bin/systemd ]; then
   systemctl enable rpcbind.service
   systemctl enable nfsserver.service
@@ -49,7 +49,7 @@ else
     /etc/init.d/autofs restart
   fi
 fi
-mount -t nfs 127.0.0.1:/tmp "/mnt/unmanaged/remote-dir/"
+mount -t nfs 127.0.0.1:/opt "/mnt/unmanaged/remote-dir/"
 
 # mount proc to an uncommon directory for unmanaged-file inspector tests
 mkdir -p "/mnt/uncommon-proc-mount"


### PR DESCRIPTION
Using /tmp as remote-dir prevented snapper under some circumstances
from rolling back the snapshot because the files couldn't be accessed.

Switching to opt prevented this issue.