### PR TITLE
Fix migration output when force is enabled

### DIFF
--- a/lib/migration.rb
+++ b/lib/migration.rb
@@ -67,15 +67,12 @@ class Migration
       load_migrations
 
       if options[:force]
-        description = SystemDescription.load(
-          description_name, store, skip_format_compatibility: true
-        )
+        hash = Manifest.load(description_name, store.manifest_path(description_name)).to_hash
       else
-        description = SystemDescription.load!(
+        hash = SystemDescription.load!(
           description_name, store, skip_format_compatibility: true
-        )
+        ).to_hash
       end
-      hash = description.to_hash
 
       current_version = hash["meta"]["format_version"]
       if !current_version


### PR DESCRIPTION
Load the description with Manifest.load to prevent error output
on system description loading with enabled force option.