### PR TITLE
[Review] Request from 'aduffeck' @ 'SUSE/machinery/review_150306_store_used_filter_in_description'

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -456,8 +456,16 @@ class Cli
         inspect_options[:extract_unmanaged_files] = true
       end
 
+      filter_definition = ""
+
       inspector_task.inspect_system(
-        system_description_store, host, name, CurrentUser.new, scope_list, inspect_options
+        system_description_store,
+        host,
+        name,
+        CurrentUser.new,
+        scope_list,
+        filter_definition,
+        inspect_options
       )
 
       Hint.show_data(name: name)

--- a/lib/filter.rb
+++ b/lib/filter.rb
@@ -1,17 +1,17 @@
 class Filter
   attr_accessor :element_filters
 
-  def initialize(filter_definition = "")
-    @element_filters = parse_filter_definition(filter_definition)
-  end
-
-  def parse_filter_definition(filter_definition)
+  def self.parse_filter_definition(filter_definition)
     element_filters = {}
     filter_definition.scan(/\"?([^,]*?)=([^\"]*)\"?,?/).each do |path, matcher_definition|
       element_filters[path] = ElementFilter.new(path, matcher_definition.split(","))
     end
 
     element_filters
+  end
+
+  def initialize(filter_definition = "")
+    @element_filters = Filter.parse_filter_definition(filter_definition)
   end
 
   def matches?(path, value)

--- a/lib/filter.rb
+++ b/lib/filter.rb
@@ -3,7 +3,7 @@ class Filter
 
   def self.parse_filter_definition(filter_definition)
     element_filters = {}
-    filter_definition.scan(/\"?([^,]*?)=([^\"]*)\"?,?/).each do |path, matcher_definition|
+    filter_definition.scan(/\"([^,]*?)=([^\"]*)\"|([^,]+)=([^,]*)/).map(&:compact).each do |path, matcher_definition|
       element_filters[path] = ElementFilter.new(path, matcher_definition.split(","))
     end
 

--- a/lib/filter.rb
+++ b/lib/filter.rb
@@ -14,6 +14,15 @@ class Filter
     @element_filters = Filter.parse_filter_definition(filter_definition)
   end
 
+  def add_filter_definition(filter_definition)
+    new_element_filters = Filter.parse_filter_definition(filter_definition)
+
+    new_element_filters.each do |path, element_filter|
+      @element_filters[path] ||= ElementFilter.new(path)
+      @element_filters[path].add_matchers(element_filter.matchers)
+    end
+  end
+
   def matches?(path, value)
     filter = element_filter_for(path)
     return false if !filter

--- a/lib/filter.rb
+++ b/lib/filter.rb
@@ -23,6 +23,12 @@ class Filter
     end
   end
 
+  def to_array
+    @element_filters.map do |path, element_filter|
+      "#{path}=#{element_filter.matchers.join(",")}"
+    end
+  end
+
   def matches?(path, value)
     filter = element_filter_for(path)
     return false if !filter

--- a/lib/filter.rb
+++ b/lib/filter.rb
@@ -3,8 +3,9 @@ class Filter
 
   def self.parse_filter_definition(filter_definition)
     element_filters = {}
-    filter_definition.scan(/\"([^,]*?)=([^\"]*)\"|([^,]+)=([^,]*)/).map(&:compact).each do |path, matcher_definition|
-      element_filters[path] = ElementFilter.new(path, matcher_definition.split(","))
+    filter_definition.scan(/\"([^,]*?)=([^\"]*)\"|([^,]+)=([^,]*)/).
+      map(&:compact).each do |path, matcher_definition|
+        element_filters[path] = ElementFilter.new(path, matcher_definition.split(","))
     end
 
     element_filters

--- a/lib/filter.rb
+++ b/lib/filter.rb
@@ -23,6 +23,10 @@ class Filter
     end
   end
 
+  def add_element_filter(element_filter)
+    @element_filters[element_filter.path] = element_filter
+  end
+
   def to_array
     @element_filters.map do |path, element_filter|
       "#{path}=#{element_filter.matchers.join(",")}"

--- a/lib/inspect_task.rb
+++ b/lib/inspect_task.rb
@@ -21,7 +21,8 @@ class InspectTask
     check_root(system, current_user)
 
     filter = prepare_filter(filter_definition, options)
-    description, failed_inspections = build_description(store, name, system, scopes, filter, options)
+    description, failed_inspections = build_description(store, name, system,
+      scopes, filter, options)
 
     if !description.attributes.empty?
       print_description(description, scopes) if options[:show]

--- a/schema/v3/system-description-global.schema.json
+++ b/schema/v3/system-description-global.schema.json
@@ -10,6 +10,18 @@
         "format_version": {
           "type": "integer",
           "minimum": 1
+        },
+        "filters": {
+          "type": "object",
+          "required": ["inspect"],
+          "properties": {
+            "inspect": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
         }
       },
       "additionalProperties": {

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -81,6 +81,7 @@ describe Cli do
             example_host,
             an_instance_of(CurrentUser),
             Inspector.all_scopes,
+            "",
             {}
           ).
           and_return(description)
@@ -97,6 +98,7 @@ describe Cli do
             name,
             an_instance_of(CurrentUser),
             Inspector.all_scopes,
+            "",
             {}
            ).
            and_return(description)
@@ -112,6 +114,7 @@ describe Cli do
             example_host,
             an_instance_of(CurrentUser),
             Inspector.all_scopes,
+            "",
             {}
            ).
           and_return(description)
@@ -127,6 +130,7 @@ describe Cli do
             example_host,
             an_instance_of(CurrentUser),
             ["packages", "repositories"],
+            "",
             {}
           ).
           and_return(description)
@@ -142,6 +146,7 @@ describe Cli do
             example_host,
             an_instance_of(CurrentUser),
             ["packages"],
+            "",
             {}
           ).
           and_return(description)
@@ -157,6 +162,7 @@ describe Cli do
             example_host,
             an_instance_of(CurrentUser),
             Inspector.all_scopes,
+            "",
             {}
           ).
           and_return(description)
