### PR TITLE
[Review] Request from 'aduffeck' @ 'SUSE/machinery/review_150306_store_used_filter_in_description'

### DIFF
--- a/helpers/default_filters.json
+++ b/helpers/default_filters.json
@@ -1,0 +1,24 @@
+{
+  "inspect": [
+    "/unmanaged_files/files/name=/etc/passwd",
+    "/unmanaged_files/files/name=/etc/shadow",
+    "/unmanaged_files/files/name=/etc/group",
+    "/unmanaged_files/files/name=/tmp",
+    "/unmanaged_files/files/name=/var/tmp",
+    "/unmanaged_files/files/name=/lost+found",
+    "/unmanaged_files/files/name=/var/run",
+    "/unmanaged_files/files/name=/var/lib/rpm",
+    "/unmanaged_files/files/name=/.snapshots",
+    "/unmanaged_files/files/name=/proc",
+    "/unmanaged_files/files/name=/boot",
+    "/unmanaged_files/files/name=/etc/init.d/boot.d",
+    "/unmanaged_files/files/name=/etc/init.d/rc0.d",
+    "/unmanaged_files/files/name=/etc/init.d/rc1.d",
+    "/unmanaged_files/files/name=/etc/init.d/rc2.d",
+    "/unmanaged_files/files/name=/etc/init.d/rc3.d",
+    "/unmanaged_files/files/name=/etc/init.d/rc4.d",
+    "/unmanaged_files/files/name=/etc/init.d/rc5.d",
+    "/unmanaged_files/files/name=/etc/init.d/rc6.d",
+    "/unmanaged_files/files/name=/etc/init.d/rcS.d"
+  ]
+}

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -654,7 +654,9 @@ class Cli
 
     skip_files = options.delete("skip-files")
     if skip_files
-      filter.add_element_filter_from_definition("/unmanaged_files/files/name=#{skip_files}")
+      skip_files.split(",").each do |file|
+        filter.add_element_filter_from_definition("/unmanaged_files/files/name=#{file}")
+      end
     end
 
     filter

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -654,7 +654,13 @@ class Cli
 
     skip_files = options.delete("skip-files")
     if skip_files
-      skip_files.split(",").each do |file|
+      files = if skip_files.start_with?("@")
+        File.read(skip_files[1..-1]).lines.map(&:chomp)
+      else
+        skip_files.split(",")
+      end
+
+      files.each do |file|
         filter.add_element_filter_from_definition("/unmanaged_files/files/name=#{file}")
       end
     end

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -442,7 +442,6 @@ class Cli
       Machinery::Ui.puts "Inspecting #{host}#{inspected_scopes}..."
 
       inspect_options = {}
-      inspect_options[:skip_files] = options["skip-files"] if options["skip-files"]
       if options["show"]
         inspect_options[:show] = true
       end
@@ -456,7 +455,7 @@ class Cli
         inspect_options[:extract_unmanaged_files] = true
       end
 
-      filter_definition = ""
+      filter = prepare_filter("", options)
 
       inspector_task.inspect_system(
         system_description_store,
@@ -464,7 +463,7 @@ class Cli
         name,
         CurrentUser.new,
         scope_list,
-        filter_definition,
+        filter,
         inspect_options
       )
 
@@ -647,5 +646,17 @@ class Cli
     else
       SystemDescriptionStore.new
     end
+  end
+
+
+  def self.prepare_filter(definition, options)
+    filter = Filter.new(definition)
+
+    skip_files = options.delete("skip-files")
+    if skip_files
+      filter.add_element_filter_from_definition("/unmanaged_files/files/name=#{skip_files}")
+    end
+
+    filter
   end
 end

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -456,8 +456,16 @@ class Cli
         inspect_options[:extract_unmanaged_files] = true
       end
 
+      filter_definition = ""
+
       inspector_task.inspect_system(
-        system_description_store, host, name, CurrentUser.new, scope_list, inspect_options
+        system_description_store,
+        host,
+        name,
+        CurrentUser.new,
+        scope_list,
+        filter_definition,
+        inspect_options
       )
 
       Hint.show_data(name: name)

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -455,7 +455,7 @@ class Cli
         inspect_options[:extract_unmanaged_files] = true
       end
 
