### PR TITLE
[Review] Request from 'aduffeck' @ 'SUSE/machinery/review_150326_implement_negated_filters2'

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,7 @@
 * Fix piping output of Machinery to less (gh#SUSE/machinery#521)
 * If machinery upgrade-format fails because of validation issues, show the
   user a hint that the option --force can be used.
+* Support negated filter expressions in --exclude option
 
 ## Version 1.5.0 - Fri Mar 13 13:03:47 CET 2015 - thardeck@suse.de
 

--- a/docs/Filtering-Design.md
+++ b/docs/Filtering-Design.md
@@ -89,12 +89,12 @@ As a first step only exact matches are supported, where the
 array has to have exactly the elements specified in the condition. Matches of
 sub arrays will be defined later.
 
-Filters can be inverted by prefixing them with a `!`:
+Filters can be inverted by using the `!=` operator:
 
-    !/scope/element=condition
+    /scope/element!=condition
 
 When applied on a scope this filter results in a list of only the elements
-which match the condition. *Inverted filters are not implemented yet*
+which match the condition.
 
 The first step is basic filtering, which only supports simple matches for
 equalness and don't allow for wild cards or any other more complex regular
@@ -117,7 +117,7 @@ Match the apache package:
 
 Match all services which are not enabled:
 
-    !/services/services/state=enabled
+    /services/services/state!=enabled
 
 Match the home directory of user alfred in unmanaged files:
 
@@ -296,7 +296,7 @@ of the resulting description.
 
 Show all enabled services in description NAME:
 
-    machinery --exclude=!/services/services/state=enabled show NAME
+    machinery --exclude='/services/services/state!=enabled' show NAME
 
 The filter removes all services which match the filter criterion from the
 output. In this case it is all services which are not enabled. So the result is
@@ -385,7 +385,7 @@ it:
 * Step 3: Implement generic `--exclude` option to let users add additional
   filters on demand. This option can also be used in our integration tests.
   (done as experimental option)
-* Step 4: Implement `filter` command and persistent per-description filters.
-* Step 5: Implement user-level persistent filters.
-* Step 6: Implement disabling of filters
-* Step 7: Implement inveretd filters
+* Step 4: Implement inverted filters
+* Step 5: Implement `filter` command and persistent per-description filters.
+* Step 6: Implement user-level persistent filters.
+* Step 7: Implement disabling of filters

--- a/lib/element_filter.rb
+++ b/lib/element_filter.rb
@@ -16,47 +16,55 @@
 # you may find current contact information at www.suse.com
 
 class ElementFilter
-  attr_accessor :path, :operator, :matchers
+  attr_accessor :path, :matchers
 
-  def initialize(path, operator, matchers = nil)
+  def initialize(path, operator = nil, matchers = nil)
     @path = path
-    @operator = operator
-    @matchers = []
+    @matchers = {}
 
-    raise("Wrong filter type") if ![NilClass, String, Array].include?(matchers.class)
-    raise("Wrong filter operator '#{@operator}'") if !["!=", "="].include?(@operator)
+    if ![NilClass, String, Array].include?(matchers.class)
+      raise Machinery::Errors::InvalidFilter.new("Wrong filter type")
+    end
 
-    add_matchers(matchers) if matchers
+    add_matchers(operator, matchers) if operator && matchers
   end
 
-  def add_matchers(matchers)
-    @matchers += Array(matchers)
+  def add_matchers(operator, matchers)
+    if ![Filter::OPERATOR_EQUALS, Filter::OPERATOR_EQUALS_NOT].include?(operator)
+      raise Machinery::Errors::InvalidFilter.new("Wrong filter operator '#{operator}'")
+    end
+
+    @matchers[operator] ||= []
+    @matchers[operator] += Array(matchers)
   end
 
   def matches?(value)
-    @matchers.each do |matcher|
-      values_equal = case value
-      when Machinery::Array
-        value_array = value.elements
+    @matchers.each do |operator, matchers|
+      matchers.each do |matcher|
+        values_equal = case value
+        when Machinery::Array
+          value_array = value.elements
 
-        (value_array - Array(matcher)).empty? && (Array(matcher) - value_array).empty?
-      when String
-        if matcher.is_a?(Array)
-          exception = Machinery::Errors::ElementFilterTypeMismatch.new
-          exception.failed_matcher = "#{path}#{operator}#{matcher.join(",")}"
-          raise exception
-        end
+          (value_array - Array(matcher)).empty? && (Array(matcher) - value_array).empty?
+        when String
+          if matcher.is_a?(Array)
+            exception = Machinery::Errors::ElementFilterTypeMismatch.new
+            exception.failed_matcher =
+              "#{path}#{operator}#{matcher.join(",")}"
+            raise exception
+          end
 
-        if matcher.end_with?("*")
-          value.start_with?(matcher[0..-2])
-        else
-          value == matcher
+          if matcher.end_with?("*")
+            value.start_with?(matcher[0..-2])
+          else
+            value == matcher
+          end
         end
-      end
-      if operator == "="
-        return true if values_equal
-      elsif operator == "!="
-        return true if !values_equal
+        if operator == Filter::OPERATOR_EQUALS
+          return true if values_equal
+        elsif operator == Filter::OPERATOR_EQUALS_NOT
+          return true if !values_equal
+        end
       end
     end
 

--- a/lib/element_filter.rb
+++ b/lib/element_filter.rb
@@ -16,13 +16,15 @@
 # you may find current contact information at www.suse.com
 
 class ElementFilter
-  attr_accessor :path, :matchers
+  attr_accessor :path, :operator, :matchers
 
-  def initialize(path, matchers = nil)
+  def initialize(path, operator, matchers = nil)
     @path = path
+    @operator = operator
     @matchers = []
 
-    raise("Wrong type") if ![NilClass, String, Array].include?(matchers.class)
+    raise("Wrong filter type") if ![NilClass, String, Array].include?(matchers.class)
+    raise("Wrong filter operator '#{@operator}'") if ![:==].include?(@operator)
 
     add_matchers(matchers) if matchers
   end

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -100,6 +100,8 @@ module Machinery
     end
 
     class MigrationError < MachineryError; end
+
+    class InvalidFilter < MachineryError; end
     class ElementFilterTypeMismatch < MachineryError
       attr_accessor :failed_matcher
     end

--- a/lib/filter.rb
+++ b/lib/filter.rb
@@ -49,7 +49,7 @@ class Filter
   def self.parse_filter_definitions(filter_definitions)
     element_filters = {}
     Array(filter_definitions).each do |definition|
-      path, operator, matcher_definition = definition.scan(/(.*?)(=|!=)(.*)/)[0]
+      path, operator, matcher_definition = definition.scan(/([a-zA-Z_\/]+)(.*=)(.*)/)[0]
 
       element_filters[path] ||= ElementFilter.new(path, operator)
       if matcher_definition.index(",")

--- a/lib/filter.rb
+++ b/lib/filter.rb
@@ -46,12 +46,13 @@
 class Filter
   attr_accessor :element_filters
 
+
   def self.parse_filter_definitions(filter_definitions)
     element_filters = {}
     Array(filter_definitions).each do |definition|
-      path, matcher_definition = definition.split("=", 2)
+      path, operator, matcher_definition = definition.scan(/(.*?)(=|!=)(.*)/)[0]
 
-      element_filters[path] ||= ElementFilter.new(path)
+      element_filters[path] ||= ElementFilter.new(path, operator)
       if matcher_definition.index(",")
         matchers = matcher_definition.split(/(?<!\\),/)
         matchers.map! { |matcher| matcher.gsub("\\,", ",") } # Unescape escaped commas
@@ -89,7 +90,7 @@ class Filter
     new_element_filters = Filter.parse_filter_definitions(filter_definition)
 
     new_element_filters.each do |path, element_filter|
-      @element_filters[path] ||= ElementFilter.new(path)
+      @element_filters[path] ||= ElementFilter.new(path, element_filter.operator)
       @element_filters[path].add_matchers(element_filter.matchers)
     end
   end
@@ -97,7 +98,8 @@ class Filter
   def add_element_filters(element_filters)
     Array(element_filters).each do |element_filter|
       path = element_filter.path
-      @element_filters[path] ||= ElementFilter.new(path)
+      operator = element_filter.operator
+      @element_filters[path] ||= ElementFilter.new(path, operator)
       @element_filters[path].add_matchers(element_filter.matchers)
     end
   end

--- a/lib/filter.rb
+++ b/lib/filter.rb
@@ -125,7 +125,7 @@ class Filter
   def to_array
     @element_filters.flat_map do |path, element_filter|
       element_filter.matchers.map do |matcher|
-        "#{path}=#{Array(matcher).join(",")}"
+        "#{path}#{element_filter.operator}#{Array(matcher).join(",")}"
       end
     end
   end

--- a/lib/filter.rb
+++ b/lib/filter.rb
@@ -46,7 +46,6 @@
 class Filter
   attr_accessor :element_filters
 
-
   def self.parse_filter_definitions(filter_definitions)
     element_filters = {}
     Array(filter_definitions).each do |definition|

--- a/plugins/inspect/unmanaged_files_inspector.rb
+++ b/plugins/inspect/unmanaged_files_inspector.rb
@@ -247,10 +247,12 @@ class UnmanagedFilesInspector < Inspector
 
     file_filter = filter.element_filter_for("/unmanaged_files/files/name") if filter
     file_filter ||= ElementFilter.new("/unmanaged_files/files/name")
-    file_filter.add_matchers(@description.store.base_path)
+    file_filter.add_matchers("=", @description.store.base_path)
 
     # Add a recursive pendant to each ignored element
-    file_filter.add_matchers(file_filter.matchers.map { |entry| File.join(entry, "/*") })
+    file_filter.matchers.each do |operator, matchers|
+      file_filter.add_matchers(operator, matchers.map { |entry| File.join(entry, "/*") })
+    end
 
     remote_dirs.delete_if { |e| file_filter.matches?(e) }
 

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -193,7 +193,7 @@ describe Cli do
       it "forwards the --skip-files option to the InspectTask as an unmanaged_files filter" do
         expect_any_instance_of(InspectTask).to receive(:inspect_system) do |_instance, _store,
           _host, _name, _user, _scopes, filter, _options|
-          expect(filter.element_filter_for("/unmanaged_files/files/name").matchers).
+          expect(filter.element_filter_for("/unmanaged_files/files/name").matchers["="]).
             to include("/foo/bar", "/baz")
         end.and_return(description)
 
@@ -209,7 +209,7 @@ describe Cli do
         end
         expect_any_instance_of(InspectTask).to receive(:inspect_system) do |_instance, _store,
           _host, _name, _user, _scopes, filter, _options|
-          expect(filter.element_filter_for("/unmanaged_files/files/name").matchers).
+          expect(filter.element_filter_for("/unmanaged_files/files/name").matchers["="]).
             to include("/foo/bar", "/baz")
         end.and_return(description)
 

--- a/spec/unit/element_filter_spec.rb
+++ b/spec/unit/element_filter_spec.rb
@@ -109,7 +109,8 @@ describe ElementFilter do
       end
 
       it "raises ElementFilterTypeMismatch when a String is matched against an Array" do
-        filter = ElementFilter.new(@path, Filter::OPERATOR_EQUALS, [["array_element_a", "array_element_b"]])
+        filter = ElementFilter.new(@path, Filter::OPERATOR_EQUALS,
+          [["array_element_a", "array_element_b"]])
         expect {
           filter.matches?("a string")
         }.to raise_error(Machinery::Errors::ElementFilterTypeMismatch)
@@ -230,15 +231,21 @@ describe ElementFilter do
   end
 
   describe "filters_scope?" do
-    specify { expect(ElementFilter.new("/foo", Filter::OPERATOR_EQUALS_NOT, "bar").filters_scope?("foo")).to be(true) }
-    specify { expect(ElementFilter.new("/foo", Filter::OPERATOR_EQUALS_NOT, "bar").filters_scope?("foo_bar")).
-      to be(false) }
+    specify {
+      expect(ElementFilter.new("/foo", Filter::OPERATOR_EQUALS_NOT, "bar").
+        filters_scope?("foo")).to be(true)
+    }
+    specify {
+      expect(ElementFilter.new("/foo", Filter::OPERATOR_EQUALS_NOT, "bar").
+        filters_scope?("foo_bar")).to be(false)
+    }
   end
 
   describe "=" do
     it "works for equal objects" do
       expect(
-        ElementFilter.new("/foo", Filter::OPERATOR_EQUALS, "bar") == ElementFilter.new("/foo", Filter::OPERATOR_EQUALS, "bar")
+        ElementFilter.new("/foo", Filter::OPERATOR_EQUALS, "bar") ==
+          ElementFilter.new("/foo", Filter::OPERATOR_EQUALS, "bar")
       ).to be(true)
       expect(
         ElementFilter.new("/foo", Filter::OPERATOR_EQUALS, ["bar", "baz"]) ==
@@ -248,14 +255,16 @@ describe ElementFilter do
 
     it "works for different objects" do
       expect(
-        ElementFilter.new("/foo", Filter::OPERATOR_EQUALS, "bar") == ElementFilter.new("/foo", Filter::OPERATOR_EQUALS, "baz")
+        ElementFilter.new("/foo", Filter::OPERATOR_EQUALS, "bar") ==
+          ElementFilter.new("/foo", Filter::OPERATOR_EQUALS, "baz")
       ).to be(false)
       expect(
         ElementFilter.new("/foo", Filter::OPERATOR_EQUALS, ["bar", "baz"]) ==
           ElementFilter.new("/foo", Filter::OPERATOR_EQUALS, ["bar", "qux"])
       ).to be(false)
       expect(
-        ElementFilter.new("/foo", Filter::OPERATOR_EQUALS, "bar") == ElementFilter.new("/baz", Filter::OPERATOR_EQUALS, "bar")
+        ElementFilter.new("/foo", Filter::OPERATOR_EQUALS, "bar") ==
+          ElementFilter.new("/baz", Filter::OPERATOR_EQUALS, "bar")
       ).to be(false)
     end
   end

--- a/spec/unit/element_filter_spec.rb
+++ b/spec/unit/element_filter_spec.rb
@@ -137,7 +137,7 @@ describe ElementFilter do
         end
 
         it "allows for filtering arrays with one element using a string filter" do
-          filter = ElementFilter.new("path", "=",  ["a"])
+          filter = ElementFilter.new("path", "=", ["a"])
           expect(filter.matches?(Machinery::Array.new(["a"]))).to be(true)
           expect(filter.matches?(Machinery::Array.new(["a", "b"]))).to be(false)
         end
@@ -203,7 +203,7 @@ describe ElementFilter do
         end
 
         it "allows for filtering arrays with one element using a string filter" do
-          filter = ElementFilter.new("path", "!=",  ["a"])
+          filter = ElementFilter.new("path", "!=", ["a"])
           expect(filter.matches?(Machinery::Array.new(["a"]))).to be(false)
           expect(filter.matches?(Machinery::Array.new(["a", "b"]))).to be(true)
         end
@@ -222,7 +222,8 @@ describe ElementFilter do
         ElementFilter.new("/foo", "=", "bar") == ElementFilter.new("/foo", "=", "bar")
       ).to be(true)
       expect(
-        ElementFilter.new("/foo", "=", ["bar", "baz"]) == ElementFilter.new("/foo", "=", ["bar", "baz"])
+        ElementFilter.new("/foo", "=", ["bar", "baz"]) ==
+          ElementFilter.new("/foo", "=", ["bar", "baz"])
       ).to be(true)
     end
 
@@ -231,7 +232,8 @@ describe ElementFilter do
         ElementFilter.new("/foo", "=", "bar") == ElementFilter.new("/foo", "=", "baz")
       ).to be(false)
       expect(
-        ElementFilter.new("/foo", "=", ["bar", "baz"]) == ElementFilter.new("/foo", "=", ["bar", "qux"])
+        ElementFilter.new("/foo", "=", ["bar", "baz"]) ==
+          ElementFilter.new("/foo", "=", ["bar", "qux"])
       ).to be(false)
       expect(
         ElementFilter.new("/foo", "=", "bar") == ElementFilter.new("/baz", "=", "bar")

--- a/spec/unit/element_filter_spec.rb
+++ b/spec/unit/element_filter_spec.rb
@@ -26,38 +26,38 @@ describe ElementFilter do
 
   describe "#initialize" do
     it "creates filter object" do
-      filter = ElementFilter.new(@path)
+      filter = ElementFilter.new(@path, :==)
       expect(filter).to be_a(ElementFilter)
     end
 
     it "creates filter object with one definition" do
-      filter = ElementFilter.new(@path, @matcher1)
+      filter = ElementFilter.new(@path, :==, @matcher1)
       expect(filter.matchers).to eq([@matcher1])
     end
 
     it "creates filter object with an array of definitions" do
       matcher = [@matcher1, @matcher2]
-      filter = ElementFilter.new(@path, matcher)
+      filter = ElementFilter.new(@path, :==, matcher)
       expect(filter.matchers).to eq(matcher)
     end
   end
 
   describe "#add_matcher" do
     it "adds one matcher definition" do
-      filter = ElementFilter.new(@path)
+      filter = ElementFilter.new(@path, :==)
       filter.add_matchers(@matcher1)
       expect(filter.matchers).to eq([@matcher1])
     end
 
     it "adds two matcher definition" do
-      filter = ElementFilter.new(@path)
+      filter = ElementFilter.new(@path, :==)
       filter.add_matchers(@matcher1)
       filter.add_matchers(@matcher2)
       expect(filter.matchers).to eq([@matcher1, @matcher2])
     end
 
     it "adds an array matcher definition" do
-      filter = ElementFilter.new(@path)
+      filter = ElementFilter.new(@path, :==)
       filter.add_matchers([["md5", "size"]])
       expect(filter.matchers).to eq([["md5", "size"]])
     end
@@ -65,26 +65,26 @@ describe ElementFilter do
 
   describe "#matchers" do
     it "returns all matchers" do
-      filter = ElementFilter.new(@path, [@matcher1, @matcher2])
+      filter = ElementFilter.new(@path, :==, [@matcher1, @matcher2])
       expect(filter.matchers).to eq(["/home/alfred", "/var/cache"])
     end
   end
 
   describe "#matches?" do
     it "returns true on matching value" do
-      filter = ElementFilter.new(@path, @matcher1)
+      filter = ElementFilter.new(@path, :==, @matcher1)
       expect(filter.matches?("/home/alfred")).
         to be(true)
     end
 
     it "returns false on non-matching value" do
-      filter = ElementFilter.new(@path, @matcher1)
+      filter = ElementFilter.new(@path, :==, @matcher1)
       expect(filter.matches?("/home/berta")).
         to be(false)
     end
 
     it "raises ElementFilterTypeMismatch when a String is matched against an Array" do
-      filter = ElementFilter.new(@path, [["array_element_a", "array_element_b"]])
+      filter = ElementFilter.new(@path, :==, [["array_element_a", "array_element_b"]])
       expect {
         filter.matches?("a string")
       }.to raise_error(Machinery::Errors::ElementFilterTypeMismatch)
@@ -92,7 +92,7 @@ describe ElementFilter do
 
     describe "matches beginning of a value" do
       before(:each) do
-        @filter = ElementFilter.new("path", "/home/alfred/*")
+        @filter = ElementFilter.new("path", :==, "/home/alfred/*")
       end
 
       it "returns false on shorter value" do
@@ -114,7 +114,7 @@ describe ElementFilter do
 
     context "matching arrays" do
       before(:each) do
-        @filter = ElementFilter.new("path", [["a", "b"]])
+        @filter = ElementFilter.new("path", :==, [["a", "b"]])
       end
 
       it "finds matches" do
@@ -130,7 +130,7 @@ describe ElementFilter do
       end
 
       it "allows for filtering arrays with one element using a string filter" do
-        filter = ElementFilter.new("path", ["a"])
+        filter = ElementFilter.new("path", :==,  ["a"])
         expect(filter.matches?(Machinery::Array.new(["a"]))).to be(true)
         expect(filter.matches?(Machinery::Array.new(["a", "b"]))).to be(false)
       end
@@ -138,29 +138,29 @@ describe ElementFilter do
   end
 
   describe "filters_scope?" do
-    specify { expect(ElementFilter.new("/foo", "bar").filters_scope?("foo")).to be(true) }
-    specify { expect(ElementFilter.new("/foo", "bar").filters_scope?("foo_bar")).to be(false) }
+    specify { expect(ElementFilter.new("/foo", :==, "bar").filters_scope?("foo")).to be(true) }
+    specify { expect(ElementFilter.new("/foo", :==, "bar").filters_scope?("foo_bar")).to be(false) }
   end
 
   describe "==" do
     it "works for equal objects" do
       expect(
-        ElementFilter.new("/foo", "bar") == ElementFilter.new("/foo", "bar")
+        ElementFilter.new("/foo", :==, "bar") == ElementFilter.new("/foo", :==, "bar")
       ).to be(true)
       expect(
-        ElementFilter.new("/foo", ["bar", "baz"]) == ElementFilter.new("/foo", ["bar", "baz"])
+        ElementFilter.new("/foo", :==, ["bar", "baz"]) == ElementFilter.new("/foo", :==, ["bar", "baz"])
       ).to be(true)
     end
 
     it "works for different objects" do
       expect(
-        ElementFilter.new("/foo", "bar") == ElementFilter.new("/foo", "baz")
+        ElementFilter.new("/foo", :==, "bar") == ElementFilter.new("/foo", :==, "baz")
       ).to be(false)
       expect(
-        ElementFilter.new("/foo", ["bar", "baz"]) == ElementFilter.new("/foo", ["bar", "qux"])
+        ElementFilter.new("/foo", :==, ["bar", "baz"]) == ElementFilter.new("/foo", :==, ["bar", "qux"])
       ).to be(false)
       expect(
-        ElementFilter.new("/foo", "bar") == ElementFilter.new("/baz", "bar")
+        ElementFilter.new("/foo", :==, "bar") == ElementFilter.new("/baz", :==, "bar")
       ).to be(false)
     end
   end

--- a/spec/unit/element_filter_spec.rb
+++ b/spec/unit/element_filter_spec.rb
@@ -26,72 +26,90 @@ describe ElementFilter do
 
   describe "#initialize" do
     it "creates filter object" do
-      filter = ElementFilter.new(@path, "=")
+      filter = ElementFilter.new(@path)
       expect(filter).to be_a(ElementFilter)
     end
 
     it "creates filter object with one definition" do
-      filter = ElementFilter.new(@path, "=", @matcher1)
-      expect(filter.matchers).to eq([@matcher1])
+      filter = ElementFilter.new(@path, Filter::OPERATOR_EQUALS, @matcher1)
+      expect(filter.matchers).to eq(Filter::OPERATOR_EQUALS => [@matcher1])
     end
 
     it "creates filter object with an array of definitions" do
       matcher = [@matcher1, @matcher2]
-      filter = ElementFilter.new(@path, "=", matcher)
-      expect(filter.matchers).to eq(matcher)
+      filter = ElementFilter.new(@path, Filter::OPERATOR_EQUALS, matcher)
+      expect(filter.matchers).to eq(Filter::OPERATOR_EQUALS => matcher)
     end
   end
 
   describe "#add_matcher" do
     it "adds one matcher definition" do
-      filter = ElementFilter.new(@path, "=")
-      filter.add_matchers(@matcher1)
-      expect(filter.matchers).to eq([@matcher1])
+      filter = ElementFilter.new(@path)
+      filter.add_matchers(Filter::OPERATOR_EQUALS, @matcher1)
+      expect(filter.matchers).to eq(Filter::OPERATOR_EQUALS => [@matcher1])
     end
 
     it "adds two matcher definition" do
-      filter = ElementFilter.new(@path, "=")
-      filter.add_matchers(@matcher1)
-      filter.add_matchers(@matcher2)
-      expect(filter.matchers).to eq([@matcher1, @matcher2])
+      filter = ElementFilter.new(@path)
+      filter.add_matchers(Filter::OPERATOR_EQUALS, @matcher1)
+      filter.add_matchers(Filter::OPERATOR_EQUALS, @matcher2)
+      expect(filter.matchers).to eq(Filter::OPERATOR_EQUALS => [@matcher1, @matcher2])
     end
 
     it "adds an array matcher definition" do
-      filter = ElementFilter.new(@path, "=")
-      filter.add_matchers([["md5", "size"]])
-      expect(filter.matchers).to eq([["md5", "size"]])
+      filter = ElementFilter.new(@path)
+      filter.add_matchers(Filter::OPERATOR_EQUALS, [["md5", "size"]])
+      expect(filter.matchers).to eq(Filter::OPERATOR_EQUALS => [["md5", "size"]])
+    end
+
+    it "raises an exception when invalid operators are used" do
+      filter = ElementFilter.new(@path)
+      expect {
+        filter.add_matchers(">=", ["foo"])
+      }.to raise_error(Machinery::Errors::InvalidFilter)
     end
   end
 
   describe "#matchers" do
     it "returns all matchers" do
-      filter = ElementFilter.new(@path, "=", [@matcher1, @matcher2])
-      expect(filter.matchers).to eq(["/home/alfred", "/var/cache"])
+      filter = ElementFilter.new(@path, Filter::OPERATOR_EQUALS, [@matcher1, @matcher2])
+      expect(filter.matchers).to eq(Filter::OPERATOR_EQUALS => ["/home/alfred", "/var/cache"])
     end
   end
 
   describe "#matches?" do
+    context "with multiple operators" do
+      it "works" do
+        filter = ElementFilter.new(@path)
+        filter.add_matchers(Filter::OPERATOR_EQUALS, @matcher1)
+        filter.add_matchers(Filter::OPERATOR_EQUALS_NOT, @matcher2)
+        expect(filter.matches?(@matcher1)).to be(true)         # :== matches
+        expect(filter.matches?("/something/else")).to be(true) # :!= matcher
+        expect(filter.matches?(@matcher2)).to be(false)        # neither matcher matches
+      end
+    end
+
     context "with equals operator" do
       it "returns true on matching value" do
-        filter = ElementFilter.new(@path, "=", @matcher1)
+        filter = ElementFilter.new(@path, Filter::OPERATOR_EQUALS, @matcher1)
         expect(filter.matches?("/home/alfred")).
           to be(true)
       end
 
       it "returns false on non-matching value" do
-        filter = ElementFilter.new(@path, "=", @matcher1)
+        filter = ElementFilter.new(@path, Filter::OPERATOR_EQUALS, @matcher1)
         expect(filter.matches?("/home/berta")).
           to be(false)
       end
 
       it "returns true when one matcher matches" do
-        filter = ElementFilter.new(@path, "=", [@matcher1, @matcher2])
+        filter = ElementFilter.new(@path, Filter::OPERATOR_EQUALS, [@matcher1, @matcher2])
         expect(filter.matches?("/home/alfred")).
           to be(true)
       end
 
       it "raises ElementFilterTypeMismatch when a String is matched against an Array" do
-        filter = ElementFilter.new(@path, "=", [["array_element_a", "array_element_b"]])
+        filter = ElementFilter.new(@path, Filter::OPERATOR_EQUALS, [["array_element_a", "array_element_b"]])
         expect {
           filter.matches?("a string")
         }.to raise_error(Machinery::Errors::ElementFilterTypeMismatch)
@@ -99,7 +117,7 @@ describe ElementFilter do
 
       describe "matches beginning of a value" do
         before(:each) do
-          @filter = ElementFilter.new("path", "=", "/home/alfred/*")
+          @filter = ElementFilter.new("path", Filter::OPERATOR_EQUALS, "/home/alfred/*")
         end
 
         it "returns false on shorter value" do
@@ -121,7 +139,7 @@ describe ElementFilter do
 
       context "matching arrays" do
         before(:each) do
-          @filter = ElementFilter.new("path", "=", [["a", "b"]])
+          @filter = ElementFilter.new("path", Filter::OPERATOR_EQUALS, [["a", "b"]])
         end
 
         it "finds matches" do
@@ -137,7 +155,7 @@ describe ElementFilter do
         end
 
         it "allows for filtering arrays with one element using a string filter" do
-          filter = ElementFilter.new("path", "=", ["a"])
+          filter = ElementFilter.new("path", Filter::OPERATOR_EQUALS, ["a"])
           expect(filter.matches?(Machinery::Array.new(["a"]))).to be(true)
           expect(filter.matches?(Machinery::Array.new(["a", "b"]))).to be(false)
         end
@@ -146,26 +164,26 @@ describe ElementFilter do
 
     context "with equals not operator" do
       it "returns false on matching value" do
-        filter = ElementFilter.new(@path, "!=", [@matcher1])
+        filter = ElementFilter.new(@path, Filter::OPERATOR_EQUALS_NOT, [@matcher1])
         expect(filter.matches?("/home/alfred")).
           to be(false)
       end
 
       it "returns true on non-matching value" do
-        filter = ElementFilter.new(@path, "!=", @matcher1)
+        filter = ElementFilter.new(@path, Filter::OPERATOR_EQUALS_NOT, @matcher1)
         expect(filter.matches?("/home/berta")).
           to be(true)
       end
 
       it "returns true when one matcher doesn't match" do
-        filter = ElementFilter.new(@path, "!=", [@matcher2, @matcher1])
+        filter = ElementFilter.new(@path, Filter::OPERATOR_EQUALS_NOT, [@matcher2, @matcher1])
         expect(filter.matches?("/home/alfred")).
           to be(true)
       end
 
       describe "matches beginning of a value" do
         before(:each) do
-          @filter = ElementFilter.new("path", "!=", "/home/alfred/*")
+          @filter = ElementFilter.new("path", Filter::OPERATOR_EQUALS_NOT, "/home/alfred/*")
         end
 
         it "returns true on shorter value" do
@@ -187,7 +205,7 @@ describe ElementFilter do
 
       context "matching arrays" do
         before(:each) do
-          @filter = ElementFilter.new("path", "!=", [["a", "b"]])
+          @filter = ElementFilter.new("path", Filter::OPERATOR_EQUALS_NOT, [["a", "b"]])
         end
 
         it "does not match equal arrays" do
@@ -203,7 +221,7 @@ describe ElementFilter do
         end
 
         it "allows for filtering arrays with one element using a string filter" do
-          filter = ElementFilter.new("path", "!=", ["a"])
+          filter = ElementFilter.new("path", Filter::OPERATOR_EQUALS_NOT, ["a"])
           expect(filter.matches?(Machinery::Array.new(["a"]))).to be(false)
           expect(filter.matches?(Machinery::Array.new(["a", "b"]))).to be(true)
         end
@@ -212,31 +230,32 @@ describe ElementFilter do
   end
 
   describe "filters_scope?" do
-    specify { expect(ElementFilter.new("/foo", "=", "bar").filters_scope?("foo")).to be(true) }
-    specify { expect(ElementFilter.new("/foo", "=", "bar").filters_scope?("foo_bar")).to be(false) }
+    specify { expect(ElementFilter.new("/foo", Filter::OPERATOR_EQUALS_NOT, "bar").filters_scope?("foo")).to be(true) }
+    specify { expect(ElementFilter.new("/foo", Filter::OPERATOR_EQUALS_NOT, "bar").filters_scope?("foo_bar")).
+      to be(false) }
   end
 
   describe "=" do
     it "works for equal objects" do
       expect(
-        ElementFilter.new("/foo", "=", "bar") == ElementFilter.new("/foo", "=", "bar")
+        ElementFilter.new("/foo", Filter::OPERATOR_EQUALS, "bar") == ElementFilter.new("/foo", Filter::OPERATOR_EQUALS, "bar")
       ).to be(true)
       expect(
-        ElementFilter.new("/foo", "=", ["bar", "baz"]) ==
-          ElementFilter.new("/foo", "=", ["bar", "baz"])
+        ElementFilter.new("/foo", Filter::OPERATOR_EQUALS, ["bar", "baz"]) ==
+          ElementFilter.new("/foo", Filter::OPERATOR_EQUALS, ["bar", "baz"])
       ).to be(true)
     end
 
     it "works for different objects" do
       expect(
-        ElementFilter.new("/foo", "=", "bar") == ElementFilter.new("/foo", "=", "baz")
+        ElementFilter.new("/foo", Filter::OPERATOR_EQUALS, "bar") == ElementFilter.new("/foo", Filter::OPERATOR_EQUALS, "baz")
       ).to be(false)
       expect(
-        ElementFilter.new("/foo", "=", ["bar", "baz"]) ==
-          ElementFilter.new("/foo", "=", ["bar", "qux"])
+        ElementFilter.new("/foo", Filter::OPERATOR_EQUALS, ["bar", "baz"]) ==
+          ElementFilter.new("/foo", Filter::OPERATOR_EQUALS, ["bar", "qux"])
       ).to be(false)
       expect(
-        ElementFilter.new("/foo", "=", "bar") == ElementFilter.new("/baz", "=", "bar")
+        ElementFilter.new("/foo", Filter::OPERATOR_EQUALS, "bar") == ElementFilter.new("/baz", Filter::OPERATOR_EQUALS, "bar")
       ).to be(false)
     end
   end

--- a/spec/unit/filter_spec.rb
+++ b/spec/unit/filter_spec.rb
@@ -45,6 +45,16 @@ describe Filter do
       expect(element_filter.keys.length).to eq(1)
       expect(element_filter["/foo"].matchers).to eq([["bar", "baz,qux"]])
     end
+
+    it "fails on unknown operators" do
+      expect {
+        Filter.parse_filter_definitions("/foo<=bar")
+      }.to raise_error(Machinery::Errors::InvalidFilter)
+
+      expect {
+        Filter.parse_filter_definitions("/foo<!=bar")
+      }.to raise_error(Machinery::Errors::InvalidFilter)
+    end
   end
 
   describe "#initialize" do

--- a/spec/unit/filter_spec.rb
+++ b/spec/unit/filter_spec.rb
@@ -83,9 +83,9 @@ describe Filter do
 
   describe "#to_array" do
     it "returns the element filter definitions as a string array" do
-      filter = Filter.new(["foo=bar,baz", "foo=qux", "scope=matcher"])
+      filter = Filter.new(["foo=bar,baz", "foo=qux", "scope=matcher", "equals!=not"])
       expect(filter.to_array).to eq([
-        "foo=bar,baz", "foo=qux", "scope=matcher"
+        "foo=bar,baz", "foo=qux", "scope=matcher", "equals!=not"
       ])
     end
   end

--- a/spec/unit/filter_spec.rb
+++ b/spec/unit/filter_spec.rb
@@ -31,8 +31,16 @@ describe Filter do
     it "parses definition with multiple matcher" do
       element_filter = Filter.parse_filter_definitions("/foo=bar,baz")
       expect(element_filter.keys.length).to eq(1)
+      expect(element_filter["/foo"].operator).to eq("=")
       expect(element_filter["/foo"].matchers).
         to eq([["bar", "baz"]])
+    end
+
+    it "parses definition with 'equals not' operator" do
+      element_filter = Filter.parse_filter_definitions("/foo!=bar,baz")
+      expect(element_filter.keys.length).to eq(1)
+      expect(element_filter["/foo"].operator).to eq("!=")
+      expect(element_filter["/foo"].matchers).to eq([["bar", "baz"]])
     end
 
     it "handles escaped commas" do

--- a/spec/unit/filter_spec.rb
+++ b/spec/unit/filter_spec.rb
@@ -115,8 +115,8 @@ describe Filter do
       ])
 
       expected = [
-        ElementFilter.new("/unmanaged_files/files/name", ["/home/alfred", "/var/cache"]),
-        ElementFilter.new("/unmanaged_files/files/changes", [["md5", "size"]])
+        ElementFilter.new("/unmanaged_files/files/name", "=", ["/home/alfred", "/var/cache"]),
+        ElementFilter.new("/unmanaged_files/files/changes", "=", [["md5", "size"]])
       ]
       expect(filter.element_filters_for_scope("unmanaged_files")).to eq(expected)
     end
