### PR TITLE
Make SKIP_CLEANUP explicit

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -114,7 +114,7 @@ namespace :rpm do
     # base even when the unit tests are failing.
     Rake::Task["package"].prerequisites.delete("test")
 
-    skip_cleanup = (ENV["SKIP_CLEANUP"] == "true")
+    skip_cleanup = (ENV["SKIP_RPM_CLEANUP"] == "true")
     release = Release.new(skip_cleanup: skip_cleanup)
     release.build_local
   end

--- a/spec/definitions/vagrant/machinery_rpm_provisioner.rb
+++ b/spec/definitions/vagrant/machinery_rpm_provisioner.rb
@@ -74,8 +74,8 @@ module MachineryRpm
       cmds << "cd #{MACHINERY_ROOT}"
       cmds << "export HOME=$(echo ~/)"
       cmds << "export LC_ALL=en_US.utf8"
-      # Forward SKIP_CLEANUP environment variable to the new, clean environment
-      cmds << "export SKIP_CLEANUP=true" if ENV["SKIP_CLEANUP"] == "true"
+      # Forward SKIP_RPM_CLEANUP environment variable to the new, clean environment
+      cmds << "export SKIP_RPM_CLEANUP=true" if ENV["SKIP_RPM_CLEANUP"] == "true"
       cmds << "rake rpm:build#{obs_cmd}"
 
       cmd = cmds.join(" && ") + " 2>&1"


### PR DESCRIPTION
The name of SKIP_CLEANUP environment variable conflicted with one in
Pennyworth. So I made the name explicit.