### PR TITLE
Add core filtering engine and make use of it in unmanaged files inspector

### DIFF
--- a/docs/Filtering-Design.md
+++ b/docs/Filtering-Design.md
@@ -63,6 +63,14 @@ When the matched element is a string it is used literally without the quotes to
 match against the condiditon, e.g. a JSON such as `"name": "apache"` matches
 `name=apache`.
 
+It is possible to match the beginning of a string by adding `*` as a suffix. For
+example
+
+    /unmanaged_files/files/name=/etc/ssh/ssh_host_key*
+
+would match all files whose name starts with the given value, such as
+`/etc/ssh/ssh_host_key` and `/etc/ssh/ssh_host_key.pub`.
+
 If it is an array, the its string representation is matched against the
 condition. e.g. a JSON such as `"changes": ["deleted"]` matches
 `changes=deleted`, and a JSON such as `"changes":  ["mode", "user"]` matches

--- a/lib/filter.rb
+++ b/lib/filter.rb
@@ -2,19 +2,25 @@ class Filter
   attr_accessor :criteria
 
   def initialize(filter_definition = nil)
-    if filter_definition.nil?
-      @criteria = []
-    elsif filter_definition.is_a?(String)
-      @criteria = [ filter_definition ]
+    @criteria = []
+    @start_criteria = []
+    if filter_definition.is_a?(String)
+      add_criterion(filter_definition)
     elsif filter_definition.is_a?(Array)
-      @criteria = filter_definition
-    else
+      filter_definition.each do |definition|
+        add_criterion(definition)
+      end
+    elsif !filter_definition.nil?
       raise "Wrong type"
     end
   end
 
   def add_criterion(filter_definition)
-    @criteria.push(filter_definition)
+    if filter_definition.end_with?("*")
+      @start_criteria.push(filter_definition[0..-2])
+    else
+      @criteria.push(filter_definition)
+    end
   end
 
   def add_criteria_set(locator, value_set)
@@ -34,8 +40,14 @@ class Filter
   end
 
   def matches?(locator, value)
+    match = "#{locator}=#{value}"
     @criteria.each do |criterion|
-      if criterion == "#{locator}=#{value}"
+      if match == criterion
+        return true
+      end
+    end
+    @start_criteria.each do |criterion|
+      if match.start_with?(criterion)
         return true
       end
     end

--- a/lib/filter.rb
+++ b/lib/filter.rb
@@ -1,0 +1,28 @@
+class Filter
+  attr_accessor :criteria
+
+  def initialize(filter_definition = nil)
+    if filter_definition.nil?
+      @criteria = []
+    elsif filter_definition.is_a?(String)
+      @criteria = [ filter_definition ]
+    elsif filter_definition.is_a?(Array)
+      @criteria = filter_definition
+    else
+      raise "Wrong type"
+    end
+  end
+
+  def add_criterion(filter_definition)
+    @criteria.push(filter_definition)
+  end
+
+  def matches?(locator, value)
+    @criteria.each do |criterion|
+      if criterion == "#{locator}=#{value}"
+        return true
+      end
+    end
+    false
+  end
+end

--- a/lib/filter.rb
+++ b/lib/filter.rb
@@ -17,6 +17,22 @@ class Filter
     @criteria.push(filter_definition)
   end
 
+  def add_criteria_set(locator, value_set)
+    value_set.each do |value|
+      add_criterion("#{locator}=#{value}")
+    end
+  end
+
+  def criteria_values(locator)
+    values = []
+    @criteria.each do |criterion|
+      if criterion =~ /^#{locator}=(.*)$/
+        values.push($1)
+      end
+    end
+    values
+  end
+
   def matches?(locator, value)
     @criteria.each do |criterion|
       if criterion == "#{locator}=#{value}"

--- a/lib/machinery.rb
+++ b/lib/machinery.rb
@@ -87,6 +87,7 @@ require_relative "scope_file_store"
 require_relative "json_validator"
 require_relative "json_validation_error_cleaner"
 require_relative "file_validator"
+require_relative "filter"
 
 Dir[File.join(Machinery::ROOT, "plugins", "**", "*.rb")].each { |f| require(f) }
 

