### PR TITLE
[Review] Request from 'aduffeck' @ 'SUSE/machinery/review_150312_fix_filtering_with_trailing_slash'

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -672,6 +672,8 @@ class Cli
 
       files.reject!(&:empty?) # Ignore empty filters
       files.map! { |file| file.gsub("\\@", "@") } # Unescape escaped @s
+      files.map! { |file| file.chomp("/") } # List directories without the trailing /, in order to
+                                            # not confuse the unmanaged files inspector
       files.each do |file|
         filter.add_element_filter_from_definition("/unmanaged_files/files/name=#{file}")
       end


### PR DESCRIPTION
Please review the following changes:
  * 6e187e6 Remove trailing spaces from filter definitions
  * 46b2a28 Merge pull request #691 from SUSE/fix_688
  * 493d543 Make addtional rpm changes unit test more self-explanatory
  * 65a06e7 Fix rpm_changes recognition on sles11sp3