@@ -133,8 +133,8 @@ describe Filter do
       ])
 
       expected = [
-        ElementFilter.new("/unmanaged_files/files/name", ["/home/alfred", "/var/cache"]),
-        ElementFilter.new("/unmanaged_files/files/changes", [["md5", "size"]])
+        ElementFilter.new("/unmanaged_files/files/name", "=", ["/home/alfred", "/var/cache"]),
+        ElementFilter.new("/unmanaged_files/files/changes", "=", [["md5", "size"]])
       ]
       filter.set_element_filters_for_scope("unmanaged_files", expected)
 

--- a/spec/unit/filter_spec.rb
+++ b/spec/unit/filter_spec.rb
@@ -22,18 +22,15 @@ describe Filter do
     it "parses array of definitions" do
       element_filter = Filter.parse_filter_definitions(["/foo=bar", "/baz=qux"])
       expect(element_filter.keys.length).to eq(2)
-      expect(element_filter["/foo"].matchers).
-        to eq(["bar"])
-      expect(element_filter["/baz"].matchers).
-        to eq(["qux"])
+      expect(element_filter["/foo"].matchers).to eq(["bar"])
+      expect(element_filter["/baz"].matchers).to eq(["qux"])
     end
 
     it "parses definition with multiple matcher" do
       element_filter = Filter.parse_filter_definitions("/foo=bar,baz")
       expect(element_filter.keys.length).to eq(1)
       expect(element_filter["/foo"].operator).to eq("=")
