### PR TITLE
[Review] Request from 'aduffeck' @ 'SUSE/machinery/local_integration_tests'

### DIFF
--- a/bin/machinery
+++ b/bin/machinery
@@ -22,7 +22,9 @@ require_relative '../lib/machinery'
 begin
   LocalSystem.validate_machinery_compatibility
   Machinery.initialize_logger(ENV["MACHINERY_LOG_FILE"] || Machinery::DEFAULT_LOG_FILE)
-  Machinery.logger.info "Executing (Version #{Machinery::VERSION}) '#{$0} #{ARGV.join(" ")}'"
+  command_log = "Executing (Version #{Machinery::VERSION}) '#{$0} #{ARGV.join(" ")}'"
+  command_log += " (store: #{ENV["MACHINERY_DIR"]})" if ENV["MACHINERY_DIR"]
+  Machinery.logger.info command_log
   Cli.run(ARGV)
 rescue Machinery::Errors::IncompatibleHost => e
   puts e

--- a/lib/machinery.rb
+++ b/lib/machinery.rb
@@ -33,6 +33,7 @@ require "kramdown"
 require "find"
 require "pathname"
 require "nokogiri"
+require "etc"
 
 require_relative "machinery_logger"
 require_relative "zypper"

--- a/lib/machinery.rb
+++ b/lib/machinery.rb
@@ -33,7 +33,6 @@ require "kramdown"
 require "find"
 require "pathname"
 require "nokogiri"
-require "etc"
 
 require_relative "machinery_logger"
 require_relative "zypper"

--- a/spec/data/export-kiwi/root
+++ b/spec/data/export-kiwi/root
@@ -1,44 +1,34 @@
 /tmp/jeos-kiwi/root:
-total 12
-drwxr-xr-x 2 vagrant vagrant 4096  etc
-drwxrwxrwt 3 vagrant vagrant 4096  tmp
-drwxr-xr-x 3 vagrant vagrant 4096  usr
+etc
+tmp
+usr
 
 /tmp/jeos-kiwi/root/etc:
-total 4
--rw-r--r-- 1 vagrant vagrant 312  crontab
+crontab
 
 /tmp/jeos-kiwi/root/tmp:
-total 16
--rw-r--r-- 1 vagrant vagrant 8163  merge_users_and_groups.pl
-drwxr-xr-x 3 vagrant vagrant 4096  unmanaged_files
--rw-r--r-- 1 vagrant vagrant  132  unmanaged_files_kiwi_excludes
+merge_users_and_groups.pl
+unmanaged_files
+unmanaged_files_kiwi_excludes
 
 /tmp/jeos-kiwi/root/tmp/unmanaged_files:
-total 8
--rw-r--r-- 1 vagrant vagrant  220  files.tgz
-drwxr-xr-x 3 vagrant vagrant 4096  trees
+files.tgz
+trees
 
 /tmp/jeos-kiwi/root/tmp/unmanaged_files/trees:
-total 4
-drwxr-xr-x 2 vagrant vagrant 4096  etc
+etc
 
 /tmp/jeos-kiwi/root/tmp/unmanaged_files/trees/etc:
-total 4
--rw-r--r-- 1 vagrant vagrant 339  unmanaged-tree.tgz
+unmanaged-tree.tgz
 
 /tmp/jeos-kiwi/root/usr:
-total 4
-drwxr-xr-x 3 vagrant vagrant 4096  share
+share
 
 /tmp/jeos-kiwi/root/usr/share:
-total 4
-drwxr-xr-x 3 vagrant vagrant 4096  bash
+bash
 
 /tmp/jeos-kiwi/root/usr/share/bash:
-total 4
-drwxr-xr-x 2 vagrant vagrant 4096  helpfiles
+helpfiles
 
 /tmp/jeos-kiwi/root/usr/share/bash/helpfiles:
-total 4
--rw-r--r-- 1 vagrant vagrant 1503  read
+read

