### PR TITLE
Fix ugly error messages in test output while trying to clean up

### DIFF
--- a/spec/integration/support/autoyast_export_examples.rb
+++ b/spec/integration/support/autoyast_export_examples.rb
@@ -17,7 +17,9 @@
 
 shared_examples "autoyast export" do
   after(:all) do
-    @machinery.run_command("test -d /tmp/jeos-autoyast && rm -r /tmp/jeos-autoyast")
+    if @machinery.running?
+      @machinery.run_command("test -d /tmp/jeos-autoyast && rm -r /tmp/jeos-autoyast")
+    end
   end
 
   describe "export-autoyast" do

--- a/spec/integration/support/kiwi_export_examples.rb
+++ b/spec/integration/support/kiwi_export_examples.rb
@@ -17,7 +17,9 @@
 
 shared_examples "kiwi export" do
   after(:all) do
-    @machinery.run_command("test -d /tmp/jeos-kiwi && rm -r /tmp/jeos-kiwi")
+    if @machinery.running?
+      @machinery.run_command("test -d /tmp/jeos-kiwi && rm -r /tmp/jeos-kiwi")
+    end
   end
 
   describe "export-kiwi" do


### PR DESCRIPTION
On some systems we clean up the export directories after the tests (e.g.
on local systems), but other systems aren't available for running the
cleanup commands anymore. This commit makes sure to only do the clean up
if the system is still available.

Depends on https://github.com/SUSE/pennyworth/pull/58
