### PR TITLE
Limit rspec version to 3.1.*

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ source "https://rubygems.org"
 gemspec
 
 group :test do
-  gem "rspec", ">= 3.1.0"
+  gem "rspec", "~> 3.1.0"
   gem "fakefs"
   gem "given_filesystem", ">= 0.1.1"
 end


### PR DESCRIPTION
Rspec 3.2.0 has changed the hook handling witch breaks the
pennyworth tests.

spec/spec_spec.rb line 40, 59, 78