### PR TITLE
Fix 787

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@
 
 * Add experimental option to show comparison of two system descriptions as
   HTML view
+* Support inspection of Red Hat Enterprise Linux 5 systems
 
 ## Version 1.6.0 - Wed Apr 01 15:43:17 CEST 2015 - thardeck@suse.de
 

--- a/plugins/inspect/changed_managed_files_inspector.rb
+++ b/plugins/inspect/changed_managed_files_inspector.rb
@@ -117,7 +117,7 @@ class ChangedManagedFilesInspector < Inspector
         # Since errors are also recognized for config-files we have
         # to filter them
       end.compact.select { |item| item.changes }
-    end
+    end.uniq
     amend_file_attributes(changed_files)
   end
 

--- a/plugins/inspect/config_files_inspector.rb
+++ b/plugins/inspect/config_files_inspector.rb
@@ -43,7 +43,7 @@ class ConfigFilesInspector < Inspector
     # use leading slash to decide between lines containing package names
     # and lines containing config files
     chunks = output.split("\n").slice_before { |l| !l.start_with?("/") }
-    chunks.reject { |pkg, *cfiles| cfiles.empty? }.map(&:first)
+    chunks.reject { |pkg, *cfiles| cfiles.empty? }.map(&:first).uniq
   end
 
   # returns a hash with entries for changed config files
@@ -79,7 +79,7 @@ class ConfigFilesInspector < Inspector
         status:          "changed",
         changes:         changes
       )
-    end
+    end.uniq
   end
 
   def initialize(system, description)

--- a/spec/data/changed_managed_files/rpm_result
+++ b/spec/data/changed_managed_files/rpm_result
@@ -5,6 +5,8 @@ S.5....T.   /etc/apache2/de:fault server.conf
 ..5....T. d /etc/apache2/listen.conf
 ..5....T. c /etc/apache2/ignore_me_because_im_a_config_file.conf
 .........    /usr/share/man/man1/time.1.gz (replaced)
+zypper-1.6.311:
+SM5..UGT.   /etc/iscsi/iscsid.conf
 kdelibs3-default-style-3.5.10:
 missing     /opt/kde3/lib64/kde3/plugins/styles/plastik.la
 vlock-2.2.3:

--- a/spec/unit/config_files_inspector_spec.rb
+++ b/spec/unit/config_files_inspector_spec.rb
@@ -50,6 +50,8 @@ apache2-2.4.6
 /etc/apache2/default-vhost.conf
 /etc/apache2/errors.conf
 yast2-pkg-bindings-3.1.1
+apache2-2.4.6
+/etc/apache2/charset.conv
 EOF
     }
     let(:rpm_qa_output_test2) {
@@ -70,6 +72,7 @@ S.5....T.  c /etc/sysconfig/SuSEfirewall2.d/services/apache2
 missing    c /usr/share/info/dir
 S.5....T.    /etc/sysconfig/ignore_me_cause_im_not_a_config_file
 .........  c /usr/share/man/man1/time.1.gz (replaced)
+..5....T.  c /etc/apache2/listen.conf
 EOF
     }
     let(:rpm_v_openiscsi_output) {


### PR DESCRIPTION
Fixes #787 

Changed managed-files were also affected by this issue so I fixed it too.

The tests are not perfect but I didn't had time to refactor them and I mean if the inspector works fine with duplication it should work fine without. And of course we have integration tests.

After merging this PR the RHEL5 integration tests can be enabled: https://github.com/SUSE/alfred/pull/1100