### PR TITLE
Filter /root/.local from unmanaged-file tests

### DIFF
--- a/spec/integration/support/inspect_unmanaged_files_examples.rb
+++ b/spec/integration/support/inspect_unmanaged_files_examples.rb
@@ -20,7 +20,8 @@ shared_examples "inspect unmanaged files" do |base|
     [
       "var/lib/logrotate.status",
       "var/spool/cron/lastrun/cron.daily",
-      "var/log/sa"
+      "var/log/sa",
+      "root/.local"
     ]
   }
   describe "--scope=unmanaged-files" do


### PR DESCRIPTION
The existence of "/root/.local" seems to be quite non-deterministic.
That is why we filter it in the unmanaged-file integration tests.