### PR TITLE
Use absolute path to binary in tests that are run locally and remote

### DIFF
--- a/spec/integration/machinery_local_spec.rb
+++ b/spec/integration/machinery_local_spec.rb
@@ -26,13 +26,13 @@ describe "machinery@local" do
     group: group
   }
   let(:machinery_config) { machinery_config }
+  let(:machinery_command) { File.join(Machinery::ROOT, "bin", "machinery") }
 
   before(:all) do
     @machinery = start_system(
       local: true,
       env: {
-        "MACHINERY_DIR" => machinery_config[:machinery_dir],
-        "PATH" => File.join(Machinery::ROOT, "bin") + ":" + ENV["PATH"]
+        "MACHINERY_DIR" => machinery_config[:machinery_dir]
       }
     )
   end

--- a/spec/integration/machinery_opensuse13.1_spec.rb
+++ b/spec/integration/machinery_opensuse13.1_spec.rb
@@ -25,6 +25,7 @@ describe "machinery@openSUSE 13.1" do
       group: "vagrant"
     }
   }
+  let(:machinery_command) { "machinery" }
 
   before(:all) do
     @machinery = start_system(box: "machinery_131")

--- a/spec/integration/machinery_opensuse13.2_spec.rb
+++ b/spec/integration/machinery_opensuse13.2_spec.rb
@@ -25,6 +25,7 @@ describe "machinery@openSUSE 13.2" do
       group: "vagrant"
     }
   }
+  let(:machinery_command) { "machinery" }
 
   before(:all) do
     @machinery = start_system(box: "machinery_132")

--- a/spec/integration/support/autoyast_export_examples.rb
+++ b/spec/integration/support/autoyast_export_examples.rb
@@ -31,7 +31,7 @@ shared_examples "autoyast export" do
 
       measure("export to autoyast") do
         @machinery.run_command(
-          "machinery export-autoyast jeos --autoyast-dir=/tmp",
+          "#{machinery_command} export-autoyast jeos --autoyast-dir=/tmp",
           as: machinery_config[:owner]
         )
       end

--- a/spec/integration/support/command_line_examples.rb
+++ b/spec/integration/support/command_line_examples.rb
@@ -19,7 +19,7 @@ shared_examples "CLI" do
   describe "CLI" do
     it "throws an error on invalid command" do
       expect { @machinery.run_command(
-        "machinery invalid_command",
+        "#{machinery_command} invalid_command",
         :as => "vagrant",
         :stdout => :capture
       ) }.to raise_error(ExecutionFailed)
@@ -27,7 +27,7 @@ shared_examples "CLI" do
 
     it "processes help option" do
       output = @machinery.run_command(
-        "machinery -h",
+        "#{machinery_command} -h",
         :as => "vagrant",
         :stdout => :capture
       )
@@ -38,7 +38,7 @@ shared_examples "CLI" do
 
     it "processes help option for subcommands" do
       output = @machinery.run_command(
-        "machinery inspect --help",
+        "#{machinery_command} inspect --help",
         :as => "vagrant",
         :stdout => :capture
       )
@@ -47,17 +47,17 @@ shared_examples "CLI" do
 
     it "does not offer --no-help or unneccessary negatable options" do
       global_output = @machinery.run_command(
-        "machinery --help",
+        "#{machinery_command} --help",
         :as => "vagrant",
         :stdout => :capture
       )
       inspect_help_output = @machinery.run_command(
-        "machinery inspect --help",
+        "#{machinery_command} inspect --help",
         :as => "vagrant",
         :stdout => :capture
       )
       show_help_output = @machinery.run_command(
-        "machinery inspect --help",
+        "#{machinery_command} inspect --help",
         :as => "vagrant",
         :stdout => :capture
       )
@@ -69,7 +69,7 @@ shared_examples "CLI" do
     describe "inspect" do
       it "fails inspect for non existing scope" do
         expect { @machinery.run_command(
-          "sudo machinery inspect localhost --scope=foobar --name=test",
+          "sudo #{machinery_command} inspect localhost --scope=foobar --name=test",
           :as => "vagrant",
           :stdout => :capture
         ) }.to raise_error(ExecutionFailed, /The following scope is not supported: foobar/)