-      expect(element_filter["/foo"].matchers).
-        to eq([["bar", "baz"]])
+      expect(element_filter["/foo"].matchers).to eq([["bar", "baz"]])
     end
 
     it "parses definition with 'equals not' operator" do
@@ -46,8 +43,7 @@ describe Filter do
     it "handles escaped commas" do
       element_filter = Filter.parse_filter_definitions("/foo=bar,baz\\,qux")
       expect(element_filter.keys.length).to eq(1)
-      expect(element_filter["/foo"].matchers).
-        to eq([["bar", "baz,qux"]])
+      expect(element_filter["/foo"].matchers).to eq([["bar", "baz,qux"]])
     end
   end
 

--- a/spec/unit/filter_spec.rb
+++ b/spec/unit/filter_spec.rb
@@ -66,7 +66,8 @@ describe Filter do
 
       expect(filters.keys.length).to eq(1)
       expect(filters["/unmanaged_files/files/name"].path).to eq("/unmanaged_files/files/name")
-      expect(filters["/unmanaged_files/files/name"].matchers).to eq(Filter::OPERATOR_EQUALS => ["/home/alfred"])
+      expect(filters["/unmanaged_files/files/name"].matchers).
+        to eq(Filter::OPERATOR_EQUALS => ["/home/alfred"])
     end
   end
 
