### PR TITLE
Clean up patterns inspector

### DIFF
--- a/plugins/inspect/patterns_inspector.rb
+++ b/plugins/inspect/patterns_inspector.rb
@@ -19,12 +19,9 @@ class PatternsInspector < Inspector
   def inspect(system, description, options = {})
     if system.has_command?("zypper")
       inspect_with_zypper(system, description)
-    elsif system.has_command?("yum")
-      inspect_with_yum(description)
     else
-      raise Machinery::Errors::MissingRequirement.new(
-        "Need binary zypper or yum to be available on the inspected system."
-      )
+      description.patterns = PatternsScope.new
+      "Patterns are not supported on this system."
     end
   end
 
@@ -61,10 +58,5 @@ class PatternsInspector < Inspector
 
     description.patterns = PatternsScope.new(patterns)
     "Found #{patterns.count} patterns."
-  end
-
-  def inspect_with_yum(description)
-    description.patterns = PatternsScope.new
-    "Patterns are not supported on this system."
   end
 end

--- a/spec/unit/patterns_inspector_spec.rb
+++ b/spec/unit/patterns_inspector_spec.rb
@@ -56,7 +56,6 @@ describe PatternsInspector do
   describe "#inspect" do
     before(:each) do
       allow(system).to receive(:has_command?).with("zypper").and_return(true)
-      allow(system).to receive(:has_command?).with("yum").and_return(false)
     end
 
     it "parses the patterns list into a Hash" do
@@ -103,22 +102,12 @@ describe PatternsInspector do
         Machinery::Errors::ZypperFailed, /Zypper is locked./)
     end
 
-    it "returns an empty array when yum is installed" do
+    it "returns an empty array when no zypper is installed and shows an unsupported message" do
       allow(system).to receive(:has_command?).with("zypper").and_return(false)
-      allow(system).to receive(:has_command?).with("yum").and_return(true)
 
-      patterns_inspector.inspect(system, description)
+      summary = patterns_inspector.inspect(system, description)
+      expect(summary).to eq("Patterns are not supported on this system.")
       expect(description.patterns).to eql(PatternsScope.new)
-    end
-
-    it "raises an error if neither zypper nor yum is installed" do
-      allow(system).to receive(:has_command?).with("zypper").and_return(false)
-      allow(system).to receive(:has_command?).with("yum").and_return(false)
-
-      expect {  patterns_inspector.inspect(system, description) }.to raise_error(
-        Machinery::Errors::MissingRequirement,
-        /Need binary zypper or yum to be available on the inspected system/
-      )
     end
   end
 end


### PR DESCRIPTION
Since yum doesn't support patterns and zypper is the only supported
program for inspecting patterns we only extract data for zypper and just
show an unsupported message on all other systems.