### PR TITLE
machinery autoyast-export raises error if dir is non-writable

### DIFF
--- a/lib/export_task.rb
+++ b/lib/export_task.rb
@@ -36,7 +36,11 @@ class ExportTask
       end
     end
 
-    FileUtils.mkdir_p(output_dir, mode: 0700) if !Dir.exists?(output_dir)
+    begin
+      FileUtils.mkdir_p(output_dir, mode: 0700) if !Dir.exists?(output_dir)
+    rescue Errno::EACCES
+      raise(Machinery::Errors::ExportFailed, "Permission denied. Directory '#{output_dir}' is not writable")
+    end
 
     if @exporter.system_description["unmanaged_files"]
       filters = File.read(

--- a/lib/export_task.rb
+++ b/lib/export_task.rb
@@ -39,7 +39,8 @@ class ExportTask
     begin
       FileUtils.mkdir_p(output_dir, mode: 0700) if !Dir.exists?(output_dir)
     rescue Errno::EACCES
-      raise(Machinery::Errors::ExportFailed, "Permission denied. Directory '#{output_dir}' is not writable")
+      raise(Machinery::Errors::ExportFailed, \
+            "Permission denied. Directory '#{output_dir}' is not writable")
     end
 
     if @exporter.system_description["unmanaged_files"]

--- a/spec/unit/export_task_spec.rb
+++ b/spec/unit/export_task_spec.rb
@@ -56,7 +56,7 @@ EOF
       allow(FileUtils).to receive(:mkdir_p).and_raise(Errno::EACCES)
       output_dir = "/foo"
       expect {
-          subject.export(File.join(output_dir, "name"), force: false)
+        subject.export(File.join(output_dir, "name"), force: false)
       }.to raise_error(Machinery::Errors::ExportFailed, /Permission denied/)
     end
 

--- a/spec/unit/export_task_spec.rb
+++ b/spec/unit/export_task_spec.rb
@@ -52,6 +52,14 @@ EOF
       expect(captured_machinery_output).to include(expected_output)
     end
 
+    it "raises a known error when a non-writable directory is given" do
+      allow(FileUtils).to receive(:mkdir_p).and_raise(Errno::EACCES)
+      output_dir = "/foo"
+      expect {
+          subject.export(File.join(output_dir, "name"), force: false)
+      }.to raise_error(Machinery::Errors::ExportFailed, /Permission denied/)
+    end
+
     describe "when the output directory already exists" do
       let(:output_dir) { "/foo" }
       let(:export_dir) { "/foo/name-type" }


### PR DESCRIPTION
Fix #458