### PR TITLE
[Review] Request from 'aduffeck' @ 'SUSE/machinery/review_150303_implement_skip_files_option'

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,8 +1,9 @@
 # Machinery Release Notes
 
 * Fix issue with changes of managed files on RHEL (gh#SUSE/machinery#636)
-* Add "--short" option to list command for showing a short list of all descriptions
+* Add `--short` option to list command for showing a short list of all descriptions
 * Improve error output for system descriptions which have outdated formats
+* Add `--skip-files` option to `inspect` command for unmanaged files
 
 ## Version 1.4.0 - Wed Feb 18 16:51:43 CET 2015 - thardeck@suse.de
 

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -415,6 +415,8 @@ class Cli
       desc: "Show specified scopes", arg_name: "SCOPE_LIST"
     c.flag ["exclude-scope", :e], type: String, required: false,
       desc: "Exclude specified scopes", arg_name: "SCOPE_LIST"
+    c.flag "skip-files", required: false, negatable: false,
+      desc: "Do not consider given files or directories during inspection (separate by commas)"
     c.switch ["extract-files", :x], required: false, negatable: false,
       desc: "Extract changed configuration files and unmanaged files from inspected system"
     c.switch "extract-changed-config-files", required: false, negatable: false,
@@ -439,6 +441,7 @@ class Cli
       Machinery::Ui.puts "Inspecting #{host}#{inspected_scopes}..."
 
       inspect_options = {}
+      inspect_options[:skip_files] = options["skip-files"] if options["skip-files"]
       if options["show"]
         inspect_options[:show] = true
       end

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -416,7 +416,8 @@ class Cli
     c.flag ["exclude-scope", :e], type: String, required: false,
       desc: "Exclude specified scopes", arg_name: "SCOPE_LIST"
     c.flag "skip-files", required: false, negatable: false,
-      desc: "Do not consider given files or directories during inspection (separate by commas)"
+      desc: "Do not consider given files or directories during inspection. " \
+        "Either provide one file or directory name or a list of names separated by commas."
     c.switch ["extract-files", :x], required: false, negatable: false,
       desc: "Extract changed configuration files and unmanaged files from inspected system"
     c.switch "extract-changed-config-files", required: false, negatable: false,

--- a/lib/inspect_task.rb
+++ b/lib/inspect_task.rb
@@ -71,16 +71,17 @@ class InspectTask
     end
 
     failed_inspections = {}
+    filter = nil
 
     skip_files = options.delete(:skip_files)
     if skip_files
-      options[:filter] = Filter.new("/unmanaged_files/files/name=#{skip_files}")
+      filter = Filter.new("/unmanaged_files/files/name=#{skip_files}")
     end
 
     scopes.map { |s| Inspector.for(s) }.each do |inspector|
       Machinery::Ui.puts "Inspecting #{Machinery::Ui.internal_scope_list_to_string(inspector.scope)}..."
       begin
-        summary = inspector.inspect(system, description, options)
+        summary = inspector.inspect(system, description, filter, options)
       rescue Machinery::Errors::MachineryError => e
         Machinery::Ui.puts " -> Inspection failed!"
         failed_inspections[inspector.scope] = e

--- a/lib/inspect_task.rb
+++ b/lib/inspect_task.rb
@@ -72,6 +72,11 @@ class InspectTask
 
     failed_inspections = {}
 
+    skip_files = options.delete(:skip_files)
+    if skip_files
+      options[:filter] = Filter.new("/unmanaged_files/files/name=#{skip_files}")
+    end
+
     scopes.map { |s| Inspector.for(s) }.each do |inspector|
       Machinery::Ui.puts "Inspecting #{Machinery::Ui.internal_scope_list_to_string(inspector.scope)}..."
       begin

--- a/lib/local_system.rb
+++ b/lib/local_system.rb
@@ -24,7 +24,7 @@ class LocalSystem < System
         description = SystemDescription.new("localhost",
           SystemDescriptionMemoryStore.new)
         inspector = OsInspector.new
-        inspector.inspect(System.for("localhost"), description)
+        inspector.inspect(System.for("localhost"), description, nil)
         @@os = description.os
       end
       @@os

--- a/man/machinery-inspect.1.md
+++ b/man/machinery-inspect.1.md
@@ -56,6 +56,9 @@ trigger errors.
   * `--extract-changed-managed-files` (optional):
     Extract changed managed files from inspected system.
 
+  * `--skip-files` (optional):
+    Do not consider given files or directories during inspection (separate by commas)
+
 ### PREREQUISITES
 
   * Inspecting a local system requires running `machinery` as root.

--- a/man/machinery-inspect.1.md
+++ b/man/machinery-inspect.1.md
@@ -57,7 +57,8 @@ trigger errors.
     Extract changed managed files from inspected system.
 
   * `--skip-files` (optional):
-    Do not consider given files or directories during inspection (separate by commas)
+    Do not consider given files or directories during inspection. Either provide
+    one file or directory name or a list of names separated by commas.
 
 ### PREREQUISITES
 

--- a/plugins/inspect/changed_managed_files_inspector.rb
+++ b/plugins/inspect/changed_managed_files_inspector.rb
@@ -22,7 +22,9 @@ class ChangedManagedFilesInspector < Inspector
     system.check_requirement("rsync", "--version") if options[:extract_changed_managed_files]
 
     if options[:filter]
-      Machinery::Ui.warn("Warning: Filtering is not yet supported for the \"changed-managed-files\" scope")
+      Machinery::Ui.warn(
+        "Warning: Filtering is not yet supported for the \"changed-managed-files\" scope"
+      )
     end
 
     @system = system

--- a/plugins/inspect/changed_managed_files_inspector.rb
+++ b/plugins/inspect/changed_managed_files_inspector.rb
@@ -21,6 +21,10 @@ class ChangedManagedFilesInspector < Inspector
   def inspect(system, description, options = {})
     system.check_requirement("rsync", "--version") if options[:extract_changed_managed_files]
 
+    if options[:filter]
+      Machinery::Ui.warn("Warning: Filtering is not yet supported for the \"changed-managed-files\" scope")
+    end
+
     @system = system
     file_store = description.scope_file_store("changed_managed_files")
 

--- a/plugins/inspect/changed_managed_files_inspector.rb
+++ b/plugins/inspect/changed_managed_files_inspector.rb
@@ -18,7 +18,7 @@
 class ChangedManagedFilesInspector < Inspector
   include ChangedRpmFilesHelper
 
-  def inspect(system, description, options = {})
+  def inspect(system, description, _filter, options = {})
     system.check_requirement("rsync", "--version") if options[:extract_changed_managed_files]
 
     if options[:filter]

--- a/plugins/inspect/config_files_inspector.rb
+++ b/plugins/inspect/config_files_inspector.rb
@@ -86,6 +86,10 @@ class ConfigFilesInspector < Inspector
     do_extract = options[:extract_changed_config_files]
     check_requirements(system, do_extract)
 
+    if options[:filter]
+      Machinery::Ui.warn("Warning: Filtering is not yet supported for the \"config-files\" scope")
+    end
+
     result = packages_with_config_files(system).flat_map do |package|
       config_file_changes(system, package)
     end

--- a/plugins/inspect/config_files_inspector.rb
+++ b/plugins/inspect/config_files_inspector.rb
@@ -82,7 +82,7 @@ class ConfigFilesInspector < Inspector
     end
   end
 
-  def inspect(system, description, options = {})
+  def inspect(system, description, _filter, options = {})
     do_extract = options[:extract_changed_config_files]
     check_requirements(system, do_extract)
 

--- a/plugins/inspect/groups_inspector.rb
+++ b/plugins/inspect/groups_inspector.rb
@@ -16,7 +16,7 @@
 # you may find current contact information at www.suse.com
 
 class GroupsInspector < Inspector
-  def inspect(system, description, options = {})
+  def inspect(system, description, _filter, options = {})
     group_content = system.read_file("/etc/group")
 
     groups = group_content ? parse_groups(group_content) : []

--- a/plugins/inspect/os_inspector.rb
+++ b/plugins/inspect/os_inspector.rb
@@ -38,7 +38,7 @@ class OsInspector < Inspector
     special_version ? " #{special_version.gsub(/[0-9]{1,2}/," \\0")}" : ""
   end
 
-  def inspect(system, description, _options = {})
+  def inspect(system, description, _filter, _options = {})
     system.check_requirement("cat", "--version") if system.is_a?(RemoteSystem)
 
     os = get_os(system)

--- a/plugins/inspect/packages_inspector.rb
+++ b/plugins/inspect/packages_inspector.rb
@@ -16,7 +16,7 @@
 # you may find current contact information at www.suse.com
 
 class PackagesInspector < Inspector
-  def inspect(system, description, options = {})
+  def inspect(system, description, _filter, options = {})
     system.check_requirement("rpm", "--version")
 
     packages = Array.new

--- a/plugins/inspect/patterns_inspector.rb
+++ b/plugins/inspect/patterns_inspector.rb
@@ -16,7 +16,7 @@
 # you may find current contact information at www.suse.com
 
 class PatternsInspector < Inspector
-  def inspect(system, description, options = {})
+  def inspect(system, description, _filter, options = {})
     if system.has_command?("zypper")
       inspect_with_zypper(system, description)
     else

--- a/plugins/inspect/repositories_inspector.rb
+++ b/plugins/inspect/repositories_inspector.rb
@@ -16,7 +16,7 @@
 # you may find current contact information at www.suse.com
 
 class RepositoriesInspector < Inspector
-  def inspect(system, description, options = {})
+  def inspect(system, description, _filter, options = {})
     if system.has_command?("zypper")
       description.repositories, summary = inspect_zypp_repositories(system)
     elsif system.has_command?("yum")

--- a/plugins/inspect/services_inspector.rb
+++ b/plugins/inspect/services_inspector.rb
@@ -16,7 +16,7 @@
 # you may find current contact information at www.suse.com
 
 class ServicesInspector < Inspector
-  def inspect(system, description, options = {})
+  def inspect(system, description, _filter, options = {})
     if system.has_command?("systemctl")
       result = ServicesScope.new(
         init_system: "systemd",

--- a/plugins/inspect/unmanaged_files_inspector.rb
+++ b/plugins/inspect/unmanaged_files_inspector.rb
@@ -241,7 +241,7 @@ class UnmanagedFilesInspector < Inspector
     # Information about services is extracted by the ServicesInspector, so
     # we ignore the links representing the same information when inspecting
     # unmanaged files.
-    ignore_list +=  [
+    ignore_list += [
       "/etc/init.d/boot.d",
       "/etc/init.d/rc0.d",
       "/etc/init.d/rc1.d",

--- a/plugins/inspect/users_inspector.rb
+++ b/plugins/inspect/users_inspector.rb
@@ -16,7 +16,7 @@
 # you may find current contact information at www.suse.com
 
 class UsersInspector < Inspector
-  def inspect(system, description, options = {})
+  def inspect(system, description, _filter, options = {})
     passwd = system.read_file("/etc/passwd")
     shadow = system.read_file("/etc/shadow")
 

--- a/spec/data/unmanaged_files/opensuse131
+++ b/spec/data/unmanaged_files/opensuse131
@@ -119,46 +119,6 @@
     Mode: 640
     Size: 284 B
 
-  * /etc/ssh/ssh_host_dsa_key (file)
-    User/Group: root:root
-    Mode: 600
-    Size: 668 B
-
-  * /etc/ssh/ssh_host_dsa_key.pub (file)
-    User/Group: root:root
-    Mode: 644
-    Size: 600 B
-
-  * /etc/ssh/ssh_host_ecdsa_key (file)
-    User/Group: root:root
-    Mode: 600
-    Size: 227 B
-
-  * /etc/ssh/ssh_host_ecdsa_key.pub (file)
-    User/Group: root:root
-    Mode: 644
-    Size: 172 B
-
-  * /etc/ssh/ssh_host_key (file)
-    User/Group: root:root
-    Mode: 600
-    Size: 975 B
-
-  * /etc/ssh/ssh_host_key.pub (file)
-    User/Group: root:root
-    Mode: 644
-    Size: 640 B
-
-  * /etc/ssh/ssh_host_rsa_key (file)
-    User/Group: root:root
-    Mode: 600
-    Size: 1.6 KiB
-
-  * /etc/ssh/ssh_host_rsa_key.pub (file)
-    User/Group: root:root
-    Mode: 644
-    Size: 392 B
-
   * /etc/sysconfig/autofs (file)
     User/Group: root:root
     Mode: 644

--- a/spec/data/unmanaged_files/opensuse132
+++ b/spec/data/unmanaged_files/opensuse132
@@ -78,56 +78,6 @@
     Mode: 640
     Size: 374 B
 
-  * /etc/ssh/ssh_host_dsa_key (file)
-    User/Group: root:root
-    Mode: 600
-    Size: 668 B
-
-  * /etc/ssh/ssh_host_dsa_key.pub (file)
-    User/Group: root:root
-    Mode: 644
-    Size: 600 B
-
-  * /etc/ssh/ssh_host_ecdsa_key (file)
-    User/Group: root:root
-    Mode: 600
-    Size: 227 B
-
-  * /etc/ssh/ssh_host_ecdsa_key.pub (file)
-    User/Group: root:root
-    Mode: 644
-    Size: 172 B
-
-  * /etc/ssh/ssh_host_ed25519_key (file)
-    User/Group: root:root
-    Mode: 600
-    Size: 399 B
-
-  * /etc/ssh/ssh_host_ed25519_key.pub (file)
-    User/Group: root:root
-    Mode: 644
-    Size: 92 B
-
-  * /etc/ssh/ssh_host_key (file)
-    User/Group: root:root
-    Mode: 600
-    Size: 975 B
-
-  * /etc/ssh/ssh_host_key.pub (file)
-    User/Group: root:root
-    Mode: 644
-    Size: 640 B
-
-  * /etc/ssh/ssh_host_rsa_key (file)
-    User/Group: root:root
-    Mode: 600
-    Size: 1.6 KiB
-
-  * /etc/ssh/ssh_host_rsa_key.pub (file)
-    User/Group: root:root
-    Mode: 644
-    Size: 392 B
-
   * /etc/sysconfig/backup (file)
     User/Group: root:root
     Mode: 644

--- a/spec/integration/support/inspect_unmanaged_files_examples.rb
+++ b/spec/integration/support/inspect_unmanaged_files_examples.rb
@@ -32,7 +32,7 @@ shared_examples "inspect unmanaged files" do |base|
     it "extracts list of unmanaged files" do
       measure("Inspect system") do
         @machinery.run_command(
-          "#{machinery_command} inspect #{@subject_system.ip} --scope=unmanaged-files --extract-files",
+          "#{machinery_command} inspect #{@subject_system.ip} --scope=unmanaged-files --skip-files=/etc/ssh --extract-files",
           as: "vagrant"
         )
       end
@@ -119,6 +119,15 @@ shared_examples "inspect unmanaged files" do |base|
       expect(entries).to_not include("  - /var/run")
       expect(entries).to_not include("  - /var/lib/rpm")
       expect(entries).to_not include("  - /.snapshots")
+    end
+
+    it "adheres to user provided filters" do
+      entries = @machinery.run_command(
+        "#{machinery_command} show #{@subject_system.ip} --scope=unmanaged-files",
+        as: "vagrant", stdout: :capture
+      )
+
+      expect(entries).to_not include("/etc/ssh")
     end
 
     it "extracts unmanaged files as tarballs" do

--- a/spec/unit/changed_managed_files_inspector_spec.rb
+++ b/spec/unit/changed_managed_files_inspector_spec.rb
@@ -24,6 +24,7 @@ describe ChangedManagedFilesInspector do
   let(:description) {
     SystemDescription.new("foo", SystemDescriptionStore.new)
   }
+  let(:filter) { nil }
   subject {
     inspector = ChangedManagedFilesInspector.new
 
@@ -38,7 +39,7 @@ describe ChangedManagedFilesInspector do
 
   describe "#inspect" do
     before(:each) do
-      subject.inspect(system, description)
+      subject.inspect(system, description, filter)
     end
 
     it "returns a list of all changed files" do

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -183,6 +183,21 @@ describe Cli do
         run_command(["inspect", "--exclude-scope=packages,repositories", example_host])
       end
 
+      it "forwards the --skip-files option to the InspectTask" do
+        expect_any_instance_of(InspectTask).to receive(:inspect_system).
+          with(
+            an_instance_of(SystemDescriptionStore),
+            example_host,
+            example_host,
+            an_instance_of(CurrentUser),
+            Inspector.all_scopes,
+            skip_files: "/foo/bar"
+          ).
+          and_return(description)
+
+        run_command(["inspect", "--skip-files=/foo/bar", example_host])
+      end
+
       describe "file extraction" do
         it "doesn't extract files when --extract-files is not specified" do
           expect_any_instance_of(InspectTask).to receive(:inspect_system).

--- a/spec/unit/config_files_inspector_spec.rb
+++ b/spec/unit/config_files_inspector_spec.rb
@@ -26,6 +26,7 @@ describe ConfigFilesInspector do
     let(:description) {
       SystemDescription.new(name, store)
     }
+    let(:filter) { nil }
 
     before(:each) do
       create_test_description(json: "{}", name: name, store: store).save
@@ -221,7 +222,7 @@ EOF
       expect_inspect_configfiles(system, false)
 
       inspector = ConfigFilesInspector.new
-      summary = inspector.inspect(system, description)
+      summary = inspector.inspect(system, description, filter)
 
       expect(description["config_files"]).to eq(expected_data)
       expect(summary).to include("6 changed configuration files")
@@ -237,7 +238,7 @@ EOF
       ).and_return("")
 
       inspector = ConfigFilesInspector.new
-      inspector.inspect(system, description)
+      inspector.inspect(system, description, filter)
 
       expected = ConfigFilesScope.new(
         extracted: false,
@@ -253,7 +254,7 @@ EOF
       ).and_raise(Machinery::Errors::MissingRequirement)
 
       inspector = ConfigFilesInspector.new
-      expect{inspector.inspect(system, description)}.to raise_error(
+      expect{inspector.inspect(system, description, filter)}.to raise_error(
         Machinery::Errors::MissingRequirement)
     end
 
@@ -262,7 +263,7 @@ EOF
       expect_inspect_configfiles(system, true)
 
       inspector = ConfigFilesInspector.new
-      summary = inspector.inspect(system, description, :extract_changed_config_files => true )
+      summary = inspector.inspect(system, description, filter, :extract_changed_config_files => true )
       expect(summary).to include("Extracted 6 changed configuration files")
       cfdir = File.join(store.description_path(name), "config_files")
       expect(File.stat(cfdir).mode & 0777).to eq(0700)
@@ -277,7 +278,7 @@ EOF
       expect_inspect_configfiles(system, true)
 
       inspector = ConfigFilesInspector.new
-      summary = inspector.inspect(system, description, :extract_changed_config_files => true)
+      summary = inspector.inspect(system, description, filter, :extract_changed_config_files => true)
       expect(summary).to include("Extracted 6 changed configuration files")
       expect(File.stat(cfdir).mode & 0777).to eq(0750)
     end
@@ -294,7 +295,7 @@ EOF
       expect(File.exists?(cfdir_file)).to be true
 
       inspector = ConfigFilesInspector.new
-      inspector.inspect(system, description)
+      inspector.inspect(system, description, filter)
 
       expect(File.exists?(cfdir_file)).to be false
     end
@@ -304,7 +305,7 @@ EOF
       expect_inspect_configfiles(system, true)
 
       inspector = ConfigFilesInspector.new
-      inspector.inspect(system, description, extract_changed_config_files: true )
+      inspector.inspect(system, description, filter, extract_changed_config_files: true )
 
       expect {
         JsonValidator.new(description.to_hash).validate
@@ -316,7 +317,7 @@ EOF
       expect_inspect_configfiles(system, true)
 
       inspector = ConfigFilesInspector.new
-      inspector.inspect(system, description, :extract_changed_config_files => true)
+      inspector.inspect(system, description, filter, :extract_changed_config_files => true)
       names = description["config_files"].files.map(&:name)
 
       expect(names).to eq(names.sort)

--- a/spec/unit/groups_inspector_spec.rb
+++ b/spec/unit/groups_inspector_spec.rb
@@ -21,6 +21,7 @@ describe GroupsInspector do
   let(:description) {
     SystemDescription.new("systemname", SystemDescriptionStore.new)
   }
+  let(:filter) { nil }
   let(:group_content) {
     <<-EOF.gsub(/^\s+/, "").gsub(/\s+$/, "\n")
       root:x:0:
@@ -59,7 +60,7 @@ describe GroupsInspector do
     it "return an empty list when /etc/group is missing" do
       expect(system).to receive(:read_file).with("/etc/group").and_return(nil)
 
-      summary = subject.inspect(system, description)
+      summary = subject.inspect(system, description, filter)
 
       expect(description.groups).to be_empty
       expect(summary).to eq("Found 0 groups.")
@@ -68,7 +69,7 @@ describe GroupsInspector do
     it "returns the groups" do
       expect(system).to receive(:read_file).with("/etc/group").and_return(group_content)
 
-      summary = subject.inspect(system, description)
+      summary = subject.inspect(system, description, filter)
       expect(description.groups).to eq(expected_groups)
       expect(summary).to eq("Found 3 groups.")
     end
@@ -76,14 +77,14 @@ describe GroupsInspector do
     it "can handle a missing newline at the end in /etc/group" do
       expect(system).to receive(:read_file).with("/etc/group").and_return(group_content.chomp)
 
-      summary = subject.inspect(system, description)
+      summary = subject.inspect(system, description, filter)
       expect(description.groups).to eq(expected_groups)
     end
 
     it "returns sorted data" do
       expect(system).to receive(:read_file).with("/etc/group").and_return(group_content)
 
-      subject.inspect(system, description)
+      subject.inspect(system, description, filter)
       names = description.groups.map(&:name)
       expect(names).to eq(names.sort)
     end

--- a/spec/unit/inspect_task_spec.rb
+++ b/spec/unit/inspect_task_spec.rb
@@ -59,7 +59,6 @@ describe InspectTask, "#inspect_system" do
     )
   }
 
-
   let(:current_user_root) {
     current_user = double
     allow(current_user).to receive(:is_root?).and_return(true)
@@ -94,6 +93,27 @@ describe InspectTask, "#inspect_system" do
     )
 
     expect(description.foo).to eql(SimpleInspectTaskScope.new("bar" => "baz"))
+  end
+
+  describe "with the :skip_files option" do
+    it "maps it to an unmanaged_files filter" do
+      expect_any_instance_of(FooInspector).
+        to receive(:inspect) do |_inspector, _description, _system, options|
+        filter = options[:filter]
+        expect(filter.element_filters.length).to eq(1)
+        expect(filter.element_filters["/unmanaged_files/files/name"].matchers).
+          to eq(["/foo/bar"])
+      end.and_call_original
+
+      inspect_task.inspect_system(
+        store,
+        host,
+        name,
+        current_user_non_root,
+        ["foo"],
+        skip_files: "/foo/bar"
+      )
+    end
   end
 
   describe "in case of inspection errors" do

--- a/spec/unit/inspect_task_spec.rb
+++ b/spec/unit/inspect_task_spec.rb
@@ -27,7 +27,7 @@ describe InspectTask, "#inspect_system" do
   end
 
   class FooInspector < Inspector
-    def inspect(_system, description, _options = nil)
+    def inspect(_system, description, _filter, _options = nil)
       result = SimpleInspectTaskScope.new("bar" => "baz")
 
       description.foo = result
@@ -36,7 +36,7 @@ describe InspectTask, "#inspect_system" do
   end
 
   class BarInspector < Inspector
-    def inspect(_system, description, _options = nil)
+    def inspect(_system, description, _filter, _options = nil)
       result = SimpleInspectTaskScope.new("bar" => "baz")
 
       description.bar = result

--- a/spec/unit/os_inspector_spec.rb
+++ b/spec/unit/os_inspector_spec.rb
@@ -24,6 +24,7 @@ describe OsInspector do
     SystemDescription.new("systemname", SystemDescriptionStore.new)
   }
   let(:system) { LocalSystem.new }
+  let(:filter) { nil }
   subject(:inspector) { OsInspector.new }
 
   before(:each) do
@@ -101,7 +102,7 @@ describe OsInspector do
 
       expect(inspector).to receive(:get_arch).with(system).and_return("x86_64")
 
-      summary = inspector.inspect(system, description)
+      summary = inspector.inspect(system, description, filter)
 
       expect(description.os).to eq(
         OsOpenSuse13_1.new(
@@ -119,7 +120,7 @@ describe OsInspector do
 
       expect(inspector).to receive(:get_arch).with(system).and_return("x86_64")
 
-      summary = inspector.inspect(system, description)
+      summary = inspector.inspect(system, description, filter)
 
       expect(description.os.name).to eq "Red Hat Enterprise Linux Server"
       expect(description.os.version).to eq "6.5 (Santiago)"
@@ -133,7 +134,7 @@ describe OsInspector do
 
       expect(inspector).to receive(:get_arch).with(system).and_return("x86_64")
 
-      summary = inspector.inspect(system, description)
+      summary = inspector.inspect(system, description, filter)
 
       expect(description.os.name).to eq "SUSE Linux Enterprise Server 11"
       expect(description.os.version).to eq "11 SP3"
@@ -149,7 +150,7 @@ describe OsInspector do
 
       expect(inspector).to receive(:get_arch).with(system).and_return("x86_64")
 
-      inspector.inspect(system, description)
+      inspector.inspect(system, description, filter)
 
       expect(description.os.version).to eq("12 Beta 1")
     end
@@ -162,7 +163,7 @@ describe OsInspector do
 
       expect(inspector).to receive(:get_arch).with(system).and_return("x86_64")
 
-      inspector.inspect(system, description)
+      inspector.inspect(system, description, filter)
 
       expect(description.os.version).to eq("11 SP3 Beta 10")
     end
@@ -175,7 +176,7 @@ describe OsInspector do
 
       expect(inspector).to receive(:get_arch).with(system).and_return("i586")
 
-      inspector.inspect(system, description)
+      inspector.inspect(system, description, filter)
 
       expect(description.os.version).to eq("11.2")
       expect(description.os.name).to eq("openSUSE 11.2")
@@ -183,7 +184,7 @@ describe OsInspector do
 
     it "throws exception when the operation system cannot be determined" do
       expect {
-        inspector.inspect(system, description)
+        inspector.inspect(system, description, filter)
       }.to raise_error(Machinery::Errors::UnknownOs)
     end
   end

--- a/spec/unit/packages_inspector_spec.rb
+++ b/spec/unit/packages_inspector_spec.rb
@@ -21,6 +21,7 @@ describe PackagesInspector, ".inspect" do
   let(:description) {
     SystemDescription.new("systemname", SystemDescriptionStore.new)
   }
+  let(:filter) { nil }
   let(:packages_inspector) { PackagesInspector.new }
 
   let(:package_example) { <<EOF
@@ -64,7 +65,7 @@ EOF
 
     expect(system).to receive(:run_command) { data }
 
-    inspector.inspect(system, description)
+    inspector.inspect(system, description, filter)
     description.packages
   end
 
@@ -86,7 +87,7 @@ EOF
     expect(system).to receive(:check_requirement) { true }
     expect(system).to receive(:run_command) { package_example }
 
-    summary = packages_inspector.inspect(system, description)
+    summary = packages_inspector.inspect(system, description, filter)
     expect(summary).to include("Found 2 packages")
   end
 

--- a/spec/unit/repositories_inspector_spec.rb
+++ b/spec/unit/repositories_inspector_spec.rb
@@ -25,6 +25,7 @@ describe RepositoriesInspector do
   let(:description) {
     SystemDescription.new("systemname", SystemDescriptionStore.new)
   }
+  let(:filter) { nil }
 
   describe "zypper repositories" do
     let(:zypper_output_xml) {
@@ -188,7 +189,7 @@ password=2fdcb7499fd46842
       ).and_return(scc_credentials)
 
       inspector = RepositoriesInspector.new
-      summary = inspector.inspect(system, description)
+      summary = inspector.inspect(system, description, filter)
       expect(description.repositories).to match_array(expected_repo_list)
       expect(summary).to include("Found 4 repositories")
     end
@@ -208,7 +209,7 @@ password=2fdcb7499fd46842
       setup_expectation_zypper_details(system, zypper_empty_output_details)
 
       inspector = RepositoriesInspector.new
-      summary = inspector.inspect(system, description)
+      summary = inspector.inspect(system, description, filter)
       expect(description.repositories).to eq(RepositoriesScope.new([]))
       expect(summary).to include("Found 0 repositories")
     end
@@ -226,7 +227,7 @@ password=2fdcb7499fd46842
       setup_expectation_zypper_details_exit_6(system)
 
       inspector = RepositoriesInspector.new
-      summary = inspector.inspect(system, description)
+      summary = inspector.inspect(system, description, filter)
       expect(description.repositories).to eq(RepositoriesScope.new([]))
       expect(summary).to include("Found 0 repositories")
     end
@@ -236,7 +237,7 @@ password=2fdcb7499fd46842
       allow(system).to receive(:has_command?).with("yum").and_return(false)
 
       inspector = RepositoriesInspector.new
-      expect { inspector.inspect(system, description) }.to raise_error(
+      expect { inspector.inspect(system, description, filter) }.to raise_error(
         Machinery::Errors::MissingRequirement, /Need either the binary 'zypper' or 'yum'/
       )
     end
@@ -250,7 +251,7 @@ password=2fdcb7499fd46842
 
       inspector = RepositoriesInspector.new
 
-      inspector.inspect(system, description)
+      inspector.inspect(system, description, filter)
       names = description.repositories.map(&:name)
 
       expect(names).to eq(names.sort)
@@ -309,7 +310,7 @@ EOF
       expect(system).to receive(:run_command).and_return(expected_yum_extractor_output)
 
       inspector = RepositoriesInspector.new
-      summary = inspector.inspect(system, description)
+      summary = inspector.inspect(system, description, filter)
       expect(description.repositories).to match_array(expected_yum_repo_list)
       expect(summary).to include("Found 2 repositories")
     end
@@ -318,7 +319,7 @@ EOF
       expect(system).to receive(:run_command).and_return(faulty_yum_extractor_output)
 
       inspector = RepositoriesInspector.new
-      expect { inspector.inspect(system, description) }.to raise_error(
+      expect { inspector.inspect(system, description, filter) }.to raise_error(
         Machinery::Errors::InspectionFailed, /Extraction of YUM repositories failed./
       )
     end
@@ -328,7 +329,7 @@ EOF
       expect(system).to receive(:run_command).and_return(unsupported_metalink_repo)
 
       inspector = RepositoriesInspector.new
-      expect { inspector.inspect(system, description) }.to raise_error(
+      expect { inspector.inspect(system, description, filter) }.to raise_error(
         Machinery::Errors::InspectionFailed, /Yum repository baseurl is missing/
       )
     end

--- a/spec/unit/services_inspector_spec.rb
+++ b/spec/unit/services_inspector_spec.rb
@@ -24,6 +24,7 @@ describe ServicesInspector do
     let(:description) {
       SystemDescription.new("systemname", SystemDescriptionStore.new)
     }
+    let(:filter) { nil }
 
     let(:systemctl_list_unit_files_output) {
       <<-EOF
@@ -50,7 +51,7 @@ EOF
         ).
         and_return(systemctl_list_unit_files_output)
 
-      summary = inspector.inspect(system, description)
+      summary = inspector.inspect(system, description, filter)
 
       expect(description.services).to eq(ServicesScope.new(
         init_system: "systemd",
@@ -77,7 +78,7 @@ EOF
           Service.new(name: "autofs",      state: "off"),
           Service.new(name: "boot.isapnp", state: "on")])
 
-      summary = inspector.inspect(system, description)
+      summary = inspector.inspect(system, description, filter)
 
       expect(description.services).to eq(ServicesScope.new(
         init_system: "sysvinit",
@@ -102,7 +103,7 @@ EOF
         and_raise(Machinery::Errors::MissingRequirement)
 
       expect {
-        inspector.inspect(system, description)
+        inspector.inspect(system, description, filter)
       }.to raise_error(Machinery::Errors::MissingRequirement)
     end
 
@@ -117,7 +118,7 @@ EOF
           Service.new(name: "crond", state: "on"),
           Service.new(name: "dnsmasq", state: "off")])
 
-      summary = inspector.inspect(system, description)
+      summary = inspector.inspect(system, description, filter)
 
       expect(description.services).to eq(ServicesScope.new(
         init_system: "sysvinit",

--- a/spec/unit/unmanaged_files_inspector_spec.rb
+++ b/spec/unit/unmanaged_files_inspector_spec.rb
@@ -318,7 +318,7 @@ describe UnmanagedFilesInspector do
       system = double
       expect_inspect_unmanaged(system, false, false)
 
-      summary = subject.inspect(system, description)
+      summary = subject.inspect(system, description, nil)
 
       expected = UnmanagedFilesScope.new(
         extracted: false,
@@ -333,7 +333,7 @@ describe UnmanagedFilesInspector do
 
       expect_inspect_unmanaged(system, true, false)
 
-      summary = subject.inspect(system, description)
+      summary = subject.inspect(system, description, nil)
 
       expect(description["unmanaged_files"]).to eq(expected_data)
       expect(summary).to include("Found #{expected_data.files.size} unmanaged files and trees")
@@ -344,7 +344,7 @@ describe UnmanagedFilesInspector do
 
       expect_inspect_unmanaged(system, true, false)
 
-      subject.inspect(system, description)
+      subject.inspect(system, description, nil)
       names = description["unmanaged_files"].files.map(&:name)
 
       expect(names).to eq(names.sort)
@@ -356,7 +356,7 @@ describe UnmanagedFilesInspector do
       expect_inspect_unmanaged(system, true, false, ["/usr/local"])
 
       filter = Filter.new("/unmanaged_files/files/name=/usr/local/*")
-      subject.inspect(system, description, filter: filter)
+      subject.inspect(system, description, filter)
       names = description["unmanaged_files"].files.map(&:name)
 
       expect(names).to eq(names.sort)
@@ -368,7 +368,7 @@ describe UnmanagedFilesInspector do
       expect_inspect_unmanaged(system, true, false, ["/usr/local", "/etc/skel/.config"])
 
       filter = Filter.new("/unmanaged_files/files/name=/usr/local/*,/etc/skel/.config")
-      subject.inspect(system, description, filter: filter)
+      subject.inspect(system, description, filter)
       names = description["unmanaged_files"].files.map(&:name)
 
       expect(names).to eq(names.sort)
@@ -380,7 +380,7 @@ describe UnmanagedFilesInspector do
         "rpm", "--version"
       ).and_raise(Machinery::Errors::MissingRequirement)
 
-      expect{subject.inspect(system, description)}.to raise_error(
+      expect{subject.inspect(system, description, nil)}.to raise_error(
         Machinery::Errors::MissingRequirement)
     end
 
@@ -389,7 +389,7 @@ describe UnmanagedFilesInspector do
       expect_inspect_unmanaged(system, true, true)
 
       summary = subject.inspect(
-        system, description,
+        system, description, nil,
         :extract_unmanaged_files => true
       )
 
@@ -403,7 +403,7 @@ describe UnmanagedFilesInspector do
       system = double
       expect_inspect_unmanaged(system, true, true)
 
-      subject.inspect(system, description, extract_unmanaged_files: true)
+      subject.inspect(system, description, nil, extract_unmanaged_files: true)
 
       json_hash = JSON.parse(description.to_json)
       expect {

--- a/spec/unit/users_inspector_spec.rb
+++ b/spec/unit/users_inspector_spec.rb
@@ -32,6 +32,7 @@ lp:*:16125:1:2:3:4:5
 EOF
   }
   let(:system) { double }
+  let(:filter) { nil }
   subject { UsersInspector.new }
 
   describe "#inspect" do
@@ -39,7 +40,7 @@ EOF
       expect(system).to receive(:read_file).with("/etc/passwd").and_return(nil)
       expect(system).to receive(:read_file).with("/etc/shadow").and_return(nil)
 
-      summary = subject.inspect(system, description)
+      summary = subject.inspect(system, description, filter)
       expect(description.users).to be_empty
       expect(summary).to eq("Found 0 users.")
     end
@@ -78,7 +79,7 @@ EOF
         )
       ])
 
-      summary = subject.inspect(system, description)
+      summary = subject.inspect(system, description, filter)
 
       expect(description.users).to eq(expected)
       expect(summary).to eq("Found 2 users.")
@@ -104,7 +105,7 @@ EOF
         )
       ])
 
-      summary = subject.inspect(system, description)
+      summary = subject.inspect(system, description, filter)
 
       expect(description.users).to eq(expected)
     end
@@ -134,7 +135,7 @@ EOF
         )
       ])
 
-      summary = subject.inspect(system, description)
+      summary = subject.inspect(system, description, filter)
 
       expect(description.users).to eq(expected)
       expect(summary).to eq("Found 2 users.")
@@ -144,7 +145,7 @@ EOF
       expect(system).to receive(:read_file).with("/etc/passwd").and_return(passwd_content)
       expect(system).to receive(:read_file).with("/etc/shadow").and_return(nil)
 
-      subject.inspect(system, description)
+      subject.inspect(system, description, filter)
       names = description.users.map(&:name)
       expect(names).to eq(names.sort)
     end


### PR DESCRIPTION
Please review the following changes:
  * 6c4e4f0 Add changelog entry for the --skip-files option
  * 9c9f52d Document --skip-files option in man page
  * 5b68305 Test "--skip-files" option in the unmanaged files integration test
  * f0d9fdc Show warning when filtering with a scope which doesn't support it yet
  * 403d231 Implement "--skip-files" option for "machinery inspect"
  * 2dac6d1 Make UnmanagedFilesInspector adhere to given filters