### PR TITLE
Define the default vagarant shar explicitly in Vagrantfile.

### DIFF
--- a/spec/definitions/vagrant/Vagrantfile
+++ b/spec/definitions/vagrant/Vagrantfile
@@ -97,6 +97,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
   # config.vm.synced_folder "../data", "/vagrant_data"
+  config.vm.synced_folder '.', "/vagrant", type: "rsync"
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.


### PR DESCRIPTION
- We encountered issues with vagrant trying to install nfs packages using
  yum, which failed
- This seem to happen sometimes as we do not have the default vagrant share
  defined in the Vagrantfile
- By adding it explicitly and defining it to use rsync instead of nfs this
  issue should not occur again
