### PR TITLE
Allow exporting of openSUSE 13.2 kiwi-configs

### DIFF
--- a/lib/kiwi_config.rb
+++ b/lib/kiwi_config.rb
@@ -148,23 +148,23 @@ suseImportBuildKey
 suseConfig
 EOF
     case @system_description.os
-      when OsOpenSuse13_2
-        boot = "vmxboot/suse-13.2"
-        bootloader = "grub2"
-      when OsOpenSuse13_1
-        boot = "vmxboot/suse-13.1"
-        bootloader = "grub2"
-      when OsSles12
-        boot = "vmxboot/suse-SLES12"
-        bootloader = "grub2"
-      when OsSles11
-        boot = "vmxboot/suse-SLES11"
-        bootloader = "grub"
-      else
-        raise Machinery::Errors::ExportFailed.new(
-          "Export is not possible because the operating system " \
-          "'#{@system_description.os.display_name}' is not supported."
-        )
+    when OsOpenSuse13_2
+      boot = "vmxboot/suse-13.2"
+      bootloader = "grub2"
+    when OsOpenSuse13_1
+      boot = "vmxboot/suse-13.1"
+      bootloader = "grub2"
+    when OsSles12
+      boot = "vmxboot/suse-SLES12"
+      bootloader = "grub2"
+    when OsSles11
+      boot = "vmxboot/suse-SLES11"
+      bootloader = "grub"
+    else
+      raise Machinery::Errors::ExportFailed.new(
+        "Export is not possible because the operating system " \
+        "'#{@system_description.os.display_name}' is not supported."
+      )
     end
 
     builder = Nokogiri::XML::Builder.new do |xml|

--- a/lib/kiwi_config.rb
+++ b/lib/kiwi_config.rb
@@ -148,6 +148,9 @@ suseImportBuildKey
 suseConfig
 EOF
     case @system_description.os
+      when OsOpenSuse13_2
+        boot = "vmxboot/suse-13.2"
+        bootloader = "grub2"
       when OsOpenSuse13_1
         boot = "vmxboot/suse-13.1"
         bootloader = "grub2"


### PR DESCRIPTION
This fixes #716.

To properly fix the issue we should incorporate the boot information in our OS data modell I suppose so there is no additional check needed in kiwi_config.