### PR TITLE
[Review] Request from 'aduffeck' @ 'SUSE/machinery/implement_experimental_features_option'

### DIFF
--- a/lib/config.rb
+++ b/lib/config.rb
@@ -28,6 +28,10 @@ module Machinery
         default:     true,
         description: "Show hints about usage of Machinery in the context of the commands ran by the user"
       )
+      entry("experimental-features",
+        default:     false,
+        description: "Enable experimental features. Use at your own risk."
+      )
     end
   end
 end

--- a/lib/config_base.rb
+++ b/lib/config_base.rb
@@ -32,6 +32,8 @@ class ConfigBase
   end
 
   def entry(key, parameters = {})
+    key = normalize_key(key)
+
     @entries[key] = { value: parameters[:default], description: parameters[:description] }
      create_method(key.to_sym) { get(key) }
      create_method("#{key}=".to_sym) { |value| set(key, value) }
@@ -42,15 +44,18 @@ class ConfigBase
   end
 
   def each(&block)
-    @entries.each(&block)
+    @entries.map { |key, value| [unnormalize_key(key), value] }.each(&block)
   end
 
   def get(key)
+    key = normalize_key(key)
+
     ensure_config_exists(key)
     @entries[key][:value]
   end
 
   def set(key, value, options = {auto_save: true} )
+    key = normalize_key(key)
     ensure_config_exists(key)
 
     # Check if data type is correct. true and false are not of the same type which makes the check complex
@@ -113,5 +118,13 @@ class ConfigBase
 
   def create_method(name, &block)
     self.class.send(:define_method, name, &block)
+  end
+
+  def normalize_key(key)
+    key.gsub("-", "_")
+  end
+
+  def unnormalize_key(key)
+    key.gsub("_", "-")
   end
 end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -21,6 +21,18 @@ describe Machinery::Config do
   include FakeFS::SpecHelpers
   subject { Machinery::Config.new }
 
+  it "works with keys with dashes in the name" do
+    subject.entry("config-key", default: "configvalue", description: "configtext")
+
+    subject.set("config-key", "newconfigvalue")
+    expect(subject.get("config-key")).to eq("newconfigvalue")
+    expect(subject.config_key).to eq("newconfigvalue")
+
+    keys = []
+    subject.each { |key, _value| keys << key }
+    expect(keys).to include("config-key")
+  end
+
   describe "#get" do
     it "returns the default value" do
       subject.entry("configkey", default: "configvalue", description: "configtext")


### PR DESCRIPTION
Please review the following changes:
  * dcf4ebc Add a "experimental-features" option (disabled by default)
  * 99dae2b Add support for configuration options with '-'s