@@ -79,7 +79,7 @@ shared_examples "CLI" do
     describe "build" do
       it "fails without an output path" do
         expect { @machinery.run_command(
-          "machinery build test",
+          "#{machinery_command} build test",
           :as => "vagrant",
           :stdout => :capture
         ) }.to raise_error(ExecutionFailed, /image-dir is required/)
@@ -87,7 +87,7 @@ shared_examples "CLI" do
 
       it "fails without a name" do
         expect { @machinery.run_command(
-          "machinery build --image-dir=/tmp/",
+          "#{machinery_command} build --image-dir=/tmp/",
           :as => "vagrant",
           :stdout => :capture
         ) }.to raise_error(ExecutionFailed, /You need to provide the required argument/)

--- a/spec/integration/support/inspect_changed_managed_files_examples.rb
+++ b/spec/integration/support/inspect_changed_managed_files_examples.rb
@@ -20,13 +20,13 @@ shared_examples "inspect changed managed files" do |base|
     it "extracts list of managed files" do
       measure("Inspect system") do
         @machinery.run_command(
-          "machinery inspect #{@subject_system.ip} --scope=changed-managed-files --extract-files",
+          "#{machinery_command} inspect #{@subject_system.ip} --scope=changed-managed-files --extract-files",
           as: machinery_config[:owner]
         )
       end
 
       actual_files_list = @machinery.run_command(
-        "machinery show #{@subject_system.ip} --scope=changed-managed-files",
+        "#{machinery_command} show #{@subject_system.ip} --scope=changed-managed-files",
         as: machinery_config[:owner], stdout: :capture
       )
 

--- a/spec/integration/support/inspect_config_files_examples.rb
+++ b/spec/integration/support/inspect_config_files_examples.rb
@@ -22,13 +22,13 @@ shared_examples "inspect config files" do |base|
     it "extracts list of config files" do
       measure("Inspect system") do
         @machinery.run_command(
-          "machinery inspect #{@subject_system.ip} --scope=config-files --extract-files",
+          "#{machinery_command} inspect #{@subject_system.ip} --scope=config-files --extract-files",
           as: "vagrant"
         )
       end
 
       actual_files_list = @machinery.run_command(
-        "machinery show #{@subject_system.ip} --scope=config-files",
+        "#{machinery_command} show #{@subject_system.ip} --scope=config-files",
         as: "vagrant", stdout: :capture
       )
 

--- a/spec/integration/support/inspect_simple_scopes.rb
+++ b/spec/integration/support/inspect_simple_scopes.rb
@@ -20,7 +20,7 @@ shared_examples "inspect simple scope" do |scope, base|
     it "inspects #{scope}" do
       measure("Inspect #{scope}") do
         @machinery.run_command(
-            "machinery inspect #{@subject_system.ip} --scope=#{scope} --name=test",
+            "#{machinery_command} inspect #{@subject_system.ip} --scope=#{scope} --name=test",
             :as => "vagrant",
             :stdout => :capture
         )
@@ -28,7 +28,7 @@ shared_examples "inspect simple scope" do |scope, base|
 
       expected = File.read("spec/data/#{scope}/#{base}")
       actual = @machinery.run_command(
-          "machinery show test --scope=#{scope}",
+          "#{machinery_command} show test --scope=#{scope}",
           :as => "vagrant",
           :stdout => :capture
       )

--- a/spec/integration/support/inspect_simple_scopes.rb
+++ b/spec/integration/support/inspect_simple_scopes.rb
@@ -20,17 +20,17 @@ shared_examples "inspect simple scope" do |scope, base|
     it "inspects #{scope}" do
       measure("Inspect #{scope}") do
         @machinery.run_command(
-            "#{machinery_command} inspect #{@subject_system.ip} --scope=#{scope} --name=test",
-            :as => "vagrant",
-            :stdout => :capture
+          "#{machinery_command} inspect #{@subject_system.ip} --scope=#{scope} --name=test",
+          :as => "vagrant",
+          :stdout => :capture
         )
       end
 
       expected = File.read("spec/data/#{scope}/#{base}")
       actual = @machinery.run_command(
-          "#{machinery_command} show test --scope=#{scope}",
-          :as => "vagrant",
-          :stdout => :capture
+        "#{machinery_command} show test --scope=#{scope}",
+        :as => "vagrant",
+        :stdout => :capture
       )
       expect(actual).to match_machinery_show_scope(expected)
     end

