### PR TITLE
Fix KIWI export integration test

### DIFF
--- a/spec/data/export-kiwi/root
+++ b/spec/data/export-kiwi/root
@@ -12,7 +12,7 @@ total 4
 total 16
 -rw-r--r-- 1 vagrant vagrant 8163  merge_users_and_groups.pl
 drwxr-xr-x 3 vagrant vagrant 4096  unmanaged_files
--rw-r--r-- 1 vagrant vagrant  113  unmanaged_files_kiwi_excludes
+-rw-r--r-- 1 vagrant vagrant  132  unmanaged_files_kiwi_excludes
 
 /tmp/jeos-kiwi/root/tmp/unmanaged_files:
 total 8


### PR DESCRIPTION
The ls listing of the KIWI export wasn't adapted after adding the new
filter for /etc/zypp/repos.d.