### PR TITLE
Fix ugly error messages in RSpec "after" hooks when cleaning up

### DIFF
--- a/spec/integration/support/autoyast_export_examples.rb
+++ b/spec/integration/support/autoyast_export_examples.rb
@@ -17,7 +17,7 @@
 
 shared_examples "autoyast export" do
   after(:all) do
-    @machinery.run_command("test -d /tmp/jeos-autoyast && rm -r /tmp/jeos-autoyast")
+    @machinery.cleanup_directory("/tmp/jeos-autoyast")
   end
 
   describe "export-autoyast" do

--- a/spec/integration/support/kiwi_export_examples.rb
+++ b/spec/integration/support/kiwi_export_examples.rb
@@ -17,7 +17,7 @@
 
 shared_examples "kiwi export" do
   after(:all) do
-    @machinery.run_command("test -d /tmp/jeos-kiwi && rm -r /tmp/jeos-kiwi")
+    @machinery.cleanup_directory("/tmp/jeos-kiwi")
   end
 
   describe "export-kiwi" do


### PR DESCRIPTION
We now use the new Runner#cleanup_directory method in pennyworth which
cleans up the directory on runners working with real machines, but does
not run into error when working with VMs.

Depends on https://github.com/SUSE/pennyworth/pull/59
