### PR TITLE
Fix rpm building

### DIFF
--- a/machinery.spec.erb
+++ b/machinery.spec.erb
@@ -125,6 +125,10 @@ popd
 # Here we do a surgery on the binary to actually load the bundled gems. This is
 # a hack, but it can't be done anywhere else because the binary is generated
 # during gem install.
+# work around issue with machinery2.0 binary naming (related to /etc/gemrc)
+%if 0%{?suse_version} == 1310
+  mv "%{buildroot}%{_bindir}/%{binary_name}"* "%{buildroot}%{_bindir}/%{binary_name}"
+%endif
 sed -i '/gem/i \
 Gem.path.unshift("%{_libdir}/ruby/gems/%{rb_ver}/gems/%{mod_full_name}/bundle/ruby/%{rb_ver}")
 

--- a/machinery.spec.erb
+++ b/machinery.spec.erb
@@ -125,13 +125,10 @@ popd
 # Here we do a surgery on the binary to actually load the bundled gems. This is
 # a hack, but it can't be done anywhere else because the binary is generated
 # during gem install.
-for i in $(/usr/bin/ruby-find-versioned ruby)  ; do
-  rubysuffix="${i#/usr/bin/ruby}"
-  sed -i '/gem/i \
-  Gem.path.unshift("%{_libdir}/ruby/gems/%{rb_ver}/gems/%{mod_full_name}/bundle/ruby/%{rb_ver}")
+sed -i '/gem/i \
+Gem.path.unshift("%{_libdir}/ruby/gems/%{rb_ver}/gems/%{mod_full_name}/bundle/ruby/%{rb_ver}")
 
-  ' %{buildroot}%{_bindir}/%{binary_name}$rubysuffix
-done
+' %{buildroot}%{_bindir}/%{binary_name}
 
 # Man page & additional files
 
@@ -146,7 +143,7 @@ ln -s %{_libdir}/ruby/gems/%{rb_ver}/gems/%{mod_full_name}/NEWS
 
 %files
 %defattr(-,root,root,-)
-%{_bindir}/%{binary_name}*
+%{_bindir}/%{binary_name}
 %{_libdir}/ruby/gems/%{rb_ver}/cache/%{mod_full_name}.gem
 %{_libdir}/ruby/gems/%{rb_ver}/gems/%{mod_full_name}/
 %{_libdir}/ruby/gems/%{rb_ver}/specifications/%{mod_full_name}.gemspec


### PR DESCRIPTION
Fixing the original issue that caused us to create the commit
dd4761784697aadfc7f7acc66cfcae85a33923fb
    
Building machinery on 13.1 failed because the ruby macros were changed
recently and an issue in the 13.1 /etc/gemrc resulted in always renaming
machinery to machinery2.0 which normally should only happen for symlink
builds.