-      filter = prepare_filter("", options)
+      filter = prepare_filter("inspect", options)
 
       inspector_task.inspect_system(
         system_description_store,
@@ -649,8 +649,8 @@ class Cli
   end
 
 
-  def self.prepare_filter(definition, options)
-    filter = Filter.new(definition)
+  def self.prepare_filter(command, options)
+    filter = Filter.from_default_definition(command)
 
     skip_files = options.delete("skip-files")
     if skip_files

--- a/lib/element_filter.rb
+++ b/lib/element_filter.rb
@@ -7,7 +7,7 @@ class ElementFilter
 
     raise("Wrong type") if ![NilClass, String, Array].include?(matchers.class)
 
-    add_matchers(matchers)
+    add_matchers(matchers) if matchers
   end
 
   def add_matchers(matchers)

--- a/lib/element_filter.rb
+++ b/lib/element_filter.rb
@@ -1,3 +1,20 @@
+# Copyright (c) 2013-2015 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
 class ElementFilter
   attr_accessor :path, :matchers
 

--- a/lib/filter.rb
+++ b/lib/filter.rb
@@ -46,16 +46,17 @@
 class Filter
   attr_accessor :element_filters
 
-  def self.parse_filter_definition(filter_definition)
+  def self.parse_filter_definitions(filter_definitions)
     element_filters = {}
-    filter_definition.scan(/\"([^,]*?)=([^\"]*)\"|([^,]+)=([^=]*)$|([^,]+)=([^,]*)/).
-      map(&:compact).each do |path, matcher_definition|
-        element_filters[path] ||= ElementFilter.new(path)
-        if matcher_definition.index(",")
-          element_filters[path].add_matchers([matcher_definition.split(",")])
-        else
-          element_filters[path].add_matchers(matcher_definition)
-        end
+    Array(filter_definitions).each do |definition|
+      path, matcher_definition = definition.split("=", 2)
+
+      element_filters[path] ||= ElementFilter.new(path)
+      if matcher_definition.index(",")
+        element_filters[path].add_matchers([matcher_definition.split(",")])
+      else
+        element_filters[path].add_matchers(matcher_definition)
+      end
     end
 
     element_filters
@@ -77,12 +78,12 @@ class Filter
     filter
   end
 
-  def initialize(filter_definition = "")
-    @element_filters = Filter.parse_filter_definition(filter_definition)
+  def initialize(definitions = [])
+    @element_filters = Filter.parse_filter_definitions(definitions)
   end
 
   def add_element_filter_from_definition(filter_definition)
-    new_element_filters = Filter.parse_filter_definition(filter_definition)
+    new_element_filters = Filter.parse_filter_definitions(filter_definition)
 
     new_element_filters.each do |path, element_filter|
       @element_filters[path] ||= ElementFilter.new(path)

--- a/lib/filter.rb
+++ b/lib/filter.rb
@@ -1,17 +1,17 @@
 class Filter
   attr_accessor :element_filters
 
-  def initialize(filter_definition = "")
-    @element_filters = parse_filter_definition(filter_definition)
-  end
-
-  def parse_filter_definition(filter_definition)
+  def self.parse_filter_definition(filter_definition)
     element_filters = {}
     filter_definition.scan(/\"?([^,]*?)=([^\"]*)\"?,?/).each do |path, matcher_definition|
       element_filters[path] = ElementFilter.new(path, matcher_definition.split(","))
     end
 
     element_filters
+  end
+
+  def initialize(filter_definition = "")
+    @element_filters = Filter.parse_filter_definition(filter_definition)
   end
 
   def matches?(path, value)

--- a/lib/filter.rb
+++ b/lib/filter.rb
@@ -3,7 +3,7 @@ class Filter
 
   def self.parse_filter_definition(filter_definition)
     element_filters = {}
-    filter_definition.scan(/\"?([^,]*?)=([^\"]*)\"?,?/).each do |path, matcher_definition|
+    filter_definition.scan(/\"([^,]*?)=([^\"]*)\"|([^,]+)=([^,]*)/).map(&:compact).each do |path, matcher_definition|
       element_filters[path] = ElementFilter.new(path, matcher_definition.split(","))
     end
 

--- a/lib/filter.rb
+++ b/lib/filter.rb
@@ -14,6 +14,15 @@ class Filter
     @element_filters = Filter.parse_filter_definition(filter_definition)
   end
 
+  def add_filter_definition(filter_definition)
+    new_element_filters = Filter.parse_filter_definition(filter_definition)
+
+    new_element_filters.each do |path, element_filter|
+      @element_filters[path] ||= ElementFilter.new(path)
+      @element_filters[path].add_matchers(element_filter.matchers)
+    end
+  end
+
   def matches?(path, value)
     filter = element_filter_for(path)
     return false if !filter

--- a/lib/filter.rb
+++ b/lib/filter.rb
@@ -15,7 +15,7 @@ class Filter
     @element_filters = Filter.parse_filter_definition(filter_definition)
   end
 
-  def add_filter_definition(filter_definition)
+  def add_element_filter_from_definition(filter_definition)
     new_element_filters = Filter.parse_filter_definition(filter_definition)
 
     new_element_filters.each do |path, element_filter|

--- a/lib/filter.rb
+++ b/lib/filter.rb
@@ -23,6 +23,12 @@ class Filter
     end
   end
 
+  def to_array
+    @element_filters.map do |path, element_filter|
+      "#{path}=#{element_filter.matchers.join(",")}"
+    end
+  end
+
   def matches?(path, value)
     filter = element_filter_for(path)
     return false if !filter

--- a/lib/filter.rb
+++ b/lib/filter.rb
@@ -3,8 +3,9 @@ class Filter
 
   def self.parse_filter_definition(filter_definition)
     element_filters = {}
-    filter_definition.scan(/\"([^,]*?)=([^\"]*)\"|([^,]+)=([^,]*)/).map(&:compact).each do |path, matcher_definition|
-      element_filters[path] = ElementFilter.new(path, matcher_definition.split(","))
+    filter_definition.scan(/\"([^,]*?)=([^\"]*)\"|([^,]+)=([^,]*)/).
+      map(&:compact).each do |path, matcher_definition|
+        element_filters[path] = ElementFilter.new(path, matcher_definition.split(","))
     end
 
     element_filters

--- a/lib/filter.rb
+++ b/lib/filter.rb
@@ -3,7 +3,7 @@ class Filter
 
   def self.parse_filter_definition(filter_definition)
     element_filters = {}
-    filter_definition.scan(/\"([^,]*?)=([^\"]*)\"|([^,]+)=([^,]*)/).
+    filter_definition.scan(/\"([^,]*?)=([^\"]*)\"|([^,]+)=([^=]*)$|([^,]+)=([^,]*)/).
       map(&:compact).each do |path, matcher_definition|
         element_filters[path] = ElementFilter.new(path, matcher_definition.split(","))
     end

--- a/lib/filter.rb
+++ b/lib/filter.rb
@@ -61,6 +61,22 @@ class Filter
     element_filters
   end
 
+  def self.from_default_definition(command)
+    filter = Filter.new
+
+    default_filters_file = File.join(Machinery::ROOT, "helpers/default_filters.json")
+    if File.exists?(default_filters_file)
+      default_filters = JSON.parse(File.read(default_filters_file))
+      if default_filters[command]
+        default_filters[command].each do |definition|
+          filter.add_element_filter_from_definition(definition)
+        end
+      end
+    end
+
+    filter
+  end
+
   def initialize(filter_definition = "")
     @element_filters = Filter.parse_filter_definition(filter_definition)
   end

--- a/lib/filter.rb
+++ b/lib/filter.rb
@@ -23,6 +23,10 @@ class Filter
     end
   end
 
+  def add_element_filter(element_filter)
+    @element_filters[element_filter.path] = element_filter
+  end
+
   def to_array
     @element_filters.map do |path, element_filter|
       "#{path}=#{element_filter.matchers.join(",")}"

--- a/lib/filter.rb
+++ b/lib/filter.rb
@@ -1,3 +1,20 @@
+# Copyright (c) 2013-2015 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
 class Filter
   attr_accessor :element_filters
 

--- a/lib/filter.rb
+++ b/lib/filter.rb
@@ -15,6 +15,34 @@
 # To contact SUSE about this file by physical or electronic mail,
 # you may find current contact information at www.suse.com
 
+# The Filter class is used to hold the information about the filter conditions
+# that should be applied during certain Machinery commands.
+#
+# Filters are usually created by passing a filter definition string to the
+# constructor, e.g.
+#
+#   filter = Filter.new("/unmanaged_files/files/name=/opt")
+#
+# Existing filters can be extended by amending the definition:
+#
+#   filter.add_element_filter_from_definition("/unmanaged_files/files/name=/srv")
+#
+# or by adding ElementFilters directly:
+#
+#   element_filter = ElementFilter.new("/unmanaged_files/files/name", ["/opt", "/srv"])
+#   filter.add_element_filter(element_filter)
+#
+#
+# The actual filtering can be done by passing values to Filter#matches?
+#
+#   filter = Filter.new("/unmanaged_files/files/name=/opt*")
+#   filter.matches?("/unmanaged_files/files/name", "/opt/foo")
+#   => true
+#   filter.matches?("/unmanaged_files/files/name", "/srv/bar")
+#   => false
+#
+# More details about how the filter work can be found at
+# https://github.com/SUSE/machinery/blob/master/docs/Filtering-Design.md
 class Filter
   attr_accessor :element_filters
 

--- a/lib/inspect_task.rb
+++ b/lib/inspect_task.rb
@@ -64,7 +64,7 @@ class InspectTask
 
     skip_files = options.delete(:skip_files)
     if skip_files
-      filter.add_filter_definition("/unmanaged_files/files/name=#{skip_files}")
+      filter.add_element_filter_from_definition("/unmanaged_files/files/name=#{skip_files}")
     end
 
     filter

--- a/lib/inspect_task.rb
+++ b/lib/inspect_task.rb
@@ -16,11 +16,10 @@
 # you may find current contact information at www.suse.com
 
 class InspectTask
-  def inspect_system(store, host, name, current_user, scopes, filter_definition, options = {})
+  def inspect_system(store, host, name, current_user, scopes, filter, options = {})
     system = System.for(host)
     check_root(system, current_user)
 
-    filter = prepare_filter(filter_definition, options)
     description, failed_inspections = build_description(store, name, system,
       scopes, filter, options)
 
@@ -57,17 +56,6 @@ class InspectTask
       output = renderer.render(description)
       Machinery::Ui.puts output if output
     end
-  end
-
-  def prepare_filter(definition, options)
-    filter = Filter.new(definition)
-
-    skip_files = options.delete(:skip_files)
-    if skip_files
-      filter.add_element_filter_from_definition("/unmanaged_files/files/name=#{skip_files}")
-    end
-
-    filter
   end
 
   def adapt_filter_in_metadata(filter_in_metadata, scope, filter)

--- a/lib/inspect_task.rb
+++ b/lib/inspect_task.rb
@@ -21,7 +21,8 @@ class InspectTask
     check_root(system, current_user)
 
     filter = prepare_filter(filter_definition, options)
-    description, failed_inspections = build_description(store, name, system, scopes, filter, options)
+    description, failed_inspections = build_description(store, name, system,
+      scopes, filter, options)
 
     if !description.attributes.empty?
       print_description(description, scopes) if options[:show]

--- a/lib/system_description.rb
+++ b/lib/system_description.rb
@@ -102,6 +102,15 @@ class SystemDescription < Machinery::Object
 
       description.format_version = json_format_version
 
+      if hash["meta"] && hash["meta"]["filters"]
+        hash["meta"]["filters"].each do |command, filter_definitions|
+          description.filters[command] = Filter.new
+          filter_definitions.each do |definition|
+            description.filters[command].add_element_filter_from_definition(definition)
+          end
+        end
+      end
+
       description
     end
 

--- a/plugins/inspect/unmanaged_files_inspector.rb
+++ b/plugins/inspect/unmanaged_files_inspector.rb
@@ -218,44 +218,6 @@ class UnmanagedFilesInspector < Inspector
     3
   end
 
-  def ignore_list(description)
-    ignore_list = [
-      "/tmp",
-      "/var/tmp",
-      "/lost+found",
-      "/var/run",
-      "/var/lib/rpm",
-      "/.snapshots",
-      description.store.base_path,
-      "/proc",
-      "/boot"
-    ]
-
-    # Information about users and groups are extracted by the according inspector
-    ignore_list += [
-      "/etc/passwd",
-      "/etc/shadow",
-      "/etc/group"
-    ]
-
-    # Information about services is extracted by the ServicesInspector, so
-    # we ignore the links representing the same information when inspecting
-    # unmanaged files.
-    ignore_list += [
-      "/etc/init.d/boot.d",
-      "/etc/init.d/rc0.d",
-      "/etc/init.d/rc1.d",
-      "/etc/init.d/rc2.d",
-      "/etc/init.d/rc3.d",
-      "/etc/init.d/rc4.d",
-      "/etc/init.d/rc5.d",
-      "/etc/init.d/rc6.d",
-      "/etc/init.d/rcS.d"
-    ]
-
-    ignore_list
-  end
-
   def inspect(system, description, filter, options = {})
     do_extract = options && options[:extract_unmanaged_files]
     check_requirements(system, do_extract)
@@ -280,7 +242,7 @@ class UnmanagedFilesInspector < Inspector
 
     file_filter = filter.element_filter_for("/unmanaged_files/files/name") if filter
     file_filter ||= ElementFilter.new("/unmanaged_files/files/name")
-    file_filter.add_matchers(ignore_list(description))
+    file_filter.add_matchers(description.store.base_path)
 
     # Add a recursive pendant to each ignored element
     file_filter.add_matchers(file_filter.matchers.map { |entry| entry + "/*" })

--- a/schema/v3/system-description-global.schema.json
+++ b/schema/v3/system-description-global.schema.json
@@ -10,6 +10,18 @@
         "format_version": {
           "type": "integer",
           "minimum": 1
+        },
+        "filters": {
+          "type": "object",
+          "required": ["inspect"],
+          "properties": {
+            "inspect": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
         }
       },
       "additionalProperties": {

--- a/spec/support/system_description_factory.rb
+++ b/spec/support/system_description_factory.rb
@@ -61,6 +61,7 @@ module SystemDescriptionFactory
   # +modified+: Modified date of the system description scopes.
   # +hostname+: Hostname of the inspected host.
   # +add_scope_meta+: Add meta data for each scope if true.
+  # +filters+: Add filter information to the meta section
   def create_test_description(options = {})
     options = {
         name: "description",
@@ -106,6 +107,7 @@ module SystemDescriptionFactory
     meta = {
       format_version: 3
     }
+    meta[:filters] = options[:filters] if options[:filters]
 
     (options[:scopes] + options[:extracted_scopes]).uniq.each do |scope|
       json_objects << EXAMPLE_SCOPES[scope]

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -194,10 +194,10 @@ describe Cli do
         expect_any_instance_of(InspectTask).to receive(:inspect_system) do |_instance, _store,
           _host, _name, _user, _scopes, filter, _options|
           expect(filter.element_filter_for("/unmanaged_files/files/name").matchers).
-            to include("/foo/bar")
+            to include("/foo/bar", "/baz")
         end.and_return(description)
 
-        run_command(["inspect", "--skip-files=/foo/bar", example_host])
+        run_command(["inspect", "--skip-files=/foo/bar,/baz", example_host])
       end
 
       describe "file extraction" do

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -192,7 +192,7 @@ describe Cli do
 
       it "forwards the --skip-files option to the InspectTask" do
         expect_any_instance_of(InspectTask).to receive(:inspect_system) do |_instance, _store, _host, _name, _user, _scopes, filter, _options|
-          expect(filter.element_filter_for("/unmanaged_files/files/name").matchers).to eq(["/foo/bar"])
+          expect(filter.element_filter_for("/unmanaged_files/files/name").matchers).to include("/foo/bar")
         end.and_return(description)
 
         run_command(["inspect", "--skip-files=/foo/bar", example_host])

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -81,7 +81,7 @@ describe Cli do
             example_host,
             an_instance_of(CurrentUser),
             Inspector.all_scopes,
-            "",
+            an_instance_of(Filter),
             {}
           ).
           and_return(description)
@@ -98,7 +98,7 @@ describe Cli do
             name,
             an_instance_of(CurrentUser),
             Inspector.all_scopes,
-            "",
+            an_instance_of(Filter),
             {}
            ).
            and_return(description)
@@ -114,7 +114,7 @@ describe Cli do
             example_host,
             an_instance_of(CurrentUser),
             Inspector.all_scopes,
-            "",
+            an_instance_of(Filter),
             {}
            ).
           and_return(description)
@@ -130,7 +130,7 @@ describe Cli do
             example_host,
             an_instance_of(CurrentUser),
             ["packages", "repositories"],
-            "",
+            an_instance_of(Filter),
             {}
           ).
           and_return(description)
@@ -146,7 +146,7 @@ describe Cli do
             example_host,
             an_instance_of(CurrentUser),
             ["packages"],
-            "",
+            an_instance_of(Filter),
             {}
           ).
           and_return(description)
@@ -162,7 +162,7 @@ describe Cli do
             example_host,
             an_instance_of(CurrentUser),
             Inspector.all_scopes,
-            "",
+            an_instance_of(Filter),
             {}
           ).
           and_return(description)
@@ -182,7 +182,7 @@ describe Cli do
             example_host,
             an_instance_of(CurrentUser),
             scope_list,
-            "",
+            an_instance_of(Filter),
             {}
           ).
           and_return(description)
@@ -191,17 +191,9 @@ describe Cli do
       end
 
       it "forwards the --skip-files option to the InspectTask" do
-        expect_any_instance_of(InspectTask).to receive(:inspect_system).
-          with(
-            an_instance_of(SystemDescriptionStore),
-            example_host,
-            example_host,
-            an_instance_of(CurrentUser),
-            Inspector.all_scopes,
-            "",
-            skip_files: "/foo/bar"
-          ).
-          and_return(description)
+        expect_any_instance_of(InspectTask).to receive(:inspect_system) do |_instance, _store, _host, _name, _user, _scopes, filter, _options|
+          expect(filter.element_filter_for("/unmanaged_files/files/name").matchers).to eq(["/foo/bar"])
+        end.and_return(description)
 
         run_command(["inspect", "--skip-files=/foo/bar", example_host])
       end
@@ -215,7 +207,7 @@ describe Cli do
               example_host,
               an_instance_of(CurrentUser),
               Inspector.all_scopes,
-              "",
+              an_instance_of(Filter),
               {}
             ).
             and_return(description)
@@ -231,7 +223,7 @@ describe Cli do
               example_host,
               an_instance_of(CurrentUser),
               Inspector.all_scopes,
-              "",
+              an_instance_of(Filter),
               :extract_changed_config_files=>true, :extract_unmanaged_files=>true, :extract_changed_managed_files=>true
             ).
             and_return(description)
@@ -247,7 +239,7 @@ describe Cli do
               example_host,
               an_instance_of(CurrentUser),
               Inspector.all_scopes,
-              "",
+              an_instance_of(Filter),
               :extract_changed_config_files=>true
             ).
             and_return(description)
@@ -263,7 +255,7 @@ describe Cli do
               example_host,
               an_instance_of(CurrentUser),
               Inspector.all_scopes,
-              "",
+              an_instance_of(Filter),
               :extract_unmanaged_files=>true
             ).
             and_return(description)

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -190,7 +190,7 @@ describe Cli do
         run_command(["inspect", "--exclude-scope=packages,repositories", example_host])
       end
 
