### PR TITLE
Fix v1.3.0 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,8 @@
 # Machinery Release Notes
 
+
+## Version 1.3.0 - Mon Jan 26 16:00:08 CET 2015 - chuller@novell.com
+
 * Added support for inspecting System z systems
 * Added support for inspecting POWER LE systems
 * Added support to run Machinery on System z

--- a/RPM_CHANGES
+++ b/RPM_CHANGES
@@ -1,6 +1,9 @@
 # Machinery RPM Changelog
 
 
+## Version 1.3.0 - Mon Jan 26 16:00:08 CET 2015 - chuller@novell.com
+
+* update to version 1.3.0
 * tracking bug (#bnc914712)
 
 ## Version 1.2.0 - Mon Dec 22 15:06:20 CET 2014 - aduffeck@suse.de

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -17,6 +17,6 @@
 
 module Machinery
 
-  VERSION = "1.2.0"
+  VERSION = "1.3.0"
 
 end


### PR DESCRIPTION
There were issues during the 1.3.0 release which prevented the changelog
and version changes from being integrated. The version tag was refering
to an abandoned commit so we recreated the tag to an existing commit
directly before the release and finalized the changelog with this one.