--- a/spec/integration/integration_spec_helper.rb
+++ b/spec/integration/integration_spec_helper.rb
@@ -21,6 +21,19 @@ require_relative "../../../pennyworth/lib/ssh_keys_importer"
 require_relative "../support/system_description_factory"
 
 def prepare_machinery_for_host(system, ip, opts = {})
+  if system.runner.is_a?(LocalRunner)
+    prepare_local_machinery_for_host(system, ip)
+  else
+    prepare_remote_machinery_for_host(system, ip, opts)
+  end
+end
+
+def prepare_local_machinery_for_host(system, ip)
+  system.run_command("ssh-keygen -R #{ip}")
+  system.run_command("ssh-keyscan -H #{ip} >> ~/.ssh/known_hosts")
+end
+
+def prepare_remote_machinery_for_host(system, ip, opts)
   opts = {
     user:     "vagrant"
   }.merge(opts)

--- a/spec/integration/integration_spec_helper.rb
+++ b/spec/integration/integration_spec_helper.rb
@@ -15,6 +15,8 @@
 # To contact SUSE about this file by physical or electronic mail,
 # you may find current contact information at www.suse.com
 
+require "etc"
+
 require_relative "../../lib/machinery"
 require_relative "../../../pennyworth/lib/spec"
 require_relative "../../../pennyworth/lib/ssh_keys_importer"

--- a/spec/integration/machinery_local_spec.rb
+++ b/spec/integration/machinery_local_spec.rb
@@ -30,8 +30,10 @@ describe "machinery@local" do
   before(:all) do
     @machinery = start_system(
       local: true,
-      env: { "MACHINERY_DIR" => machinery_config[:machinery_dir] },
-      command_map: { "machinery" => File.join(Machinery::ROOT, "bin/machinery") }
+      env: {
+        "MACHINERY_DIR" => machinery_config[:machinery_dir],
+        "PATH" => File.join(Machinery::ROOT, "bin") + ":" + ENV["PATH"]
+      }
     )
   end
 

--- a/spec/integration/machinery_local_spec.rb
+++ b/spec/integration/machinery_local_spec.rb
@@ -1,0 +1,40 @@
+# Copyright (c) 2013-2015 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
+require_relative "integration_spec_helper"
+
+describe "machinery@local" do
+  let(:tmp_dir) { Dir.mktmpdir("machinery") }
+
+  before(:all) do
+    @machinery_dir = Dir.mktmpdir("machinery")
+    @owner = ENV["USER"]
+    @group = "users"
+    @machinery = start_system(
+      local: true,
+      env: { "MACHINERY_DIR" => @machinery_dir },
+      command_map: { "machinery" => File.join(Machinery::ROOT, "bin/machinery") }
+    )
+  end
+
+  after(:all) do
+    FileUtils.rm_r @machinery_dir
+  end
+
+  include_examples "CLI"
+  include_examples "kiwi export"
+end

--- a/spec/integration/machinery_local_spec.rb
+++ b/spec/integration/machinery_local_spec.rb
@@ -20,25 +20,27 @@ require_relative "integration_spec_helper"
 describe "machinery@local" do
   current_user = Etc.getlogin
   group = Etc.getgrgid(Etc.getpwnam(current_user).gid).name
