### PR TITLE
Don't extract the root directory as changed managed file

### DIFF
--- a/plugins/inspect/changed_managed_files_inspector.rb
+++ b/plugins/inspect/changed_managed_files_inspector.rb
@@ -35,7 +35,13 @@ class ChangedManagedFilesInspector < Inspector
     file_store.remove
     if options[:extract_changed_managed_files]
       file_store.create
-      existing_files = changed_files.reject { |f| f.changes.nil? || f.changes.include?("deleted") }
+
+      existing_files = changed_files.reject do |f|
+        f.changes.nil? ||
+        f.changes.include?("deleted") ||
+        f.name == "/"
+      end
+
       system.retrieve_files(existing_files.map(&:name), file_store.path)
     end
 


### PR DESCRIPTION
If the mode of the root directory ('/') has changed we don't want to
extract the root directory because this will lead to extraction of
its sub-directories. This approach excludes the root directory from
extraction, the meta information is still stored in the manifest.