### PR TITLE
Require package_manager in repositories scope

### DIFF
--- a/plugins/schema/v3/system-description-repositories.schema.json
+++ b/plugins/schema/v3/system-description-repositories.schema.json
@@ -4,7 +4,7 @@
   "type": "array",
   "items" : {
     "type" : "object",
-    "required": ["alias", "name", "url", "type", "enabled", "gpgcheck"],
+    "required": ["alias", "name", "url", "type", "enabled", "gpgcheck", "package_manager"],
     "properties": {
       "alias": {
         "type": "string",


### PR DESCRIPTION
The attribute was added to the migration and inspection but it wasn't
marked as required in the schema so this was fixed now as discussed.

Fixes #630 