### PR TITLE
[Review] Request from 'tgoettlicher' @ 'SUSE/machinery/review_150304_don_t_extract_the_root_directory_as_changed_managed_file'

### DIFF
--- a/plugins/inspect/changed_managed_files_inspector.rb
+++ b/plugins/inspect/changed_managed_files_inspector.rb
@@ -38,7 +38,7 @@ class ChangedManagedFilesInspector < Inspector
 
       existing_files = changed_files.reject do |f|
         f.changes.nil? ||
-        f.changes.include?("deleted")
+        f.changes.include?("deleted") ||
         f.name == "/"
       end
 

--- a/plugins/inspect/changed_managed_files_inspector.rb
+++ b/plugins/inspect/changed_managed_files_inspector.rb
@@ -35,7 +35,13 @@ class ChangedManagedFilesInspector < Inspector
     file_store.remove
     if options[:extract_changed_managed_files]
       file_store.create
-      existing_files = changed_files.reject { |f| f.changes.nil? || f.changes.include?("deleted") }
+
+      existing_files = changed_files.reject do |f|
+        f.changes.nil? ||
+        f.changes.include?("deleted")
+        f.name == "/"
+      end
+
       system.retrieve_files(existing_files.map(&:name), file_store.path)
     end
 


### PR DESCRIPTION
Please review the following changes:
  * 589eea9 Don't extract the root directory as changed managed file
  * 331c54d Don't extract the root directory as changed managed file
  * cd95bbf Merge pull request #663 from SUSE/fix_integration_test