-      it "forwards the --skip-files option to the InspectTask" do
+      it "forwards the --skip-files option to the InspectTask as an unmanaged_files filter" do
         expect_any_instance_of(InspectTask).to receive(:inspect_system) do |_instance, _store, _host, _name, _user, _scopes, filter, _options|
           expect(filter.element_filter_for("/unmanaged_files/files/name").matchers).to include("/foo/bar")
         end.and_return(description)

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -200,6 +200,27 @@ describe Cli do
         run_command(["inspect", "--skip-files=/foo/bar,/baz", example_host])
       end
 
+      it "the --skip-files option reads a list of excluded files from a file" do
+        expect_any_instance_of(InspectTask).to receive(:inspect_system) do |_instance, _store,
+          _host, _name, _user, _scopes, filter, _options|
+          expect(filter.element_filter_for("/unmanaged_files/files/name").matchers).
+            to include("/foo/bar", "/baz")
+        end.and_return(description)
+
+        FileUtils.mkdir_p("/tmp")
+        exclude_file = Tempfile.new('exclude_file')
+        begin
+          File.write(exclude_file.path, <<EOF)
+/foo/bar
+/baz
+EOF
+          run_command(["inspect", "--skip-files=@#{exclude_file.path}", example_host])
+        ensure
+          exclude_file.close
+          exclude_file.unlink
+        end
+      end
+
       describe "file extraction" do
         it "doesn't extract files when --extract-files is not specified" do
           expect_any_instance_of(InspectTask).to receive(:inspect_system).

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -191,8 +191,10 @@ describe Cli do
       end
 
       it "forwards the --skip-files option to the InspectTask as an unmanaged_files filter" do
