### PR TITLE
Use a regex to check the unit test output

### DIFF
--- a/spec/unit/manifest_spec.rb
+++ b/spec/unit/manifest_spec.rb
@@ -98,8 +98,7 @@ EOF
       )
       expect(Machinery::Ui).to receive(:warn).with(
         [
-          "The property '#/meta/os' of type String did not match the following " \
-          "type: object in schema b5a414ed-d79e-5362-92f8-a0640edcc3fd#"
+          /The property '#\/meta\/os' of type String did not match the following type:/
         ]
       )
 


### PR DESCRIPTION
The name of the fake schema can change on other systems so we must use a
regex.