### PR TITLE
Format scopes in hint cmd properly

### DIFF
--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -64,7 +64,7 @@ module Machinery
         end.compact.first || "<HOSTNAME>"
         formatted_scopes = Machinery::Ui.internal_scope_list_to_string(@scopes)
 
-        cmd = "#{$0} inspect --extract-files --scope=#{formatted_scopes}"
+        cmd = "#{$0} inspect --extract-files --scope=#{formatted_scopes.delete(" ")}"
         cmd += " --name='#{@description.name}'" if hostname != @description.name
         cmd += " #{hostname}"
 

--- a/spec/unit/exceptions_spec.rb
+++ b/spec/unit/exceptions_spec.rb
@@ -30,7 +30,7 @@ describe Machinery::Errors::MissingExtractedFiles do
         "system description" \
         " but the corresponding files weren't extracted during inspection.\n" \
         "The files are required to continue with this command. " \
-        "Run `#{$0} inspect --extract-files --scope=config-files, changed-managed-files " \
+        "Run `#{$0} inspect --extract-files --scope=config-files,changed-managed-files " \
         "--name='#{name}' example.com` to extract them."
       )
   end


### PR DESCRIPTION
Remove the spaces between scopes to allow the execution without manual
interaction.

Fixes #541