-  test_config = {
+  machinery_config = {
     machinery_dir: Dir.mktmpdir("machinery"),
     owner: current_user,
     group: group
   }
+  let(:machinery_config) { machinery_config }
 
   before(:all) do
     @machinery = start_system(
       local: true,
-      env: { "MACHINERY_DIR" => test_config[:machinery_dir] },
+      env: { "MACHINERY_DIR" => machinery_config[:machinery_dir] },
       command_map: { "machinery" => File.join(Machinery::ROOT, "bin/machinery") }
     )
   end
 
   after(:all) do
-    FileUtils.rm_r test_config[:machinery_dir]
+    FileUtils.rm_r machinery_config[:machinery_dir]
   end
 
   include_examples "CLI"
-  include_examples "kiwi export", test_config
-  include_examples "autoyast export", test_config
+  include_examples "inspect", ["opensuse131"]
+  include_examples "kiwi export"
+  include_examples "autoyast export"
 end

--- a/spec/integration/machinery_local_spec.rb
+++ b/spec/integration/machinery_local_spec.rb
@@ -18,23 +18,26 @@
 require_relative "integration_spec_helper"
 
 describe "machinery@local" do
-  let(:tmp_dir) { Dir.mktmpdir("machinery") }
+  current_user = Etc.getlogin
+  group = Etc.getgrgid(Etc.getpwnam(current_user).gid).name
+  test_config = {
+    machinery_dir: Dir.mktmpdir("machinery"),
+    owner: current_user,
+    group: group
+  }
 
   before(:all) do
-    @machinery_dir = Dir.mktmpdir("machinery")
-    @owner = ENV["USER"]
-    @group = "users"
     @machinery = start_system(
       local: true,
-      env: { "MACHINERY_DIR" => @machinery_dir },
+      env: { "MACHINERY_DIR" => test_config[:machinery_dir] },
       command_map: { "machinery" => File.join(Machinery::ROOT, "bin/machinery") }
     )
   end
 
   after(:all) do
-    FileUtils.rm_r @machinery_dir
+    FileUtils.rm_r test_config[:machinery_dir]
   end
 
   include_examples "CLI"
-  include_examples "kiwi export"
+  include_examples "kiwi export", test_config
 end

--- a/spec/integration/machinery_local_spec.rb
+++ b/spec/integration/machinery_local_spec.rb
@@ -40,4 +40,5 @@ describe "machinery@local" do
 
   include_examples "CLI"
   include_examples "kiwi export", test_config
+  include_examples "autoyast export", test_config
 end

--- a/spec/integration/machinery_opensuse13.1_spec.rb
+++ b/spec/integration/machinery_opensuse13.1_spec.rb
@@ -18,6 +18,14 @@
 require_relative "integration_spec_helper"
 
 describe "machinery@openSUSE 13.1" do
+  let(:machinery_config) {
+    {
+      machinery_dir: "/home/vagrant/.machinery",
+      owner: "vagrant",
+      group: "vagrant"
+    }
+  }
+
   before(:all) do
     @machinery = start_system(box: "machinery_131")
   end

--- a/spec/integration/machinery_opensuse13.2_spec.rb
+++ b/spec/integration/machinery_opensuse13.2_spec.rb
@@ -18,6 +18,14 @@
 require_relative "integration_spec_helper"
 
 describe "machinery@openSUSE 13.2" do
+  let(:machinery_config) {
+    {
+      machinery_dir: "/home/vagrant/.machinery",
+      owner: "vagrant",
+      group: "vagrant"
+    }
+  }
+
   before(:all) do
     @machinery = start_system(box: "machinery_132")
   end

--- a/spec/integration/support/autoyast_export_examples.rb
+++ b/spec/integration/support/autoyast_export_examples.rb
@@ -17,7 +17,7 @@
 
 shared_examples "autoyast export" do
   after(:all) do
-    @machinery.run_command("rm -r /tmp/jeos-autoyast")
+    @machinery.run_command("test -d /tmp/jeos-autoyast && rm -r /tmp/jeos-autoyast")
   end
 
   describe "export-autoyast" do

--- a/spec/integration/support/autoyast_export_examples.rb
+++ b/spec/integration/support/autoyast_export_examples.rb
@@ -15,38 +15,31 @@
 # To contact SUSE about this file by physical or electronic mail,
 # you may find current contact information at www.suse.com
 
-shared_examples "autoyast export" do |opts|
-  let(:options) { opts || {
-    machinery_dir: "/home/vagrant/.machinery",
-    owner: "vagrant",
-    group: "vagrant"
-  }
-  }
-
+shared_examples "autoyast export" do
   after(:all) do
-    @machinery.run_command("rm", "-r", "/tmp/jeos-autoyast")
+    @machinery.run_command("rm -r /tmp/jeos-autoyast")
   end
 
   describe "export-autoyast" do
     it "creates an autoyast profile" do
       @machinery.inject_directory(
         File.join(Machinery::ROOT, "spec/data/descriptions/jeos/"),
-        options[:machinery_dir],
-        owner: options[:owner],
-        group: options[:group]
+        machinery_config[:machinery_dir],
+        owner: machinery_config[:owner],
+        group: machinery_config[:group]
       )
 
       measure("export to autoyast") do
         @machinery.run_command(
           "machinery export-autoyast jeos --autoyast-dir=/tmp",
-          as: options[:owner]
+          as: machinery_config[:owner]
         )
       end
 
       file_list = @machinery.run_command(
         "ls /tmp/jeos-autoyast",
         stdout: :capture,
-        as: options[:owner]
+        as: machinery_config[:owner]
       ).split("\n")
       expect(file_list).to include("autoinst.xml")
     end

--- a/spec/integration/support/autoyast_export_examples.rb
+++ b/spec/integration/support/autoyast_export_examples.rb
@@ -15,27 +15,38 @@
 # To contact SUSE about this file by physical or electronic mail,
 # you may find current contact information at www.suse.com
 
-shared_examples "autoyast export" do
+shared_examples "autoyast export" do |opts|
+  let(:options) { opts || {
+    machinery_dir: "/home/vagrant/.machinery",
+    owner: "vagrant",
+    group: "vagrant"
+  }
+  }
+
+  after(:all) do
+    @machinery.run_command("rm", "-r", "/tmp/jeos-autoyast")
+  end
+
   describe "export-autoyast" do
     it "creates an autoyast profile" do
       @machinery.inject_directory(
         File.join(Machinery::ROOT, "spec/data/descriptions/jeos/"),
-        "/home/vagrant/.machinery/",
-        owner: "vagrant",
-        group: "users"
+        options[:machinery_dir],
+        owner: options[:owner],
+        group: options[:group]
       )
 
       measure("export to autoyast") do
         @machinery.run_command(
           "machinery export-autoyast jeos --autoyast-dir=/tmp",
-          as: "vagrant"
+          as: options[:owner]
         )
       end
 
       file_list = @machinery.run_command(
         "ls /tmp/jeos-autoyast",
         stdout: :capture,
-        as: "vagrant"
+        as: options[:owner]
       ).split("\n")
       expect(file_list).to include("autoinst.xml")
     end

--- a/spec/integration/support/inspect_changed_managed_files_examples.rb
+++ b/spec/integration/support/inspect_changed_managed_files_examples.rb
@@ -20,14 +20,14 @@ shared_examples "inspect changed managed files" do |base|
     it "extracts list of managed files" do
       measure("Inspect system") do
         @machinery.run_command(
-            "machinery inspect #{@subject_system.ip} --scope=changed-managed-files --extract-files",
-            as: "vagrant"
+          "machinery inspect #{@subject_system.ip} --scope=changed-managed-files --extract-files",
+          as: machinery_config[:owner]
         )
       end
 
       actual_files_list = @machinery.run_command(
-          "machinery show #{@subject_system.ip} --scope=changed-managed-files",
-          as: "vagrant", stdout: :capture
+        "machinery show #{@subject_system.ip} --scope=changed-managed-files",
+        as: machinery_config[:owner], stdout: :capture
       )
 
       expected_files_list = File.read("spec/data/changed_managed_files/#{base}")
@@ -38,10 +38,12 @@ shared_examples "inspect changed managed files" do |base|
     it "extracts files from the system" do
       expected_files_list = File.read("spec/data/changed_managed_files/#{base}")
       actual_managed_files_list = nil
+
       measure("Gather information about extracted files") do
         actual_managed_files_list = @machinery.run_command(
-            "cd ~/.machinery/#{@subject_system.ip}/changed_managed_files/; find",
-            as: "vagrant", stdout: :capture
+          "cd #{machinery_config[:machinery_dir]}/#{@subject_system.ip}/changed_managed_files/; find",
+          as: machinery_config[:owner],
+          stdout: :capture
         ).split("\n")
       end
 
@@ -61,8 +63,8 @@ shared_examples "inspect changed managed files" do |base|
 
       # test file content
       actual_content = @machinery.run_command(
-          "cat ~/.machinery/#{@subject_system.ip}/changed_managed_files/usr/share/info/sed.info.gz",
-          as: "vagrant", stdout: :capture
+        "cat #{machinery_config[:machinery_dir]}/#{@subject_system.ip}/changed_managed_files/usr/share/info/sed.info.gz",
+        as: machinery_config[:owner], stdout: :capture
       )
       expect(actual_content).to include("changed managed files test entry")
     end

--- a/spec/integration/support/inspect_config_files_examples.rb
+++ b/spec/integration/support/inspect_config_files_examples.rb
@@ -41,7 +41,7 @@ shared_examples "inspect config files" do |base|
       actual_config_files = nil
       measure("Gather information about extracted files") do
         actual_config_files = @machinery.run_command(
-          "cd ~/.machinery/#{@subject_system.ip}/config_files/; find -type f",
+          "cd #{machinery_config[:machinery_dir]}/#{@subject_system.ip}/config_files/; find -type f",
           as: "vagrant", stdout: :capture
         ).split("\n")
       end
@@ -57,7 +57,7 @@ shared_examples "inspect config files" do |base|
 
       # test file content
       actual_content = @machinery.run_command(
-        "grep config_files_integration_test ~/.machinery/#{@subject_system.ip}/config_files/etc/crontab",
+        "grep config_files_integration_test #{machinery_config[:machinery_dir]}/#{@subject_system.ip}/config_files/etc/crontab",
         as: "vagrant", stdout: :capture
       )
       expect(actual_content).to eq(expected_content)

--- a/spec/integration/support/inspect_unmanaged_files_examples.rb
+++ b/spec/integration/support/inspect_unmanaged_files_examples.rb
@@ -77,7 +77,7 @@ shared_examples "inspect unmanaged files" do |base|
 
       it "does not extract unmanaged directories which are remote file systems" do
         actual_tarballs = @machinery.run_command(
-          "cd ~/.machinery/#{@subject_system.ip}/unmanaged_files/trees; find -type f",
+          "cd #{machinery_config[:machinery_dir]}/#{@subject_system.ip}/unmanaged_files/trees; find -type f",
           as: "vagrant", stdout: :capture
         ).split("\n")
 
@@ -127,12 +127,12 @@ shared_examples "inspect unmanaged files" do |base|
       actual_filestgz_list = nil
       measure("Gather information about extracted files") do
         actual_tarballs = @machinery.run_command(
-          "cd ~/.machinery/#{@subject_system.ip}/unmanaged_files/trees; find -type f",
+          "cd #{machinery_config[:machinery_dir]}/#{@subject_system.ip}/unmanaged_files/trees; find -type f",
           as: "vagrant", stdout: :capture
         ).split("\n")
 
         actual_filestgz_list = @machinery.run_command(
-          "tar -tf ~/.machinery/#{@subject_system.ip}/unmanaged_files/files.tgz",
+          "tar -tf #{machinery_config[:machinery_dir]}/#{@subject_system.ip}/unmanaged_files/files.tgz",
           as: "vagrant", stdout: :capture
         ).split("\n")
       end
@@ -164,7 +164,7 @@ shared_examples "inspect unmanaged files" do |base|
       expected_md5sums = parse_md5sums(expected_output)
 
       output = @machinery.run_command(
-        "cd /tmp; tar -xf ~/.machinery/#{@subject_system.ip}/unmanaged_files/trees/srv/test.tgz;" \
+        "cd /tmp; tar -xf #{machinery_config[:machinery_dir]}/#{@subject_system.ip}/unmanaged_files/trees/srv/test.tgz;" \
           " md5sum /tmp/srv/test/*",
         as: "vagrant", stdout: :capture
       )
@@ -202,7 +202,7 @@ shared_examples "inspect unmanaged files" do |base|
       )
 
       file_output = @machinery.run_command(
-        "ls ~/.machinery/#{@subject_system.ip}/unmanaged_files/trees/opt/test-quote-char/test-dir-name-with-\\'\\ quote-char\\ \\'/unmanaged-dir-with-\\'\\ quote\\ \\'.tgz",
+        "ls #{machinery_config[:machinery_dir]}/#{@subject_system.ip}/unmanaged_files/trees/opt/test-quote-char/test-dir-name-with-\\'\\ quote-char\\ \\'/unmanaged-dir-with-\\'\\ quote\\ \\'.tgz",
         as: "vagrant", stdout: :capture
       )
       expect(file_output).to include("unmanaged-dir-with-' quote '.tgz")

