### PR TITLE
Allow using inspection hosts without ssh key installation

### DIFF
--- a/spec/integration/integration_spec_helper.rb
+++ b/spec/integration/integration_spec_helper.rb
@@ -22,11 +22,14 @@ require_relative "../support/system_description_factory"
 
 def prepare_machinery_for_host(system, ip, opts = {})
   opts = {
-    password: "linux",
     user:     "vagrant"
   }.merge(opts)
 
-  SshKeysImporter.import(ip, opts[:password], File.join(Machinery::ROOT, "spec/keys/machinery_rsa.pub"))
+  if opts[:password]
+    SshKeysImporter.import(
+      ip, opts[:password], File.join(Machinery::ROOT, "spec/keys/machinery_rsa.pub")
+    )
+  end
 
   system.inject_file(
     File.join(Machinery::ROOT, "spec/keys/machinery_rsa"),


### PR DESCRIPTION
Our plan was to setup external test machines manually and allow them to
have a different password so there is no need to copy over they keys by
the machinery integration tests.