### PR TITLE
Filter zypper repos from unmanaged-file export

### DIFF
--- a/export_helpers/unmanaged_files_autoyast_excludes
+++ b/export_helpers/unmanaged_files_autoyast_excludes
@@ -7,3 +7,4 @@ lib/mkinitrd
 etc/udev/rules.d/70-persistent-net.rules
 var/log/*
 etc/default/grub*
+etc/zypp/repos.d/*

--- a/export_helpers/unmanaged_files_kiwi_excludes
+++ b/export_helpers/unmanaged_files_kiwi_excludes
@@ -5,3 +5,4 @@ etc/group*
 etc/fstab
 lib/mkinitrd
 etc/udev/rules.d/70-persistent-net.rules
+etc/zypp/repos.d/*


### PR DESCRIPTION
To prevent duplication of zypper repositories the files from
/etc/zypp/repos.d are filtered.