### PR TITLE
Parse RHEL xinetd service state output from chkconfig.

### DIFF
--- a/plugins/services/services_inspector.rb
+++ b/plugins/services/services_inspector.rb
@@ -109,7 +109,7 @@ class ServicesInspector < Inspector
       stdout: :capture
     )
 
-    # Run chkconfig output through regular expressions to parse 
+    # Run chkconfig output through regular expressions to parse
     # seperatly for systemv and xinetd services.
     services = output.lines.select do |line|
       line =~ /^\S+(\s+\d:(on|off))+.*$/

--- a/plugins/services/services_inspector.rb
+++ b/plugins/services/services_inspector.rb
@@ -109,11 +109,21 @@ class ServicesInspector < Inspector
       stdout: :capture
     )
 
-    services = output.lines.map do |line|
+    # Run chkconfig output through regular expressions to parse 
+    # seperatly for systemv and xinetd services.
+    services = output.lines.select do |line|
+      line =~ /^\S+(\s+\d:(on|off))+.*$/
+    end.map do |line|
       state = []
       name, state[0], state[1], state[2], state[3], state[4], state[5], state[6] = line.split(/\s+/)
       Service.new(name: name, state: state[runlevel.to_i].split(":")[1])
     end
+
+    services += output.lines.select { |line| line =~ /^\s+\S+:\s+(on|off).*$/ }.map do |line|
+      name, state = line.split(/:/)
+      Service.new(name: name.strip, state: state.strip)
+    end
+
     services
   end
 end

--- a/spec/unit/services_inspector_spec.rb
+++ b/spec/unit/services_inspector_spec.rb
@@ -163,6 +163,11 @@ EOF
         <<-EOF
 crond 0:off 1:off 2:on 3:on 4:on 5:on 6:off
 dnsmasq 0:off 1:off 2:off 3:off 4:off 5:off 6:off
+
+xinetd based services:
+        chargen-dgram:  off
+        chargen-stream: on
+        eklogin:        off
 EOF
 
       allow(system).to receive(:has_command?).
@@ -184,7 +189,10 @@ EOF
 
       expect(services).to eq([
         Service.new(name: "crond", state: "on"),
-        Service.new(name: "dnsmasq", state: "off")
+        Service.new(name: "dnsmasq", state: "off"),
+        Service.new(name: "chargen-dgram", state: "off"),
+        Service.new(name: "chargen-stream", state: "on"),
+        Service.new(name: "eklogin", state: "off")
       ])
     end
   end


### PR DESCRIPTION
- fix for https://github.com/SUSE/machinery/issues/815
- when xinetd is installed on a RHEL5 system then chkconfig output
  has additional xinetd service state in a different format
- this change selects chkconfig output by regular expressions and
  applys different extraction fitting different output formats
- adjust services_inspector testcase to also test xinetd services