### PR TITLE
Handle missing Yum baseurls gracefully

### DIFF
--- a/helpers/yum_repositories.py
+++ b/helpers/yum_repositories.py
@@ -28,7 +28,7 @@ for repo in yb.repos.sort():
   repo_dict["alias"] = repo.id
   repo_dict["name"] = repo.name
   repo_dict["type"] = "rpm-md"
-  repo_dict["url"] = repo.getAttribute("metalink") or repo.baseurl[0]
+  repo_dict["url"] = repo.baseurl[0] if repo.baseurl else ""
   repo_dict["enabled"] = repo.enabled
   repo_dict["gpgcheck"] = repo.gpgcheck
   repo_dict["package_manager"] = "yum"

--- a/plugins/inspect/repositories_inspector.rb
+++ b/plugins/inspect/repositories_inspector.rb
@@ -69,6 +69,13 @@ class RepositoriesInspector < Inspector
       repositories = JSON.parse(system.run_command(
         "bash", "-c", "python", stdin: script, stdout: :capture
       ).split("\n").last).map { |element| Repository.new(element) }
+      repositories.each do |repository|
+        if repository.url.empty?
+          raise Machinery::Errors::InspectionFailed.new(
+            "Yum repository baseurl is missing. Metalinks are not supported at the moment."
+          )
+        end
+      end
     rescue JSON::ParserError
       raise Machinery::Errors::InspectionFailed.new("Extraction of YUM repositories failed.")
     end

--- a/spec/unit/repositories_inspector_spec.rb
+++ b/spec/unit/repositories_inspector_spec.rb
@@ -272,6 +272,11 @@ output
 EOF
     }
 
+    let(:unsupported_metalink_repo) {<<-EOF
+[{"package_manager": "yum", "name": "Fedora 21 - x86_64", "url": "", "enabled": true, "alias": "fedora", "gpgcheck": true, "type": "rpm-md"}]
+EOF
+    }
+
     let(:expected_yum_repo_list) {
       RepositoriesScope.new([
         Repository.new(
@@ -315,6 +320,16 @@ EOF
       inspector = RepositoriesInspector.new
       expect { inspector.inspect(system, description) }.to raise_error(
         Machinery::Errors::InspectionFailed, /Extraction of YUM repositories failed./
+      )
+    end
+
+    # We don't support Yum Metalink repositories atm
+    it "throws an Machinery AnalysisFailed error when the url is empty" do
+      expect(system).to receive(:run_command).and_return(unsupported_metalink_repo)
+
+      inspector = RepositoriesInspector.new
+      expect { inspector.inspect(system, description) }.to raise_error(
+        Machinery::Errors::InspectionFailed, /Yum repository baseurl is missing/
       )
     end
   end


### PR DESCRIPTION
Since Metalinks are not just a replacement for baseurls but a different
format they result in an error but are handled gracefully.