@@ -85,7 +86,8 @@ describe Filter do
       filter.add_element_filter_from_definition("foo=qux")
 
       element_filters = filter.element_filters
-      expect(element_filters["foo"].matchers).to eq(Filter::OPERATOR_EQUALS => [["bar", "baz"], "qux"])
+      expect(element_filters["foo"].matchers).
+        to eq(Filter::OPERATOR_EQUALS => [["bar", "baz"], "qux"])
     end
   end
 
@@ -108,7 +110,8 @@ describe Filter do
 
       element_filter = filter.element_filter_for("/unmanaged_files/files/name")
       expect(element_filter.path).to eq("/unmanaged_files/files/name")
-      expect(element_filter.matchers).to eq(Filter::OPERATOR_EQUALS => ["/home/alfred", "/var/cache"])
+      expect(element_filter.matchers).
+        to eq(Filter::OPERATOR_EQUALS => ["/home/alfred", "/var/cache"])
 
       element_filter = filter.element_filter_for("/changed_managed_files/files/changes")
       expect(element_filter.path).to eq("/changed_managed_files/files/changes")
@@ -127,8 +130,10 @@ describe Filter do
       ])
 
       expected = [
-        ElementFilter.new("/unmanaged_files/files/name", Filter::OPERATOR_EQUALS, ["/home/alfred", "/var/cache"]),
-        ElementFilter.new("/unmanaged_files/files/changes", Filter::OPERATOR_EQUALS, [["md5", "size"]])
+        ElementFilter.new("/unmanaged_files/files/name", Filter::OPERATOR_EQUALS,
+          ["/home/alfred", "/var/cache"]),
+        ElementFilter.new("/unmanaged_files/files/changes", Filter::OPERATOR_EQUALS,
+          [["md5", "size"]])
       ]
       expect(filter.element_filters_for_scope("unmanaged_files")).to eq(expected)
     end