-        expect_any_instance_of(InspectTask).to receive(:inspect_system) do |_instance, _store, _host, _name, _user, _scopes, filter, _options|
-          expect(filter.element_filter_for("/unmanaged_files/files/name").matchers).to include("/foo/bar")
+        expect_any_instance_of(InspectTask).to receive(:inspect_system) do |_instance, _store,
+          _host, _name, _user, _scopes, filter, _options|
+          expect(filter.element_filter_for("/unmanaged_files/files/name").matchers).
+            to include("/foo/bar")
         end.and_return(description)
 
         run_command(["inspect", "--skip-files=/foo/bar", example_host])

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -81,6 +81,7 @@ describe Cli do
             example_host,
             an_instance_of(CurrentUser),
             Inspector.all_scopes,
+            "",
             {}
           ).
           and_return(description)
@@ -97,6 +98,7 @@ describe Cli do
             name,
             an_instance_of(CurrentUser),
             Inspector.all_scopes,
+            "",
             {}
            ).
            and_return(description)
@@ -112,6 +114,7 @@ describe Cli do
             example_host,
             an_instance_of(CurrentUser),
             Inspector.all_scopes,
+            "",
             {}
            ).
           and_return(description)
@@ -127,6 +130,7 @@ describe Cli do
             example_host,
             an_instance_of(CurrentUser),
             ["packages", "repositories"],
+            "",
             {}
           ).
           and_return(description)
@@ -142,6 +146,7 @@ describe Cli do
             example_host,
             an_instance_of(CurrentUser),
             ["packages"],
+            "",
             {}
           ).
           and_return(description)
@@ -157,6 +162,7 @@ describe Cli do
             example_host,
             an_instance_of(CurrentUser),
             Inspector.all_scopes,
+            "",
             {}
           ).
           and_return(description)
@@ -176,6 +182,7 @@ describe Cli do
             example_host,
             an_instance_of(CurrentUser),
             scope_list,
+            "",
             {}
           ).
           and_return(description)
@@ -191,6 +198,7 @@ describe Cli do
             example_host,
             an_instance_of(CurrentUser),
             Inspector.all_scopes,
+            "",
             skip_files: "/foo/bar"
           ).
           and_return(description)
@@ -207,6 +215,7 @@ describe Cli do
               example_host,
               an_instance_of(CurrentUser),
               Inspector.all_scopes,
+              "",
               {}
             ).
             and_return(description)
@@ -222,6 +231,7 @@ describe Cli do
               example_host,
               an_instance_of(CurrentUser),
               Inspector.all_scopes,
+              "",
               :extract_changed_config_files=>true, :extract_unmanaged_files=>true, :extract_changed_managed_files=>true
             ).
             and_return(description)
@@ -237,6 +247,7 @@ describe Cli do
               example_host,
               an_instance_of(CurrentUser),
               Inspector.all_scopes,
+              "",
               :extract_changed_config_files=>true
             ).
             and_return(description)
@@ -252,6 +263,7 @@ describe Cli do
               example_host,
               an_instance_of(CurrentUser),
               Inspector.all_scopes,
+              "",
               :extract_unmanaged_files=>true
             ).
             and_return(description)

--- a/spec/unit/element_filter_spec.rb
+++ b/spec/unit/element_filter_spec.rb
@@ -56,10 +56,10 @@ describe ElementFilter do
       expect(filter.matchers).to eq([@matcher1, @matcher2])
     end
 
-    it "adds set of two definitions" do
+    it "adds an array matcher definition" do
       filter = ElementFilter.new(@path)
-      filter.add_matchers([["/home/alfred", "/var/cache"]])
-      expect(filter.matchers).to eq([[@matcher1, @matcher2]])
+      filter.add_matchers([["md5", "size"]])
+      expect(filter.matchers).to eq([["md5", "size"]])
     end
   end
 

--- a/spec/unit/element_filter_spec.rb
+++ b/spec/unit/element_filter_spec.rb
@@ -1,3 +1,20 @@
+# Copyright (c) 2013-2015 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
 require_relative "spec_helper"
 
 describe ElementFilter do

--- a/spec/unit/element_filter_spec.rb
+++ b/spec/unit/element_filter_spec.rb
@@ -41,8 +41,8 @@ describe ElementFilter do
 
     it "adds set of two definitions" do
       filter = ElementFilter.new(@path)
-      filter.add_matchers(["/home/alfred", "/var/cache"])
-      expect(filter.matchers).to eq([@matcher1, @matcher2])
+      filter.add_matchers([["/home/alfred", "/var/cache"]])
+      expect(filter.matchers).to eq([[@matcher1, @matcher2]])
     end
   end
 

--- a/spec/unit/filter_spec.rb
+++ b/spec/unit/filter_spec.rb
@@ -60,7 +60,7 @@ describe Filter do
   describe "#add_filter_definition" do
     it "adds definitions" do
       filter = Filter.new("\"foo=bar,baz\"")
-      filter.add_filter_definition("bar=baz")
+      filter.add_element_filter_from_definition("bar=baz")
 
       element_filters = filter.element_filters
       expect(element_filters["foo"].matchers).to eq(["bar", "baz"])
@@ -69,7 +69,7 @@ describe Filter do
 
     it "merges new definitions with existing element filter" do
       filter = Filter.new("\"foo=bar,baz\"")
-      filter.add_filter_definition("foo=qux")
+      filter.add_element_filter_from_definition("foo=qux")
 
       element_filters = filter.element_filters
       expect(element_filters["foo"].matchers).to eq(["bar", "baz", "qux"])

--- a/spec/unit/filter_spec.rb
+++ b/spec/unit/filter_spec.rb
@@ -1,3 +1,20 @@
+# Copyright (c) 2013-2015 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
 require_relative "spec_helper"
 
 describe Filter do

--- a/spec/unit/filter_spec.rb
+++ b/spec/unit/filter_spec.rb
@@ -76,6 +76,15 @@ describe Filter do
     end
   end
 
+  describe "#to_array" do
+    it "returns the element filter definitions as a string array" do
+      filter = Filter.new("\"foo=bar,baz\",scope=matcher")
+      expect(filter.to_array).to eq([
+        "foo=bar,baz", "scope=matcher"
+      ])
+    end
+  end
+
   describe "#filter_for" do
     it "returns the correct filter" do
       filter = Filter.new(complex_definition)

--- a/spec/unit/filter_spec.rb
+++ b/spec/unit/filter_spec.rb
@@ -8,6 +8,30 @@ describe Filter do
       "/changed_managed_files/files/name=/usr/lib/something"
   }
 
+  describe ".parse_filter_definition" do
+    it "parses element filter containing multiple matcher" do
+      filters = Filter.parse_filter_definition(definition2)
+
+      expect(filters.keys.length).to eq(1)
+      expect(filters["/unmanaged_files/files/name"].path).to eq("/unmanaged_files/files/name")
+      expect(filters["/unmanaged_files/files/name"].matchers).to eq(["/home/alfred", "/var/cache"])
+    end
+
+    it "parses element filter with multiple filters" do
+      element_filter = Filter.parse_filter_definition(complex_definition)
+
+      expect(element_filter.keys.length).to eq(2)
+      expect(element_filter["/unmanaged_files/files/name"].path).
+        to eq("/unmanaged_files/files/name")
+      expect(element_filter["/unmanaged_files/files/name"].matchers).
+        to eq(["/home/alfred", "/var/cache"])
+      expect(element_filter["/changed_managed_files/files/name"].path).
+        to eq("/changed_managed_files/files/name")
+      expect(element_filter["/changed_managed_files/files/name"].matchers).
+        to eq(["/usr/lib/something"])
+    end
+  end
+
   describe "#initialize" do
     it "creates Filter" do
       filter = Filter.new
@@ -20,30 +44,6 @@ describe Filter do
       expect(filters.keys.length).to eq(1)
       expect(filters["/unmanaged_files/files/name"].path).to eq("/unmanaged_files/files/name")
       expect(filters["/unmanaged_files/files/name"].matchers).to eq(["/home/alfred"])