@@ -176,6 +182,7 @@ describe Cli do
             example_host,
             an_instance_of(CurrentUser),
             scope_list,
+            "",
             {}
           ).
           and_return(description)
@@ -191,6 +198,7 @@ describe Cli do
             example_host,
             an_instance_of(CurrentUser),
             Inspector.all_scopes,
+            "",
             skip_files: "/foo/bar"
           ).
           and_return(description)
@@ -207,6 +215,7 @@ describe Cli do
               example_host,
               an_instance_of(CurrentUser),
               Inspector.all_scopes,
+              "",
               {}
             ).
             and_return(description)
@@ -222,6 +231,7 @@ describe Cli do
               example_host,
               an_instance_of(CurrentUser),
               Inspector.all_scopes,
+              "",
               :extract_changed_config_files=>true, :extract_unmanaged_files=>true, :extract_changed_managed_files=>true
             ).
             and_return(description)
@@ -237,6 +247,7 @@ describe Cli do
               example_host,
               an_instance_of(CurrentUser),
               Inspector.all_scopes,
+              "",
               :extract_changed_config_files=>true
             ).
             and_return(description)
@@ -252,6 +263,7 @@ describe Cli do
               example_host,
               an_instance_of(CurrentUser),
               Inspector.all_scopes,
+              "",
               :extract_unmanaged_files=>true
             ).
             and_return(description)

--- a/spec/unit/filter_spec.rb
+++ b/spec/unit/filter_spec.rb
@@ -76,6 +76,15 @@ describe Filter do
     end
   end
 
+  describe "#to_array" do
+    it "returns the element filter definitions as a string array" do
+      filter = Filter.new("\"foo=bar,baz\",scope=matcher")
+      expect(filter.to_array).to eq([
+        "foo=bar,baz", "scope=matcher"
+      ])
+    end
+  end
+
   describe "#filter_for" do
     it "returns the correct filter" do
       filter = Filter.new(complex_definition)

--- a/spec/unit/filter_spec.rb
+++ b/spec/unit/filter_spec.rb
@@ -8,6 +8,30 @@ describe Filter do
       "/changed_managed_files/files/name=/usr/lib/something"
   }
 
+  describe ".parse_filter_definition" do
+    it "parses element filter containing multiple matcher" do
+      filters = Filter.parse_filter_definition(definition2)
+
+      expect(filters.keys.length).to eq(1)
+      expect(filters["/unmanaged_files/files/name"].path).to eq("/unmanaged_files/files/name")
+      expect(filters["/unmanaged_files/files/name"].matchers).to eq(["/home/alfred", "/var/cache"])
+    end
+
+    it "parses element filter with multiple filters" do
+      element_filter = Filter.parse_filter_definition(complex_definition)
+
+      expect(element_filter.keys.length).to eq(2)
+      expect(element_filter["/unmanaged_files/files/name"].path).
+        to eq("/unmanaged_files/files/name")
+      expect(element_filter["/unmanaged_files/files/name"].matchers).
+        to eq(["/home/alfred", "/var/cache"])
+      expect(element_filter["/changed_managed_files/files/name"].path).
+        to eq("/changed_managed_files/files/name")
+      expect(element_filter["/changed_managed_files/files/name"].matchers).
+        to eq(["/usr/lib/something"])
+    end
+  end
+
   describe "#initialize" do
     it "creates Filter" do
       filter = Filter.new