--- a/spec/unit/filter_spec.rb
+++ b/spec/unit/filter_spec.rb
@@ -39,6 +39,23 @@ describe Filter do
     end
   end
 
+  describe "#add_criterion_set" do
+    it "adds set of two definitions" do
+      filter = Filter.new
+      filter.add_criteria_set("/unmanaged_files/files/name",
+        ["/home/alfred", "/var/cache"])
+      expect(filter.criteria).to eq([@criterion1, @criterion2])
+    end
+  end
+
+  describe "#criteria_values" do
+    it "returns criteria values for given locator" do
+      filter = Filter.new([@criterion1, @criterion2])
+      expect(filter.criteria_values("/unmanaged_files/files/name")).
+        to eq(["/home/alfred", "/var/cache"])
+    end
+  end
+
   describe "#matches?" do
     it "returns true on matching value" do
       filter = Filter.new(@criterion1)

--- a/spec/unit/filter_spec.rb
+++ b/spec/unit/filter_spec.rb
@@ -1,0 +1,55 @@
+require_relative "spec_helper"
+
+describe Filter do
+  before(:each) do
+    @criterion1 = "/unmanaged_files/files/name=/home/alfred"
+    @criterion2 = "/unmanaged_files/files/name=/var/cache"
+  end
+
+  describe "#initialize" do
+    it "creates filter object" do
+      filter = Filter.new
+      expect(filter).to be_a(Filter)
+    end
+
+    it "creates filter object with one definition" do
+      filter = Filter.new(@criterion1)
+      expect(filter.criteria).to eq([@criterion1])
+    end
+
+    it "creates filter object with an array of definitions" do
+      filter_criteria = [ @criterion1, @criterion2 ]
+      filter = Filter.new(filter_criteria)
+      expect(filter.criteria).to eq(filter_criteria)
+    end
+  end
+
+  describe "#add_criterion" do
+    it "adds one filter definition" do
+      filter = Filter.new
+      filter.add_criterion(@criterion1)
+      expect(filter.criteria).to eq([@criterion1])
+    end
+
+    it "adds two filter definition" do
+      filter = Filter.new
+      filter.add_criterion(@criterion1)
+      filter.add_criterion(@criterion2)
+      expect(filter.criteria).to eq([@criterion1, @criterion2])
+    end
+  end
+
+  describe "#matches?" do
+    it "returns true on matching value" do
+      filter = Filter.new(@criterion1)
+      expect(filter.matches?("/unmanaged_files/files/name", "/home/alfred")).
+        to be(true)
+    end
+
+    it "returns false on non-matching value" do
+      filter = Filter.new(@criterion1)
+      expect(filter.matches?("/unmanaged_files/files/name", "/home/berta")).
+        to be(false)
+    end
+  end
+end

--- a/spec/unit/filter_spec.rb
+++ b/spec/unit/filter_spec.rb
@@ -68,5 +68,27 @@ describe Filter do
       expect(filter.matches?("/unmanaged_files/files/name", "/home/berta")).
         to be(false)
     end
+
+    describe "matches beginning of a value" do
+      before(:each) do
+        @filter = Filter.new("path=/home/alfred/*")
+      end
+
+      it "returns false on shorter value" do
+        expect(@filter.matches?("path", "/home/alfred")).to be(false)
+      end
+
+      it "returns true on minimal match" do
+        expect(@filter.matches?("path", "/home/alfred/")).to be(true)
+      end
+
+      it "returns true on longer match" do
+        expect(@filter.matches?("path", "/home/alfred/and/berta")).to be(true)
+      end
+
+      it "returns true on value with star at the end" do
+        expect(@filter.matches?("path", "/home/alfred/*")).to be(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
This is a first attempt at implementing the core filtering engine as described in the [filtering design document](https://github.com/SUSE/machinery/blob/master/docs/Filtering-Design.md).

For a first illustration how to use it the unmanaged files inspector has been ported. The port is pretty ugly, but exactly replicates the current behavior. It can be simplified, but this will also need changes to the behavior.

The filtering engine will have to be extended to filter descriptions. The idea would be that it's possible to do something like `filter.apply(description)` to remove all elements matched by the filter from the description.

This pull request is mostly for review of the concept and the first implementation. We might want to refine it before we merge it to master, but I'll leave that up for discussion.