### PR TITLE
Get rid of Ui.print_output, Ui.puts supports paging transparently now

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -51,6 +51,7 @@ class Cli
 
       Hint.print(:get_started)
     end
+    Machinery::Ui.close_pager
   end
 
   GLI::Commands::Help.skips_post = false
@@ -277,6 +278,8 @@ class Cli
       desc: "Pipe output into a pager"
 
     c.action do |global_options,options,args|
+      Machinery::Ui.use_pager = options[:pager]
+
       name1 = shift_arg(args, "NAME1")
       name2 = shift_arg(args, "NAME2")
       store = system_description_store
@@ -286,8 +289,7 @@ class Cli
 
       task = CompareTask.new
       opts = {
-          show_all: options["show-all"],
-          no_pager: !options["pager"]
+        show_all: options["show-all"]
       }
       task.compare(description1, description2, scope_list, opts)
     end
@@ -558,6 +560,8 @@ class Cli
       desc: "Show the filters that were applied before showing the description."
 
     c.action do |global_options,options,args|
+      Machinery::Ui.use_pager = options["pager"]
+
       name = shift_arg(args, "NAME")
       if name == "localhost" && !CurrentUser.new.is_root?
         Machinery::Ui.puts "You need root rights to access the system description of your locally inspected system."
@@ -574,7 +578,6 @@ class Cli
 
       task = ShowTask.new
       opts = {
-          no_pager:   !options["pager"],
           show_diffs: options["show-diffs"],
           show_html:  options["html"]
       }

--- a/lib/compare_task.rb
+++ b/lib/compare_task.rb
@@ -19,7 +19,7 @@ class CompareTask
   def compare(description1, description2, scopes, options = {})
     output = render_comparison(description1, description2, scopes, options)
 
-    Machinery::Ui.print_output(output, :no_pager => options[:no_pager])
+    Machinery::Ui.puts output
   end
 
   def render_comparison(description1, description2, scopes, options = {})

--- a/lib/show_task.rb
+++ b/lib/show_task.rb
@@ -43,24 +43,21 @@ class ShowTask
 
   def show_console(description, scopes, options)
     missing_scopes = []
-    output = ""
 
     scopes.map { |s| Renderer.for(s) }.each do |renderer|
       section = renderer.render(description, options)
       unless section.empty?
-        output += section
+        Machinery::Ui.puts section
       else
         missing_scopes << renderer.scope
       end
     end
 
     if missing_scopes.length > 0
-      output += "# The following requested scopes were not inspected\n\n"
+      Machinery::Ui.puts "# The following requested scopes were not inspected\n\n"
       missing_scopes.each do |scope|
-        output += "  * #{Machinery::Ui.internal_scope_list_to_string(scope)}\n"
+        Machinery::Ui.puts "  * #{Machinery::Ui.internal_scope_list_to_string(scope)}\n"
       end
     end
-
-    Machinery::Ui.print_output(output, :no_pager => options[:no_pager])
   end
 end

--- a/spec/support/machinery_output.rb
+++ b/spec/support/machinery_output.rb
@@ -22,7 +22,7 @@ module MachineryOutput
 
   def silence_machinery_output
     before(:each) do
-      [:puts, :warn, :error, :print_output].each do |method|
+      [:puts, :warn, :error].each do |method|
         allow(Machinery::Ui).to receive(method)
       end
     end

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -327,7 +327,7 @@ describe Cli do
       it "triggers the show task for packages when scope packages is specified" do
         description = create_test_description(json: test_manifest)
         expect_any_instance_of(ShowTask).to receive(:show).with(
-          description, ["packages"], an_instance_of(Filter), no_pager: true, show_diffs: false,
+          description, ["packages"], an_instance_of(Filter), show_diffs: false,
             show_html: false)
 
         run_command(["show", "description1", "--scope=packages", "--no-pager"])

--- a/spec/unit/compare_task_spec.rb
+++ b/spec/unit/compare_task_spec.rb
@@ -18,6 +18,8 @@ require_relative "spec_helper"
 
 describe CompareTask do
   describe "#compare" do
+    capture_machinery_output
+
     class CompareTaskFooScope < Machinery::Array
       include Machinery::ScopeMixin
     end
@@ -216,70 +218,63 @@ Compared descriptions are identical.
     describe "when the descriptions are different" do
       it "produces correct output" do
         setup_renderers
-
-        allow($stdout).to receive(:tty?).and_return(false)
-
-        expect(Machinery::Ui).to receive(:print_output).with(output_different, anything)
-
         subject.compare(
           description1,
           description2,
           ["compare_task_foo", "compare_task_bar", "compare_task_baz"]
         )
+
+        expect(captured_machinery_output.strip).to eq(output_different.strip)
       end
 
       it "prints a message when a description is incomplete" do
         setup_renderers
-
-        allow($stdout).to receive(:tty?).and_return(false)
-
-        expect(Machinery::Ui).to receive(:print_output).with(output_missing, anything)
 
         subject.compare(
           description3,
           description4,
           ["compare_task_foo", "compare_task_bar", "compare_task_baz", "compare_task_foobar"]
         )
