### PR TITLE
[Review] Request from 'tgoettlicher' @ 'SUSE/machinery/review_150216_fix_tar_command_s_options'

### DIFF
--- a/lib/system.rb
+++ b/lib/system.rb
@@ -55,7 +55,7 @@ class System
     out = File.open(archive, "w")
     begin
       run_command(
-        "tar", "--directory=/", "--create", "--gzip", "--null", "--files-from=-",
+        "tar", "--create", "--gzip", "--null", "--files-from=-",
         *exclude.flat_map { |f| ["--exclude", f]},
         :stdout => out,
         :stdin => filelist


### PR DESCRIPTION
Please review the following changes:
  * b23b545 Fix tar command's options
  * 005e5c6 Merge pull request #597 from SUSE/optimize_loading2
  * 2a44132 Use trailing if for validation skipping in system_description
  * 66f4dbd Update NEWS for list optimizations
  * 8c832e4 Remove obsolete `list --quick` option
  * b083cd6 Improve listing system descriptions
  * 19f113f Add SystemDescription.load 'skip_validation' option
  * b94bcdb Merge pull request #592 from SUSE/review_150213_add_html_improvements_to_changelog
  * 38d622f Add html improvements to changelog