--- a/spec/integration/support/kiwi_export_examples.rb
+++ b/spec/integration/support/kiwi_export_examples.rb
@@ -15,14 +15,13 @@
 # To contact SUSE about this file by physical or electronic mail,
 # you may find current contact information at www.suse.com
 
-shared_examples "kiwi export" do
-  before(:each) do
-    @opts = {
-      machinery_dir: @machinery_dir || "/home/vagrant/.machinery",
-      owner: @owner || "vagrant",
-      group: @group || "vagrant"
+shared_examples "kiwi export" do |opts|
+  let(:options) { opts || {
+      machinery_dir: "/home/vagrant/.machinery",
+      owner: "vagrant",
+      group: "vagrant"
     }
-  end
+  }
 
   after(:all) do
     @machinery.run_command("rm", "-r", "/tmp/jeos-kiwi")
@@ -32,22 +31,22 @@ shared_examples "kiwi export" do
     it "creates a kiwi description" do
       @machinery.inject_directory(
         File.join(Machinery::ROOT, "spec/data/descriptions/jeos/"),
-        @opts[:machinery_dir],
-        owner: @opts[:owner],
-        group: @opts[:group]
+        options[:machinery_dir],
+        owner: options[:owner],
+        group: options[:group]
       )
 
       measure("export to kiwi") do
         @machinery.run_command(
           "machinery export-kiwi jeos --kiwi-dir=/tmp --force",
-          as: @opts[:owner]
+          as: options[:owner]
         )
       end
 
       file_list = @machinery.run_command(
         "ls /tmp/jeos-kiwi",
         stdout: :capture,
-        as: @opts[:owner]
+        as: options[:owner]
       ).split("\n")
       expect(file_list).to match_array(["README.md", "config.sh", "config.xml", "root"])
     end
@@ -57,7 +56,7 @@ shared_examples "kiwi export" do
       actual = @machinery.run_command(
         "cat /tmp/jeos-kiwi/config.sh",
         stdout: :capture,
-        as: @opts[:owner]
+        as: options[:owner]
       )
       expect(actual).to eq(expected)
     end
@@ -67,7 +66,7 @@ shared_examples "kiwi export" do
       actual = @machinery.run_command(
         "cat /tmp/jeos-kiwi/config.xml",
         stdout: :capture,
-        as: @opts[:owner]
+        as: options[:owner]
       )
 
       expect(actual).to eq(expected)
@@ -79,7 +78,7 @@ shared_examples "kiwi export" do
       actual = @machinery.run_command(
         "ls -1R --time-style=+ /tmp/jeos-kiwi/root",
         stdout: :capture,
-        as: @opts[:owner]
+        as: options[:owner]
       )
       expect(actual).to eq(expected)
     end

--- a/spec/integration/support/kiwi_export_examples.rb
+++ b/spec/integration/support/kiwi_export_examples.rb
@@ -17,7 +17,7 @@
 
 shared_examples "kiwi export" do
   after(:all) do
-    @machinery.run_command("rm", "-r", "/tmp/jeos-kiwi")
+    @machinery.run_command("test -d /tmp/jeos-kiwi && rm -r /tmp/jeos-kiwi")
   end
 
   describe "export-kiwi" do

--- a/spec/integration/support/kiwi_export_examples.rb
+++ b/spec/integration/support/kiwi_export_examples.rb
@@ -15,14 +15,7 @@
 # To contact SUSE about this file by physical or electronic mail,
 # you may find current contact information at www.suse.com
 
-shared_examples "kiwi export" do |opts|
-  let(:options) { opts || {
-      machinery_dir: "/home/vagrant/.machinery",
-      owner: "vagrant",
-      group: "vagrant"
-    }
-  }
-
+shared_examples "kiwi export" do
   after(:all) do
     @machinery.run_command("rm", "-r", "/tmp/jeos-kiwi")
   end
@@ -31,22 +24,22 @@ shared_examples "kiwi export" do |opts|
     it "creates a kiwi description" do
       @machinery.inject_directory(
         File.join(Machinery::ROOT, "spec/data/descriptions/jeos/"),
-        options[:machinery_dir],
-        owner: options[:owner],
-        group: options[:group]
+        machinery_config[:machinery_dir],
+        owner: machinery_config[:owner],
+        group: machinery_config[:group]
       )
 
       measure("export to kiwi") do
         @machinery.run_command(
           "machinery export-kiwi jeos --kiwi-dir=/tmp --force",
-          as: options[:owner]
+          as: machinery_config[:owner]
         )
       end
 
       file_list = @machinery.run_command(
         "ls /tmp/jeos-kiwi",
         stdout: :capture,
-        as: options[:owner]
+        as: machinery_config[:owner]
       ).split("\n")
       expect(file_list).to match_array(["README.md", "config.sh", "config.xml", "root"])
     end
@@ -56,7 +49,7 @@ shared_examples "kiwi export" do |opts|
       actual = @machinery.run_command(
         "cat /tmp/jeos-kiwi/config.sh",
         stdout: :capture,
-        as: options[:owner]
+        as: machinery_config[:owner]
       )
       expect(actual).to eq(expected)
     end
@@ -66,7 +59,7 @@ shared_examples "kiwi export" do |opts|
       actual = @machinery.run_command(
         "cat /tmp/jeos-kiwi/config.xml",
         stdout: :capture,
-        as: options[:owner]
+        as: machinery_config[:owner]
       )
 
       expect(actual).to eq(expected)
@@ -78,7 +71,7 @@ shared_examples "kiwi export" do |opts|
       actual = @machinery.run_command(
         "ls -1R --time-style=+ /tmp/jeos-kiwi/root",
         stdout: :capture,
-        as: options[:owner]
+        as: machinery_config[:owner]
       )
       expect(actual).to eq(expected)
     end

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -52,6 +52,18 @@ describe Cli do
       create_machinery_dir
     end
 
+    describe "#system_description_store" do
+      it "returns the default store by default" do
+        expect(Cli.system_description_store.base_path).to eq(test_base_path)
+      end
+
+      it "uses the store specified by MACHINERY_DIR" do
+        with_env("MACHINERY_DIR" => "/tmp/machinery") do
+          expect(Cli.system_description_store.base_path).to eq("/tmp/machinery")
+        end
+      end
+    end
+
     describe "#inspect" do
       include_context "machinery test directory"
 


### PR DESCRIPTION
Please review the following changes:
  * 8b5d2c6 command_map is not needed, we just tweak PATH to prefer local machinery
  * d6242ba Only require 'etc' for the integration tests
  * 72bb72b Be more robust when cleaning up the export directories
  * 5f346ce Encapsulate the machinery environment (path, user, group)
  * dc9bcd1 For local machinery we only have to set up the subject system's host key
  * a4bc019 Also run the autoyast export tests locally
  * 9bc5a45 Fix overriding the kiwi export test settings when running locally
  * 07b34c5 Add a new suite of specs that are run on the locally instead of in a VM
  * e6b6eb8 Parameterize KIWI export examples so that they can be used locally, too
  * b785574 Allow for overriding the machinery store using the MACHINERY_DIR env var