-    end
-  end
-
-  describe "#parse_filter_definition" do
-    it "parses element filter containing multiple matcher" do
-      filters = subject.parse_filter_definition(definition2)
-
-      expect(filters.keys.length).to eq(1)
-      expect(filters["/unmanaged_files/files/name"].path).to eq("/unmanaged_files/files/name")
-      expect(filters["/unmanaged_files/files/name"].matchers).to eq(["/home/alfred", "/var/cache"])
-    end
-
-    it "parses element filter with multiple filters" do
-      element_filter = subject.parse_filter_definition(complex_definition)
-
-      expect(element_filter.keys.length).to eq(2)
-      expect(element_filter["/unmanaged_files/files/name"].path).
-        to eq("/unmanaged_files/files/name")
-      expect(element_filter["/unmanaged_files/files/name"].matchers).
-        to eq(["/home/alfred", "/var/cache"])
-      expect(element_filter["/changed_managed_files/files/name"].path).
-        to eq("/changed_managed_files/files/name")
-      expect(element_filter["/changed_managed_files/files/name"].matchers).
-        to eq(["/usr/lib/something"])
     end
   end
 

--- a/spec/unit/filter_spec.rb
+++ b/spec/unit/filter_spec.rb
@@ -2,7 +2,8 @@ require_relative "spec_helper"
 
 describe Filter do
   let(:definition1) { "/unmanaged_files/files/name=/home/alfred" }
