### PR TITLE
Inserting another condition for showing hints

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -40,7 +40,7 @@ class Cli
   end
 
   post do |global_options,command,options,args|
-    if command.is_a?(GLI::Commands::Help) && !global_options[:version]
+    if command.is_a?(GLI::Commands::Help) && !global_options[:version] && ARGV == ["help"]
 
       Machinery::Ui.puts "\nMachinery can show hints which guide through a typical workflow."
       if @config.hints


### PR DESCRIPTION
Fixes #369

Hints in the help command are only shown when the help command is called
without any command specification.