--- a/spec/integration/support/inspect_unmanaged_files_examples.rb
+++ b/spec/integration/support/inspect_unmanaged_files_examples.rb
@@ -32,13 +32,13 @@ shared_examples "inspect unmanaged files" do |base|
     it "extracts list of unmanaged files" do
       measure("Inspect system") do
         @machinery.run_command(
-          "machinery inspect #{@subject_system.ip} --scope=unmanaged-files --extract-files",
+          "#{machinery_command} inspect #{@subject_system.ip} --scope=unmanaged-files --extract-files",
           as: "vagrant"
         )
       end
 
       actual_output = @machinery.run_command(
-        "machinery show #{@subject_system.ip} --scope=unmanaged-files",
+        "#{machinery_command} show #{@subject_system.ip} --scope=unmanaged-files",
         as: "vagrant", stdout: :capture
       )
       # Remove timestamp, so comparison doesn't fail on that.
@@ -56,7 +56,7 @@ shared_examples "inspect unmanaged files" do |base|
 
     it "extracts meta data of unmanaged files" do
       actual_output = @machinery.run_command(
-        "machinery show #{@subject_system.ip} --scope=unmanaged-files",
+        "#{machinery_command} show #{@subject_system.ip} --scope=unmanaged-files",
         as: "vagrant", stdout: :capture
       )
 
@@ -86,7 +86,7 @@ shared_examples "inspect unmanaged files" do |base|
 
       it "lists remote fs directories as 'remote_dir'" do
         actual_output = @machinery.run_command(
-          "machinery show #{@subject_system.ip} --scope=unmanaged-files",
+          "#{machinery_command} show #{@subject_system.ip} --scope=unmanaged-files",
           as: "vagrant", stdout: :capture
         )
 
@@ -95,7 +95,7 @@ shared_examples "inspect unmanaged files" do |base|
 
       it "also shows remote fs which are mounted in a sub directory of a tree" do
         actual_output = @machinery.run_command(
-          "machinery show #{@subject_system.ip} --scope=unmanaged-files",
+          "#{machinery_command} show #{@subject_system.ip} --scope=unmanaged-files",
           as: "vagrant", stdout: :capture
         )
 
@@ -108,7 +108,7 @@ shared_examples "inspect unmanaged files" do |base|
 
       measure("Get list of unmanaged-files") do
         entries = @machinery.run_command(
-          "machinery show #{@subject_system.ip} --scope=unmanaged-files",
+          "#{machinery_command} show #{@subject_system.ip} --scope=unmanaged-files",
           as: "vagrant", stdout: :capture
         )
       end
@@ -197,7 +197,7 @@ shared_examples "inspect unmanaged files" do |base|
       )
 
       @machinery.run_command(
-        "machinery inspect #{@subject_system.ip} --scope=unmanaged-files --extract-files",
+        "#{machinery_command} inspect #{@subject_system.ip} --scope=unmanaged-files --extract-files",
         as: "vagrant"
       )
 
@@ -208,7 +208,7 @@ shared_examples "inspect unmanaged files" do |base|
       expect(file_output).to include("unmanaged-dir-with-' quote '.tgz")
 
       show_output = @machinery.run_command(
-        "machinery show #{@subject_system.ip} --scope=unmanaged-files",
+        "#{machinery_command} show #{@subject_system.ip} --scope=unmanaged-files",
         as: "vagrant", stdout: :capture
       )
       expect(show_output).to include("unmanaged-file-with-' quote '")

--- a/spec/integration/support/kiwi_export_examples.rb
+++ b/spec/integration/support/kiwi_export_examples.rb
@@ -31,7 +31,7 @@ shared_examples "kiwi export" do
 
       measure("export to kiwi") do
         @machinery.run_command(
-          "machinery export-kiwi jeos --kiwi-dir=/tmp --force",
+          "#{machinery_command} export-kiwi jeos --kiwi-dir=/tmp --force",
           as: machinery_config[:owner]
         )
       end


### PR DESCRIPTION
That fixes the problem with sudo, where the PATH environment variable
was not passed through and the system machinery was used instead of the
git one.