-  let(:definition2) { "/unmanaged_files/files/name=/home/alfred,/var/cache" }
+  let(:definition2) { "\"/unmanaged_files/files/name=/home/alfred,/var/cache\"" }
+  let(:simple_list_definition) { "/foo=bar,/baz=qux"}
   let(:complex_definition) {
     "\"/unmanaged_files/files/name=/home/alfred,/var/cache\"," +
       "/changed_managed_files/files/name=/usr/lib/something"
@@ -30,6 +31,15 @@ describe Filter do
       expect(element_filter["/changed_managed_files/files/name"].matchers).
         to eq(["/usr/lib/something"])
     end
+
+    it "parses simple lists" do
+      element_filter = Filter.parse_filter_definition(simple_list_definition)
+      expect(element_filter.keys.length).to eq(2)
+      expect(element_filter["/foo"].matchers).
+        to eq(["bar"])
+      expect(element_filter["/baz"].matchers).
+        to eq(["qux"])
+    end
   end
 
   describe "#initialize" do
@@ -49,7 +59,7 @@ describe Filter do
 
   describe "#add_filter_definition" do
     it "adds definitions" do
-      filter = Filter.new("foo=bar,baz")
+      filter = Filter.new("\"foo=bar,baz\"")
       filter.add_filter_definition("bar=baz")
 
       element_filters = filter.element_filters
@@ -58,7 +68,7 @@ describe Filter do
     end
 
     it "merges new definitions with existing element filter" do
-      filter = Filter.new("foo=bar,baz")
+      filter = Filter.new("\"foo=bar,baz\"")
       filter.add_filter_definition("foo=qux")
 
       element_filters = filter.element_filters

--- a/spec/unit/filter_spec.rb
+++ b/spec/unit/filter_spec.rb
@@ -18,40 +18,9 @@
 require_relative "spec_helper"
 
 describe Filter do
-  let(:definition1) { "/unmanaged_files/files/name=/home/alfred" }
-  let(:definition2) { "\"/changed_managed_files/files/changes=md5,size\"" }
-  let(:complex_definition) {
-    "/unmanaged_files/files/name=/home/alfred," +
-      "/unmanaged_files/files/name=/var/cache," +
-      "\"/changed_managed_files/files/changes=md5,size\""
-  }
-
-  describe ".parse_filter_definition" do
-    it "parses element filter containing multiple matcher" do
-      filters = Filter.parse_filter_definition(definition2)
-
-      expect(filters.keys.length).to eq(1)
-      expect(filters["/changed_managed_files/files/changes"].path).
-        to eq("/changed_managed_files/files/changes")
-      expect(filters["/changed_managed_files/files/changes"].matchers).to eq([["md5", "size"]])
-    end
-
-    it "parses element filter with multiple filters" do
-      element_filter = Filter.parse_filter_definition(complex_definition)
-
-      expect(element_filter.keys.length).to eq(2)
-      expect(element_filter["/unmanaged_files/files/name"].path).
-        to eq("/unmanaged_files/files/name")
-      expect(element_filter["/unmanaged_files/files/name"].matchers).
-        to eq(["/home/alfred", "/var/cache"])
-      expect(element_filter["/changed_managed_files/files/changes"].path).
-        to eq("/changed_managed_files/files/changes")
-      expect(element_filter["/changed_managed_files/files/changes"].matchers).
-        to eq([["md5", "size"]])
-    end
-
-    it "parses simple definition with multiple filters" do
-      element_filter = Filter.parse_filter_definition("/foo=bar,/baz=qux")
+  describe ".parse_filter_definitions" do
+    it "parses array of definitions" do
+      element_filter = Filter.parse_filter_definitions(["/foo=bar", "/baz=qux"])
       expect(element_filter.keys.length).to eq(2)
       expect(element_filter["/foo"].matchers).
         to eq(["bar"])
@@ -59,8 +28,8 @@ describe Filter do
         to eq(["qux"])
     end
 
-    it "parses simple definition with multiple matcher" do
-      element_filter = Filter.parse_filter_definition("/foo=bar,baz")
+    it "parses definition with multiple matcher" do
+      element_filter = Filter.parse_filter_definitions("/foo=bar,baz")
       expect(element_filter.keys.length).to eq(1)
       expect(element_filter["/foo"].matchers).
         to eq([["bar", "baz"]])
@@ -74,7 +43,7 @@ describe Filter do
     end
 
     it "parses the filter definition" do
-      filters = Filter.new(definition1).element_filters
+      filters = Filter.new("/unmanaged_files/files/name=/home/alfred").element_filters
 
       expect(filters.keys.length).to eq(1)
       expect(filters["/unmanaged_files/files/name"].path).to eq("/unmanaged_files/files/name")
@@ -103,7 +72,7 @@ describe Filter do
 
   describe "#to_array" do
     it "returns the element filter definitions as a string array" do
-      filter = Filter.new("\"foo=bar,baz\",foo=qux,scope=matcher")
+      filter = Filter.new(["foo=bar,baz", "foo=qux", "scope=matcher"])
       expect(filter.to_array).to eq([
         "foo=bar,baz", "foo=qux", "scope=matcher"
       ])
@@ -112,7 +81,11 @@ describe Filter do
 
   describe "#filter_for" do
     it "returns the correct filter" do
-      filter = Filter.new(complex_definition)
+      filter = Filter.new([
+        "/unmanaged_files/files/name=/home/alfred",
+        "/unmanaged_files/files/name=/var/cache",
+        "/changed_managed_files/files/changes=md5,size"
+      ])
 
       element_filter = filter.element_filter_for("/unmanaged_files/files/name")
       expect(element_filter.path).to eq("/unmanaged_files/files/name")
@@ -125,7 +98,13 @@ describe Filter do
   end
 
   describe "#matches?" do
-    let(:filter) { Filter.new(complex_definition) }
+    let(:filter) {
+      Filter.new([
+          "/unmanaged_files/files/name=/home/alfred",
+          "/unmanaged_files/files/name=/var/cache",
+          "/changed_managed_files/files/changes=md5,size"
+      ])
+    }
 
     it "returns false when no filter is set" do
       expect(filter.matches?("/some/path", "some_value")).to be(false)

--- a/spec/unit/filter_spec.rb
+++ b/spec/unit/filter_spec.rb
@@ -47,6 +47,25 @@ describe Filter do
     end
   end
 
+  describe "#add_filter_definition" do
+    it "adds definitions" do
+      filter = Filter.new("foo=bar,baz")
+      filter.add_filter_definition("bar=baz")
+
+      element_filters = filter.element_filters
+      expect(element_filters["foo"].matchers).to eq(["bar", "baz"])
+      expect(element_filters["bar"].matchers).to eq(["baz"])
+    end
+
+    it "merges new definitions with existing element filter" do
+      filter = Filter.new("foo=bar,baz")
+      filter.add_filter_definition("foo=qux")
+
+      element_filters = filter.element_filters
+      expect(element_filters["foo"].matchers).to eq(["bar", "baz", "qux"])
+    end
+  end
+
   describe "#filter_for" do
     it "returns the correct filter" do
       filter = Filter.new(complex_definition)

--- a/spec/unit/filter_spec.rb
+++ b/spec/unit/filter_spec.rb
@@ -3,7 +3,7 @@ require_relative "spec_helper"
 describe Filter do
   let(:definition1) { "/unmanaged_files/files/name=/home/alfred" }
   let(:definition2) { "\"/unmanaged_files/files/name=/home/alfred,/var/cache\"" }
-  let(:simple_list_definition) { "/foo=bar,/baz=qux"}
+  let(:simple_list_definition) { "/foo=bar,/baz=qux" }
   let(:complex_definition) {
     "\"/unmanaged_files/files/name=/home/alfred,/var/cache\"," +
       "/changed_managed_files/files/name=/usr/lib/something"

--- a/spec/unit/filter_spec.rb
+++ b/spec/unit/filter_spec.rb
@@ -3,7 +3,6 @@ require_relative "spec_helper"
 describe Filter do
   let(:definition1) { "/unmanaged_files/files/name=/home/alfred" }
   let(:definition2) { "\"/unmanaged_files/files/name=/home/alfred,/var/cache\"" }
-  let(:simple_list_definition) { "/foo=bar,/baz=qux" }
   let(:complex_definition) {
     "\"/unmanaged_files/files/name=/home/alfred,/var/cache\"," +
       "/changed_managed_files/files/name=/usr/lib/something"
@@ -32,13 +31,20 @@ describe Filter do
         to eq(["/usr/lib/something"])
     end
 
-    it "parses simple lists" do
-      element_filter = Filter.parse_filter_definition(simple_list_definition)
+    it "parses simple definition with multiple filters" do
+      element_filter = Filter.parse_filter_definition("/foo=bar,/baz=qux")
       expect(element_filter.keys.length).to eq(2)
       expect(element_filter["/foo"].matchers).
         to eq(["bar"])
       expect(element_filter["/baz"].matchers).
         to eq(["qux"])
+    end
+
+    it "parses simple definition with multiple matcher" do
+      element_filter = Filter.parse_filter_definition("/foo=bar,baz")
+      expect(element_filter.keys.length).to eq(1)
+      expect(element_filter["/foo"].matchers).
+        to eq(["bar", "baz"])
     end
   end
 
@@ -59,7 +65,7 @@ describe Filter do
 
   describe "#add_filter_definition" do
     it "adds definitions" do
-      filter = Filter.new("\"foo=bar,baz\"")
+      filter = Filter.new("foo=bar,baz")
       filter.add_element_filter_from_definition("bar=baz")
 
       element_filters = filter.element_filters
@@ -68,7 +74,7 @@ describe Filter do
     end
 
     it "merges new definitions with existing element filter" do
-      filter = Filter.new("\"foo=bar,baz\"")
+      filter = Filter.new("foo=bar,baz")
       filter.add_element_filter_from_definition("foo=qux")
 
       element_filters = filter.element_filters

--- a/spec/unit/filter_spec.rb
+++ b/spec/unit/filter_spec.rb
@@ -22,8 +22,8 @@ describe Filter do
   let(:definition2) { "\"/changed_managed_files/files/changes=md5,size\"" }
   let(:complex_definition) {
     "/unmanaged_files/files/name=/home/alfred," +
-    "/unmanaged_files/files/name=/var/cache," +
-    "\"/changed_managed_files/files/changes=md5,size\""
+      "/unmanaged_files/files/name=/var/cache," +
+      "\"/changed_managed_files/files/changes=md5,size\""
   }
 
   describe ".parse_filter_definition" do
@@ -31,7 +31,8 @@ describe Filter do
       filters = Filter.parse_filter_definition(definition2)
 
       expect(filters.keys.length).to eq(1)
-      expect(filters["/changed_managed_files/files/changes"].path).to eq("/changed_managed_files/files/changes")
+      expect(filters["/changed_managed_files/files/changes"].path).
+        to eq("/changed_managed_files/files/changes")
       expect(filters["/changed_managed_files/files/changes"].matchers).to eq([["md5", "size"]])
     end
 

--- a/spec/unit/inspect_task_spec.rb
+++ b/spec/unit/inspect_task_spec.rb
@@ -197,7 +197,7 @@ Inspecting foo...
       expect(inspector).to receive(:inspect) do |_system, description, filter, _options|
         expect(filter.element_filters.length).to eq(1)
         expect(filter.element_filters["/foo"].matchers).
-          to eq(["bar", "baz"])
+          to eq([["bar", "baz"]])
 
         description.foo = SimpleInspectTaskScope.new
         ""

--- a/spec/unit/inspect_task_spec.rb
+++ b/spec/unit/inspect_task_spec.rb
@@ -187,7 +187,7 @@ Inspecting foo...
         name,
         current_user_non_root,
         ["foo"],
-        Filter.new("\"/foo=bar,baz\"")
+        Filter.new("/foo=bar,baz")
       )
     end
 
@@ -198,7 +198,7 @@ Inspecting foo...
         name,
         current_user_non_root,
         ["foo"],
-        Filter.new("\"/foo=bar,baz\"")
+        Filter.new("/foo=bar,baz")
       )
 
       expected = ["/foo=bar,baz"]
@@ -209,7 +209,7 @@ Inspecting foo...
       description = SystemDescription.new(name, store)
       expect(SystemDescription).to receive(:load).and_return(description)
 
-      description.set_filter("inspect", Filter.new("/foo=bar,/baz=qux"))
+      description.set_filter("inspect", Filter.new(["/foo=bar", "/baz=qux"]))
 
       description = inspect_task.inspect_system(
         store,
@@ -217,7 +217,7 @@ Inspecting foo...
         name,
         current_user_non_root,
         ["foo"],
-        Filter.new("/foo=baz,/baz=somethingelse")
+        Filter.new(["/foo=baz", "/baz=somethingelse"])
       )
 
       expected = [

--- a/spec/unit/inspect_task_spec.rb
+++ b/spec/unit/inspect_task_spec.rb
@@ -74,13 +74,13 @@ describe InspectTask, "#inspect_system" do
   it "runs the proper inspector when a scope is given" do
     expect(Inspector).to receive(:for).with("foo").and_return(FooInspector.new)
 
-    inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"], "")
+    inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"], Filter.new)
   end
 
   it "saves the inspection data after each inspection and not just at the end" do
     expect_any_instance_of(SystemDescription).to receive(:save).twice
 
-    inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo", "bar"], "")
+    inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo", "bar"], Filter.new)
   end
 
   it "creates a proper system description" do
@@ -90,7 +90,7 @@ describe InspectTask, "#inspect_system" do
       name,
       current_user_non_root,
       ["foo"],
-      ""
+      Filter.new
     )
 
     expect(description.foo).to eql(SimpleInspectTaskScope.new("bar" => "baz"))
@@ -104,7 +104,7 @@ describe InspectTask, "#inspect_system" do
         and_raise(Machinery::Errors::SshConnectionFailed, "This is an SSH error")
 
       expect {
-        inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"], "")
+        inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"], Filter.new)
       }.to raise_error(
         Machinery::Errors::InspectionFailed,
         /Errors while inspecting foo:\n -> This is an SSH error/
@@ -122,7 +122,7 @@ Inspecting foo...
       expect_any_instance_of(FooInspector).to receive(:inspect).and_raise(RuntimeError)
 
       expect {
-        inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"], "")
+        inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"], Filter.new)
       }.to raise_error(RuntimeError)
     end
   end
@@ -135,7 +135,7 @@ Inspecting foo...
 
       it "raises an exception we don't run as root" do
         expect {
-          inspect_task.inspect_system(store, "localhost", name, current_user_non_root, ["foo"], "")
+          inspect_task.inspect_system(store, "localhost", name, current_user_non_root, ["foo"], Filter.new)
         }.to raise_error(Machinery::Errors::MissingRequirement)
       end
 
@@ -143,7 +143,7 @@ Inspecting foo...
         allow(Inspector).to receive(:all) { [] }
 
         expect {
-          inspect_task.inspect_system(store, "localhost", name, current_user_root, ["foo"], "")
+          inspect_task.inspect_system(store, "localhost", name, current_user_root, ["foo"], Filter.new)
         }.not_to raise_error
       end
     end
@@ -157,35 +157,9 @@ Inspecting foo...
         allow(Inspector).to receive(:all) { [] }
 
         expect {
-          inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"], "")
+          inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"], Filter.new)
         }.not_to raise_error
       end
-    end
-  end
-
-  describe "with the :skip_files option" do
-    it "maps it to an unmanaged_files filter" do
-      inspector = FooInspector.new
-      expect(Inspector).to receive(:for).and_return(inspector)
-
-      expect(inspector).to receive(:inspect) do |_system, description, filter, _options|
-        expect(filter.element_filters.length).to eq(1)
-        expect(filter.element_filters["/unmanaged_files/files/name"].matchers).
-          to eq(["/foo/bar"])
-
-        description.foo = SimpleInspectTaskScope.new
-        ""
-      end
-
-      inspect_task.inspect_system(
-        store,
-        host,
-        name,
-        current_user_non_root,
-        ["foo"],
-        "",
-        skip_files: "/foo/bar"
-      )
     end
   end
 
@@ -209,7 +183,7 @@ Inspecting foo...
         name,
         current_user_non_root,
         ["foo"],
-        "\"/foo=bar,baz\""
+        Filter.new("\"/foo=bar,baz\"")
       )
     end
 
@@ -220,7 +194,7 @@ Inspecting foo...
         name,
         current_user_non_root,
         ["foo"],
-        "\"/foo=bar,baz\""
+        Filter.new("\"/foo=bar,baz\"")
       )
 
       expected = ["/foo=bar,baz"]
