### PR TITLE
Fix parsing kernel command line (issue #644)

### DIFF
--- a/lib/autoyast.rb
+++ b/lib/autoyast.rb
@@ -250,7 +250,7 @@ class Autoyast < Exporter
     xml.send("pre-scripts", "config:type" => "list") do
       xml.script do
         xml.source do
-          xml.cdata 'sed -n \'/.*autoyast2\?=\(.*\)\/.*[^\s]*/s//\1/p\'' \
+          xml.cdata 'sed -n \'/.*autoyast2\?=\([^ ]*\)\/.*[^\s]*/s//\1/p\'' \
             ' /proc/cmdline > /tmp/description_url'
         end
       end

--- a/spec/data/autoyast/simple.xml
+++ b/spec/data/autoyast/simple.xml
@@ -102,7 +102,7 @@
   <scripts>
     <pre-scripts config:type="list">
       <script>
-        <source><![CDATA[sed -n '/.*autoyast2\?=\(.*\)\/.*[^\s]*/s//\1/p' /proc/cmdline > /tmp/description_url]]></source>
+        <source><![CDATA[sed -n '/.*autoyast2\?=\([^ ]*\)\/.*[^\s]*/s//\1/p' /proc/cmdline > /tmp/description_url]]></source>
       </script>
     </pre-scripts>
     <chroot-scripts config:type="list">


### PR DESCRIPTION
This commit fixes parsing the kernel command line. Parsing failed
when there was another option after the autoyast= option which
contained a slash character ('/'). The new regular expression
fixes this issue.