### PR TITLE
[Review] Request from 'tgoettlicher' @ 'SUSE/machinery/review_150227_export_autoyast_profile_which_only_installs_required_packages'

### DIFF
--- a/lib/autoyast.rb
+++ b/lib/autoyast.rb
@@ -74,6 +74,7 @@ class Autoyast < Exporter
         apply_basic_network(xml)
         apply_repositories(xml)
         xml.software do
+          apply_software_settings(xml)
           apply_packages(xml)
           apply_patterns(xml)
         end
@@ -101,6 +102,10 @@ class Autoyast < Exporter
   end
 
   private
+
+  def apply_software_settings(xml)
+    xml.install_recommended "false", "config:type" => "boolean"
+  end
 
   def apply_non_interactive_mode(xml)
     xml.general do

--- a/spec/data/autoyast/simple.xml
+++ b/spec/data/autoyast/simple.xml
@@ -34,6 +34,7 @@
     </add_on_products>
   </add-on>
   <software>
+    <install_recommended config:type="boolean">false</install_recommended>
     <packages config:type="list">
       <package>bash</package>
       <package>openSUSE-release-dvd</package>


### PR DESCRIPTION
Please review the following changes:
  * f93512f Export autoyast profile which only installs required packages
  * 6e1de0c Merge pull request #647 from SUSE/fix_638_2
  * e12a539 Add list --short option to changelog
  * 540a1de Update manpage for list --short option
  * 7b2ec5c Add short option to list
  * 513dcd1 Remove obsolete option description name cleanup in list
  * ffca70a Replace hashes in cli.rb through Ruby 1.9 syntax
  * 8a5b940 Replace verbose string option by symbol
  * dcfa701 Merge pull request #645 from SUSE/review_150227_fix_json_error_handling
  * 7c047cf Do not choke on broken JSON.