@@ -239,7 +213,7 @@ Inspecting foo...
         name,
         current_user_non_root,
         ["foo"],
-        "\"/foo=baz\""
+        Filter.new("\"/foo=baz\"")
       )
 
       expected = [

--- a/spec/unit/inspect_task_spec.rb
+++ b/spec/unit/inspect_task_spec.rb
@@ -80,7 +80,8 @@ describe InspectTask, "#inspect_system" do
   it "saves the inspection data after each inspection and not just at the end" do
     expect_any_instance_of(SystemDescription).to receive(:save).twice
 
-    inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo", "bar"], Filter.new)
+    inspect_task.inspect_system(store, host, name, current_user_non_root,
+      ["foo", "bar"], Filter.new)
   end
 
   it "creates a proper system description" do
@@ -104,7 +105,8 @@ describe InspectTask, "#inspect_system" do
         and_raise(Machinery::Errors::SshConnectionFailed, "This is an SSH error")
 
       expect {
-        inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"], Filter.new)
+        inspect_task.inspect_system(store, host, name, current_user_non_root,
+          ["foo"], Filter.new)
       }.to raise_error(
         Machinery::Errors::InspectionFailed,
         /Errors while inspecting foo:\n -> This is an SSH error/
@@ -135,7 +137,8 @@ Inspecting foo...
 
       it "raises an exception we don't run as root" do
         expect {
-          inspect_task.inspect_system(store, "localhost", name, current_user_non_root, ["foo"], Filter.new)
+          inspect_task.inspect_system(store, "localhost", name, current_user_non_root,
+            ["foo"], Filter.new)
         }.to raise_error(Machinery::Errors::MissingRequirement)
       end
 
@@ -143,7 +146,8 @@ Inspecting foo...
         allow(Inspector).to receive(:all) { [] }
 
         expect {
-          inspect_task.inspect_system(store, "localhost", name, current_user_root, ["foo"], Filter.new)
+          inspect_task.inspect_system(store, "localhost", name, current_user_root,
+            ["foo"], Filter.new)
         }.not_to raise_error
       end
     end

--- a/spec/unit/inspect_task_spec.rb
+++ b/spec/unit/inspect_task_spec.rb
@@ -74,13 +74,13 @@ describe InspectTask, "#inspect_system" do
   it "runs the proper inspector when a scope is given" do
     expect(Inspector).to receive(:for).with("foo").and_return(FooInspector.new)
 
-    inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"])
+    inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"], "")
   end
 
   it "saves the inspection data after each inspection and not just at the end" do
     expect_any_instance_of(SystemDescription).to receive(:save).twice
 
-    inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo", "bar"])
+    inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo", "bar"], "")
   end
 
   it "creates a proper system description" do
@@ -89,31 +89,11 @@ describe InspectTask, "#inspect_system" do
       host,
       name,
       current_user_non_root,
-      ["foo"]
+      ["foo"],
+      ""
     )
 
     expect(description.foo).to eql(SimpleInspectTaskScope.new("bar" => "baz"))
-  end
-
-  describe "with the :skip_files option" do
-    it "maps it to an unmanaged_files filter" do
-      expect_any_instance_of(FooInspector).
-        to receive(:inspect) do |_inspector, _description, _system, options|
-        filter = options[:filter]
-        expect(filter.element_filters.length).to eq(1)
-        expect(filter.element_filters["/unmanaged_files/files/name"].matchers).
-          to eq(["/foo/bar"])
-      end.and_call_original
-
-      inspect_task.inspect_system(
-        store,
-        host,
-        name,
-        current_user_non_root,
-        ["foo"],
-        skip_files: "/foo/bar"
-      )
-    end
   end
 
   describe "in case of inspection errors" do
@@ -124,7 +104,7 @@ describe InspectTask, "#inspect_system" do
         and_raise(Machinery::Errors::SshConnectionFailed, "This is an SSH error")
 
       expect {
-        inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"])
+        inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"], "")
       }.to raise_error(
         Machinery::Errors::InspectionFailed,
         /Errors while inspecting foo:\n -> This is an SSH error/
@@ -142,7 +122,7 @@ Inspecting foo...
       expect_any_instance_of(FooInspector).to receive(:inspect).and_raise(RuntimeError)
 
       expect {
-        inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"])
+        inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"], "")
       }.to raise_error(RuntimeError)
     end
   end
@@ -155,7 +135,7 @@ Inspecting foo...
 
       it "raises an exception we don't run as root" do
         expect {
-          inspect_task.inspect_system(store, "localhost", name, current_user_non_root, ["foo"])
+          inspect_task.inspect_system(store, "localhost", name, current_user_non_root, ["foo"], "")
         }.to raise_error(Machinery::Errors::MissingRequirement)
       end
 
@@ -163,7 +143,7 @@ Inspecting foo...
         allow(Inspector).to receive(:all) { [] }
 
         expect {
-          inspect_task.inspect_system(store, "localhost", name, current_user_root, ["foo"])
+          inspect_task.inspect_system(store, "localhost", name, current_user_root, ["foo"], "")
         }.not_to raise_error
       end
     end
@@ -177,9 +157,96 @@ Inspecting foo...
         allow(Inspector).to receive(:all) { [] }
 
         expect {
-          inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"])
+          inspect_task.inspect_system(store, host, name, current_user_non_root, ["foo"], "")
         }.not_to raise_error
       end
+    end
+  end
+
+  describe "with the :skip_files option" do
+    it "maps it to an unmanaged_files filter" do
+      inspector = FooInspector.new
+      expect(Inspector).to receive(:for).and_return(inspector)
+
+      expect(inspector).to receive(:inspect) do |_system, description, filter, _options|
+        expect(filter.element_filters.length).to eq(1)
+        expect(filter.element_filters["/unmanaged_files/files/name"].matchers).
+          to eq(["/foo/bar"])
+
+        description.foo = SimpleInspectTaskScope.new
+        ""
+      end
+
+      inspect_task.inspect_system(
+        store,
+        host,
+        name,
+        current_user_non_root,
+        ["foo"],
+        "",
+        skip_files: "/foo/bar"
+      )
+    end
+  end
+
+  context "with filters" do
+    it "passes the filters to the inspectors" do
+      inspector = FooInspector.new
+      expect(Inspector).to receive(:for).and_return(inspector)
+
+      expect(inspector).to receive(:inspect) do |_system, description, filter, _options|
+        expect(filter.element_filters.length).to eq(1)
+        expect(filter.element_filters["/foo"].matchers).
+          to eq(["bar", "baz"])
+
+        description.foo = SimpleInspectTaskScope.new
+        ""
+      end
+
+      inspect_task.inspect_system(
+        store,
+        host,
+        name,
+        current_user_non_root,
+        ["foo"],
+        "\"/foo=bar,baz\""
+      )
+    end
+
+    it "stores the filters in the system description" do
+      description = inspect_task.inspect_system(
+        store,
+        host,
+        name,
+        current_user_non_root,
+        ["foo"],
+        "\"/foo=bar,baz\""
+      )
+
+      expected = ["/foo=bar,baz"]
+      expect(description.filters["inspect"].to_array).to eq(expected)
+    end
+
+    it "only sets filters for scopes that were inspected" do
+      description = SystemDescription.new(name, store)
+      expect(SystemDescription).to receive(:load).and_return(description)
+
+      description.set_filter("inspect", Filter.new("/foo=bar,/baz=qux"))
+
+      description = inspect_task.inspect_system(
+        store,
+        host,
+        name,
+        current_user_non_root,
+        ["foo"],
+        "\"/foo=baz\""
+      )
+
+      expected = [
+        "/foo=baz",
+        "/baz=qux"
+      ]
+      expect(description.filters["inspect"].to_array).to match_array(expected)
     end
   end
 end

--- a/spec/unit/inspect_task_spec.rb
+++ b/spec/unit/inspect_task_spec.rb
@@ -217,7 +217,7 @@ Inspecting foo...
         name,
         current_user_non_root,
         ["foo"],
-        Filter.new("\"/foo=baz\"")
+        Filter.new("/foo=baz,/baz=somethingelse")
       )
 
       expected = [

--- a/spec/unit/spec_helper.rb
+++ b/spec/unit/spec_helper.rb
@@ -52,6 +52,7 @@ shared_context "machinery test directory" do
 
   before(:each) do
     FakeFS::FileSystem.clone("schema/")
+    FakeFS::FileSystem.clone("helpers/")
   end
 
   def create_machinery_dir(name = test_name)

--- a/spec/unit/system_description_spec.rb
+++ b/spec/unit/system_description_spec.rb
@@ -468,4 +468,23 @@ describe SystemDescription do
       end
     end
   end
+
+  describe "#set_filter" do
+    subject { create_test_description }
+
+    it "sets the inspection filters" do
+      expect(subject.to_hash["meta"]["filters"]).to be(nil)
+      expected = ["/foo=bar", "/scope=filter"]
+
+      subject.set_filter("inspect", Filter.new("/foo=bar,/scope=filter"))
+      filters = subject.to_hash["meta"]["filters"]["inspect"]
+      expect(filters).to eq(expected)
+    end
+
+    it "only supports inspection filters" do
+      expect {
+        subject.set_filter("show", Filter.new("/foo=bar,/scope=filter"))
+      }.to raise_error(/not supported/)
+    end
+  end
 end

--- a/spec/unit/system_description_spec.rb
+++ b/spec/unit/system_description_spec.rb
@@ -491,14 +491,14 @@ describe SystemDescription do
       expect(subject.to_hash["meta"]["filters"]).to be(nil)
       expected = ["/foo=bar", "/foo=baz", "/scope=filter"]
 
-      subject.set_filter("inspect", Filter.new("/foo=bar,/foo=baz,/scope=filter"))
+      subject.set_filter("inspect", Filter.new(["/foo=bar", "/foo=baz", "/scope=filter"]))
       filters = subject.to_hash["meta"]["filters"]["inspect"]
       expect(filters).to eq(expected)
     end
 
     it "only supports inspection filters" do
       expect {
-        subject.set_filter("show", Filter.new("/foo=bar,/scope=filter"))
+        subject.set_filter("show", Filter.new(["/foo=bar", "/scope=filter"]))
       }.to raise_error(/not supported/)
     end
   end

--- a/spec/unit/system_description_spec.rb
+++ b/spec/unit/system_description_spec.rb
@@ -423,7 +423,15 @@ describe SystemDescription do
     let(:store) { system_description_factory_store }
 
     before(:each) do
-      create_test_description(name: "description1", store_on_disk: true)
+      create_test_description(
+        name: "description1",
+        store_on_disk: true,
+        filters: {
+          "inspect" => [
+            "/unmanaged_files/files/name=/opt*"
+          ]
+        }
+      )
     end
 
     describe ".load" do
@@ -465,6 +473,13 @@ describe SystemDescription do
         )
 
         SystemDescription.load("description1", store, skip_format_compatibility: true)
+      end
+
+      it "reads the filter information" do
+        description = SystemDescription.load("description1", store)
+        expect(description.filters["inspect"]).to be_a(Filter)
+        expect(description.filters["inspect"].
+          element_filter_for("/unmanaged_files/files/name").matchers).to eq(["/opt*"])
       end
     end
   end

--- a/spec/unit/system_description_spec.rb
+++ b/spec/unit/system_description_spec.rb
@@ -474,9 +474,9 @@ describe SystemDescription do
 
     it "sets the inspection filters" do
       expect(subject.to_hash["meta"]["filters"]).to be(nil)
-      expected = ["/foo=bar", "/scope=filter"]
+      expected = ["/foo=bar", "/foo=baz", "/scope=filter"]
 
-      subject.set_filter("inspect", Filter.new("/foo=bar,/scope=filter"))
+      subject.set_filter("inspect", Filter.new("/foo=bar,/foo=baz,/scope=filter"))
       filters = subject.to_hash["meta"]["filters"]["inspect"]
       expect(filters).to eq(expected)
     end

--- a/spec/unit/unmanaged_files_inspector_spec.rb
+++ b/spec/unit/unmanaged_files_inspector_spec.rb
@@ -367,7 +367,7 @@ describe UnmanagedFilesInspector do
 
       expect_inspect_unmanaged(system, true, false, ["/usr/local", "/etc/skel/.config"])
 
-      filter = Filter.new("\"/unmanaged_files/files/name=/usr/local/*,/etc/skel/.config\"")
+      filter = Filter.new("/unmanaged_files/files/name=/usr/local/*,/unmanaged_files/files/name=/etc/skel/.config")
       subject.inspect(system, description, filter)
       names = description["unmanaged_files"].files.map(&:name)
 

--- a/spec/unit/unmanaged_files_inspector_spec.rb
+++ b/spec/unit/unmanaged_files_inspector_spec.rb
@@ -386,7 +386,7 @@ describe UnmanagedFilesInspector do
         "rpm", "--version"
       ).and_raise(Machinery::Errors::MissingRequirement)
 
