### PR TITLE
Fix repository extraction on Fedora

### DIFF
--- a/helpers/yum_repositories.py
+++ b/helpers/yum_repositories.py
@@ -28,7 +28,7 @@ for repo in yb.repos.sort():
   repo_dict["alias"] = repo.id
   repo_dict["name"] = repo.name
   repo_dict["type"] = "rpm-md"
-  repo_dict["url"] = repo.baseurl[0] or repo.getAttribute("metalink")
+  repo_dict["url"] = repo.getAttribute("metalink") or repo.baseurl[0]
   repo_dict["enabled"] = repo.enabled
   repo_dict["gpgcheck"] = repo.gpgcheck
   repo_dict["package_manager"] = "yum"


### PR DESCRIPTION
Extraction of repositories on Fedora failed because baseurl isn't
available and accessing an element in an non existing array will fail.

By switching the attributes it works for both types, baseurl and
metalink.