@@ -20,30 +44,6 @@ describe Filter do
       expect(filters.keys.length).to eq(1)
       expect(filters["/unmanaged_files/files/name"].path).to eq("/unmanaged_files/files/name")
       expect(filters["/unmanaged_files/files/name"].matchers).to eq(["/home/alfred"])
-    end
-  end
-
-  describe "#parse_filter_definition" do
-    it "parses element filter containing multiple matcher" do
-      filters = subject.parse_filter_definition(definition2)
-
-      expect(filters.keys.length).to eq(1)
-      expect(filters["/unmanaged_files/files/name"].path).to eq("/unmanaged_files/files/name")
-      expect(filters["/unmanaged_files/files/name"].matchers).to eq(["/home/alfred", "/var/cache"])
-    end
-
-    it "parses element filter with multiple filters" do
-      element_filter = subject.parse_filter_definition(complex_definition)
-
-      expect(element_filter.keys.length).to eq(2)
-      expect(element_filter["/unmanaged_files/files/name"].path).
-        to eq("/unmanaged_files/files/name")
-      expect(element_filter["/unmanaged_files/files/name"].matchers).
-        to eq(["/home/alfred", "/var/cache"])
-      expect(element_filter["/changed_managed_files/files/name"].path).
-        to eq("/changed_managed_files/files/name")
-      expect(element_filter["/changed_managed_files/files/name"].matchers).
-        to eq(["/usr/lib/something"])
     end
   end
 

--- a/spec/unit/filter_spec.rb
+++ b/spec/unit/filter_spec.rb
@@ -2,7 +2,8 @@ require_relative "spec_helper"
 
 describe Filter do
   let(:definition1) { "/unmanaged_files/files/name=/home/alfred" }