-      expect{subject.inspect(system, description, default_filter)}.to raise_error(
+      expect { subject.inspect(system, description, default_filter) }.to raise_error(
         Machinery::Errors::MissingRequirement)
     end
 

--- a/spec/unit/unmanaged_files_inspector_spec.rb
+++ b/spec/unit/unmanaged_files_inspector_spec.rb
@@ -367,7 +367,9 @@ describe UnmanagedFilesInspector do
 
       expect_inspect_unmanaged(system, true, false, ["/usr/local", "/etc/skel/.config"])
 
-      filter = Filter.new("/unmanaged_files/files/name=/usr/local/*,/unmanaged_files/files/name=/etc/skel/.config")
+      filter = Filter.new(
+        "/unmanaged_files/files/name=/usr/local/*,/unmanaged_files/files/name=/etc/skel/.config"
+      )
       subject.inspect(system, description, filter)
       names = description["unmanaged_files"].files.map(&:name)
 

--- a/spec/unit/unmanaged_files_inspector_spec.rb
+++ b/spec/unit/unmanaged_files_inspector_spec.rb
@@ -367,7 +367,7 @@ describe UnmanagedFilesInspector do
 
       expect_inspect_unmanaged(system, true, false, ["/usr/local", "/etc/skel/.config"])
 
-      filter = Filter.new("/unmanaged_files/files/name=/usr/local/*,/etc/skel/.config")
+      filter = Filter.new("\"/unmanaged_files/files/name=/usr/local/*,/etc/skel/.config\"")
       subject.inspect(system, description, filter)
       names = description["unmanaged_files"].files.map(&:name)
 

--- a/spec/unit/unmanaged_files_inspector_spec.rb
+++ b/spec/unit/unmanaged_files_inspector_spec.rb
@@ -371,9 +371,9 @@ describe UnmanagedFilesInspector do
 
       expect_inspect_unmanaged(system, true, false, ["/usr/local", "/etc/skel/.config"])
 
+      default_filter.add_element_filter_from_definition("/unmanaged_files/files/name=/usr/local/*")
       default_filter.add_element_filter_from_definition(
-        "/unmanaged_files/files/name=/usr/local/*,/unmanaged_files/files/name=/etc/skel/.config"
-      )
+        "/unmanaged_files/files/name=/etc/skel/.config")
       subject.inspect(system, description, default_filter)
       names = description["unmanaged_files"].files.map(&:name)
 


### PR DESCRIPTION
Please review the following changes:
  * e2b1627 Add documentation for the Filter class
  * 0c1861b Add copyright notes
  * df6bed7 Fix filter behavior regarding arrays in the filter definition
  * b00bc21 Do not require quoting of array filters when there's only one filter
  * 3debe88 Improve method name
  * 89bacf1 Fix hound issues
  * cfaf825 Extract filter preparation and handling code into separate methods
  * 8d28733 Adapt schema to allow storing the used filter during inspection
  * 4a49a06 Adapt to new signature of InspectTask#inspect_system
  * 42b59fe Store filter which was used for inspection in the description metadata
  * 42a0f6c Add Filter#to_array which returns an array of element filter definitions
  * 42c76a0 Fix parsing of filter definitions with simple lists
  * 0c93bc5 Add Filter#add_filter_definition which adds new element filters
  * 85a2ec3 Make Filter#parse_filter_definition a class method