+
+        expect(captured_machinery_output.strip).to eq(output_missing.strip)
       end
     end
 
     describe "when the descriptions are the same" do
       before :each do
         setup_renderers
-
-        allow($stdout).to receive(:tty?).and_return(false)
       end
 
       it "produces correct output when :show_all is set to false" do
-        expect(Machinery::Ui).to receive(:print_output).with(output_same_show_all_false, anything)
-
         subject.compare(
           description1,
           description1,
           ["compare_task_foo", "compare_task_bar", "compare_task_baz"],
           show_all: false
         )
+
+        expect(captured_machinery_output.strip).to eq(output_same_show_all_false.strip)
       end
 
       it "produces correct output when :show_all is set to true" do
-        expect(Machinery::Ui).to receive(:print_output).with(output_same_show_all_true, anything)
-
         subject.compare(
           description1,
           description1,
           ["compare_task_foo", "compare_task_bar", "compare_task_baz"],
           show_all: true
         )
+
+        expect(captured_machinery_output.strip).to eq(output_same_show_all_true.strip)
       end
 
       it "produces correct output when scopes are missing" do
-        expect(Machinery::Ui).to receive(:print_output).with(output_missing_same, anything)
-
         subject.compare(
           description3,
           description3,
           ["compare_task_foo", "compare_task_bar", "compare_task_baz"]
         )
+
+        expect(captured_machinery_output.strip).to eq(output_missing_same.strip)
       end
     end
   end

--- a/spec/unit/show_task_spec.rb
+++ b/spec/unit/show_task_spec.rb
@@ -19,7 +19,7 @@ require_relative "spec_helper"
 
 
 describe ShowTask, "#show" do
-  silence_machinery_output
+  capture_machinery_output
 
   let(:show_task) { ShowTask.new }
   let(:system_description) {
@@ -43,20 +43,18 @@ describe ShowTask, "#show" do
 
   it "prints scopes missing from the system description" do
     scope = "packages"
-    expect(Machinery::Ui).to receive(:print_output) { |s|
-      expect(s).to include("requested scopes were not inspected")
-      expect(s).to include("packages")
-    }
     show_task.show(system_description, [scope], Filter.new, no_pager: true)
+
+    expect(captured_machinery_output).to include("requested scopes were not inspected")
+    expect(captured_machinery_output).to include("packages")
   end
 
   it "does not show a message about missing scopes if there are none" do
     scope = "packages"
-    expect(Machinery::Ui).to receive(:print_output) { |s|
-      expect(s).not_to include("requested scopes were not inspected")
-      expect(s).not_to include("packages")
-    }
     show_task.show(description_with_packages, [scope], Filter.new, no_pager: true)
+
+    expect(captured_machinery_output).to_not include("requested scopes were not inspected")
+    expect(captured_machinery_output).to_not include("packages")
   end
 
   it "opens the system description in the web browser" do

--- a/spec/unit/ui_spec.rb
+++ b/spec/unit/ui_spec.rb
@@ -34,7 +34,11 @@ describe Machinery::Ui do
     end
   end
 
-  describe ".print_output" do
+  describe ".puts" do
+    before(:each) do ||
+      expect(Machinery::Ui).to receive(:use_pager).and_return(true)
+    end
+
     let(:output) { "foo bar" }
     it "pipes the output to a pager" do
       ENV['PAGER'] = 'less'
@@ -42,9 +46,9 @@ describe Machinery::Ui do
       allow($stdout).to receive(:tty?).and_return(true)
       allow(IO).to receive(:popen)
       allow($?).to receive(:success?).and_return(true)
-      expect(IO).to receive(:popen).with("$PAGER", "w")
+      expect(IO).to receive(:popen).with("$PAGER", "w").and_return(double(puts: nil))
 
-      Machinery::Ui.print_output(output)
+      Machinery::Ui.puts(output)
     end
 
     it "prints the output to stdout if no pager is available" do
@@ -53,9 +57,9 @@ describe Machinery::Ui do
       allow($stdout).to receive(:tty?).and_return(true)
       allow(LocalSystem).to receive(:validate_existence_of_package).
         and_raise(Machinery::Errors::MissingRequirement)
-      expect(Machinery::Ui).to receive(:puts).with(output)
+      expect($stdout).to receive(:puts).with(output)
 
-      Machinery::Ui.print_output(output)
+      Machinery::Ui.puts(output)
     end
 
     it "raises an error if ENV['PAGER'] is not a valid command" do
@@ -63,7 +67,7 @@ describe Machinery::Ui do
 
       allow($stdout).to receive(:tty?).and_return(true)
 
-      expect { Machinery::Ui.print_output(output) }.
+      expect { Machinery::Ui.puts(output) }.
         to raise_error(Machinery::Errors::InvalidPager, /not_a_pager/)
     end
   end


### PR DESCRIPTION
Machinery::Ui.print_output was used to print output either on the
console (when no pager was available or when the user gave the
--no-pager option) or a pager. That approach was not very flexible,
though, because the whole output had to be given as a string at once.

The new approach now uses the normal Machinery::Ui.puts method. It
writes to the console by default, but a pager can be enabled using

  Machinery::Ui.use_pager = true

That way the output can be composed from several places and can be
streamed to the user instead of having to wait for the whole output
before showing it.