@@ -145,8 +150,10 @@ describe Filter do
       ])
 
       expected = [
-        ElementFilter.new("/unmanaged_files/files/name", Filter::OPERATOR_EQUALS, ["/home/alfred", "/var/cache"]),
-        ElementFilter.new("/unmanaged_files/files/changes", Filter::OPERATOR_EQUALS, [["md5", "size"]])
+        ElementFilter.new("/unmanaged_files/files/name", Filter::OPERATOR_EQUALS,
+          ["/home/alfred", "/var/cache"]),
+        ElementFilter.new("/unmanaged_files/files/changes", Filter::OPERATOR_EQUALS,
+          [["md5", "size"]])
       ]
       filter.set_element_filters_for_scope("unmanaged_files", expected)
 

--- a/spec/unit/inspect_task_spec.rb
+++ b/spec/unit/inspect_task_spec.rb
@@ -209,7 +209,7 @@ Inspecting foo...
       expect_any_instance_of(FooInspector).to receive(:inspect) do |inspector, filter, _options|
         expect(filter.element_filters.length).to eq(1)
         expect(filter.element_filters["/foo"].matchers).
-          to eq([["bar", "baz"]])
+          to eq("=" => [["bar", "baz"]])
 
         inspector.description.foo = SimpleInspectTaskScope.new(files: SimpleInspectTaskList.new)
       end


### PR DESCRIPTION
Please review the following changes:
  * 383b93f Support ElementFilters with matchers using different operators
  * 9e11063 Merge pull request #774 from SUSE/show_inspecting_filters_2
  * 30c82cf Refactored Code: correct spelling mistake
  * 07f67b3 Show filters which were applied during inspect
  * 1b67929 Detect invalid operators in filter definitions
  * 28ee93a Fix hound issues
  * 5e31669 Adapt Filtering-Design document to reflect the inverted filters changes
  * 08bbcf9 Add changelog entry for negated filter expressions in --exclude
  * 241c417 Consider ElementFilter operators in Filter#to_array
  * fa3beb7 Remove superfluous linebreaks
  * 268d1ba Add test for defition parser with '!=' operator
  * 9a7867e Implement :!= operator in ElementFilters
  * f657fae ElementFilters have an operator now (always :== currently)