-  let(:definition2) { "/unmanaged_files/files/name=/home/alfred,/var/cache" }
+  let(:definition2) { "\"/unmanaged_files/files/name=/home/alfred,/var/cache\"" }
+  let(:simple_list_definition) { "/foo=bar,/baz=qux"}
   let(:complex_definition) {
     "\"/unmanaged_files/files/name=/home/alfred,/var/cache\"," +
       "/changed_managed_files/files/name=/usr/lib/something"
@@ -30,6 +31,15 @@ describe Filter do
       expect(element_filter["/changed_managed_files/files/name"].matchers).
         to eq(["/usr/lib/something"])
     end
+
+    it "parses simple lists" do
+      element_filter = Filter.parse_filter_definition(simple_list_definition)
+      expect(element_filter.keys.length).to eq(2)
+      expect(element_filter["/foo"].matchers).
+        to eq(["bar"])
+      expect(element_filter["/baz"].matchers).
+        to eq(["qux"])
+    end
   end
 
   describe "#initialize" do
@@ -49,7 +59,7 @@ describe Filter do
 
   describe "#add_filter_definition" do
     it "adds definitions" do
-      filter = Filter.new("foo=bar,baz")
+      filter = Filter.new("\"foo=bar,baz\"")
       filter.add_filter_definition("bar=baz")
 
       element_filters = filter.element_filters
@@ -58,7 +68,7 @@ describe Filter do
     end
 
     it "merges new definitions with existing element filter" do
-      filter = Filter.new("foo=bar,baz")
+      filter = Filter.new("\"foo=bar,baz\"")
       filter.add_filter_definition("foo=qux")
 
       element_filters = filter.element_filters

--- a/spec/unit/filter_spec.rb
+++ b/spec/unit/filter_spec.rb
@@ -47,6 +47,25 @@ describe Filter do
     end
   end
 
+  describe "#add_filter_definition" do
+    it "adds definitions" do
+      filter = Filter.new("foo=bar,baz")
+      filter.add_filter_definition("bar=baz")
+
+      element_filters = filter.element_filters
+      expect(element_filters["foo"].matchers).to eq(["bar", "baz"])
+      expect(element_filters["bar"].matchers).to eq(["baz"])
+    end
+
+    it "merges new definitions with existing element filter" do
+      filter = Filter.new("foo=bar,baz")
+      filter.add_filter_definition("foo=qux")
+
+      element_filters = filter.element_filters
+      expect(element_filters["foo"].matchers).to eq(["bar", "baz", "qux"])
+    end
+  end
+
   describe "#filter_for" do
     it "returns the correct filter" do
       filter = Filter.new(complex_definition)

--- a/spec/unit/filter_spec.rb
+++ b/spec/unit/filter_spec.rb
@@ -3,7 +3,7 @@ require_relative "spec_helper"
 describe Filter do
   let(:definition1) { "/unmanaged_files/files/name=/home/alfred" }
   let(:definition2) { "\"/unmanaged_files/files/name=/home/alfred,/var/cache\"" }
-  let(:simple_list_definition) { "/foo=bar,/baz=qux"}
+  let(:simple_list_definition) { "/foo=bar,/baz=qux" }
   let(:complex_definition) {
     "\"/unmanaged_files/files/name=/home/alfred,/var/cache\"," +
       "/changed_managed_files/files/name=/usr/lib/something"

--- a/spec/unit/inspect_task_spec.rb
+++ b/spec/unit/inspect_task_spec.rb
@@ -74,13 +74,13 @@ describe InspectTask, "#inspect_system" do
   it "runs the proper inspector when a scope is given" do
     expect(Inspector).to receive(:for).with("foo").and_return(FooInspector.new)
 
-    inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"])
+    inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"], "")
   end
 
   it "saves the inspection data after each inspection and not just at the end" do
     expect_any_instance_of(SystemDescription).to receive(:save).twice
 
-    inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo", "bar"])
+    inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo", "bar"], "")
   end
 
   it "creates a proper system description" do
@@ -89,31 +89,11 @@ describe InspectTask, "#inspect_system" do
       host,
       name,
       current_user_non_root,
-      ["foo"]
+      ["foo"],
+      ""
     )
 
     expect(description.foo).to eql(SimpleInspectTaskScope.new("bar" => "baz"))
-  end
-
-  describe "with the :skip_files option" do
-    it "maps it to an unmanaged_files filter" do
-      expect_any_instance_of(FooInspector).
-        to receive(:inspect) do |_inspector, _description, _system, options|
-        filter = options[:filter]
-        expect(filter.element_filters.length).to eq(1)
-        expect(filter.element_filters["/unmanaged_files/files/name"].matchers).
-          to eq(["/foo/bar"])
-      end.and_call_original
-
-      inspect_task.inspect_system(
-        store,
-        host,
-        name,
-        current_user_non_root,
-        ["foo"],
-        skip_files: "/foo/bar"
-      )
-    end
   end
 
   describe "in case of inspection errors" do
@@ -124,7 +104,7 @@ describe InspectTask, "#inspect_system" do
         and_raise(Machinery::Errors::SshConnectionFailed, "This is an SSH error")
 
       expect {
-        inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"])
+        inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"], "")
       }.to raise_error(
         Machinery::Errors::InspectionFailed,
         /Errors while inspecting foo:\n -> This is an SSH error/
@@ -142,7 +122,7 @@ Inspecting foo...
       expect_any_instance_of(FooInspector).to receive(:inspect).and_raise(RuntimeError)
 
       expect {
-        inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"])
+        inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"], "")
       }.to raise_error(RuntimeError)
     end
   end
@@ -155,7 +135,7 @@ Inspecting foo...
 
       it "raises an exception we don't run as root" do
         expect {
-          inspect_task.inspect_system(store, "localhost", name, current_user_non_root, ["foo"])
+          inspect_task.inspect_system(store, "localhost", name, current_user_non_root, ["foo"], "")
         }.to raise_error(Machinery::Errors::MissingRequirement)
       end
 
@@ -163,7 +143,7 @@ Inspecting foo...
         allow(Inspector).to receive(:all) { [] }
 
         expect {
-          inspect_task.inspect_system(store, "localhost", name, current_user_root, ["foo"])
+          inspect_task.inspect_system(store, "localhost", name, current_user_root, ["foo"], "")
         }.not_to raise_error
       end
     end
@@ -177,9 +157,96 @@ Inspecting foo...
         allow(Inspector).to receive(:all) { [] }
 
         expect {
-          inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"])
+          inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"], "")
         }.not_to raise_error
       end
+    end
+  end
+
+  describe "with the :skip_files option" do
+    it "maps it to an unmanaged_files filter" do
+      inspector = FooInspector.new
+      expect(Inspector).to receive(:for).and_return(inspector)
+
+      expect(inspector).to receive(:inspect) do |_system, description, filter, _options|
+        expect(filter.element_filters.length).to eq(1)
+        expect(filter.element_filters["/unmanaged_files/files/name"].matchers).
+          to eq(["/foo/bar"])
+
+        description.foo = SimpleInspectTaskScope.new
+        ""
+      end
+
+      inspect_task.inspect_system(
+        store,
+        host,
+        name,
+        current_user_non_root,
+        ["foo"],
+        "",
+        skip_files: "/foo/bar"
+      )
+    end
+  end
+
+  context "with filters" do
+    it "passes the filters to the inspectors" do
+      inspector = FooInspector.new
+      expect(Inspector).to receive(:for).and_return(inspector)
+
+      expect(inspector).to receive(:inspect) do |_system, description, filter, _options|
+        expect(filter.element_filters.length).to eq(1)
+        expect(filter.element_filters["/foo"].matchers).
+          to eq(["bar", "baz"])
+
+        description.foo = SimpleInspectTaskScope.new
+        ""
+      end
+
+      inspect_task.inspect_system(
+        store,
+        host,
+        name,
+        current_user_non_root,
+        ["foo"],
+        "\"/foo=bar,baz\""
+      )
+    end
+
+    it "stores the filters in the system description" do
+      description = inspect_task.inspect_system(
+        store,
+        host,
+        name,
+        current_user_non_root,
+        ["foo"],
+        "\"/foo=bar,baz\""
+      )
+
+      expected = ["/foo=bar,baz"]
+      expect(description.filters["inspect"].to_array).to eq(expected)
+    end
+
+    it "only sets filters for scopes that were inspected" do
+      description = SystemDescription.new(name, store)
+      expect(SystemDescription).to receive(:load).and_return(description)
+
+      description.set_filter("inspect", Filter.new("/foo=bar,/baz=qux"))
+
+      description = inspect_task.inspect_system(
+        store,
+        host,
+        name,
+        current_user_non_root,
+        ["foo"],
+        "\"/foo=baz\""
+      )
+
+      expected = [
+        "/foo=baz",
+        "/baz=qux"
+      ]
+      expect(description.filters["inspect"].to_array).to match_array(expected)
     end
   end
 end

--- a/spec/unit/system_description_spec.rb
+++ b/spec/unit/system_description_spec.rb
@@ -468,4 +468,23 @@ describe SystemDescription do
       end
     end
   end
+
+  describe "#set_filter" do
+    subject { create_test_description }
+
+    it "sets the inspection filters" do
+      expect(subject.to_hash["meta"]["filters"]).to be(nil)
+      expected = ["/foo=bar", "/scope=filter"]
+
+      subject.set_filter("inspect", Filter.new("/foo=bar,/scope=filter"))
+      filters = subject.to_hash["meta"]["filters"]["inspect"]
+      expect(filters).to eq(expected)
+    end
+
+    it "only supports inspection filters" do
+      expect {
+        subject.set_filter("show", Filter.new("/foo=bar,/scope=filter"))
+      }.to raise_error(/not supported/)
+    end
+  end
 end

--- a/spec/unit/unmanaged_files_inspector_spec.rb
+++ b/spec/unit/unmanaged_files_inspector_spec.rb
@@ -367,7 +367,7 @@ describe UnmanagedFilesInspector do
 
       expect_inspect_unmanaged(system, true, false, ["/usr/local", "/etc/skel/.config"])
 
-      filter = Filter.new("/unmanaged_files/files/name=/usr/local/*,/etc/skel/.config")
+      filter = Filter.new("\"/unmanaged_files/files/name=/usr/local/*,/etc/skel/.config\"")
       subject.inspect(system, description, filter)
       names = description["unmanaged_files"].files.map(&:name)
 


### PR DESCRIPTION
Please review the following changes:
  * cfaf825 Extract filter preparation and handling code into separate methods
  * 8d28733 Adapt schema to allow storing the used filter during inspection
  * 4a49a06 Adapt to new signature of InspectTask#inspect_system
  * 42b59fe Store filter which was used for inspection in the description metadata
  * 42a0f6c Add Filter#to_array which returns an array of element filter definitions
  * 42c76a0 Fix parsing of filter definitions with simple lists
  * 0c93bc5 Add Filter#add_filter_definition which adds new element filters
  * 85a2ec3 Make Filter#parse_filter_definition a class method