### PR TITLE
Test changed_managed_files in build integration test

### DIFF
--- a/spec/data/descriptions/opensuse131-build/manifest.json
+++ b/spec/data/descriptions/opensuse131-build/manifest.json
@@ -2052,8 +2052,7 @@
         "status": "changed",
         "changes": [
           "deleted"
-        ],
-        "package_file_flag": "d"
+        ]
       },
       {
         "name": "/usr/share/doc/packages/rsync/README",
@@ -2067,7 +2066,6 @@
           "user",
           "group"
         ],
-        "package_file_flag": "d",
         "mode": "664",
         "user": "bin",
         "group": "wheel"

--- a/spec/integration/support/build_examples.rb
+++ b/spec/integration/support/build_examples.rb
@@ -136,7 +136,7 @@ shared_examples "build" do |distribution|
 
         it "contains the changed managed-files from the system description" do
           expect(@new_description).to include_file_scope(@system_description,
-            "config_files")
+            "changed_managed_files")
         end
 
         it "removed the deleted managed file" do


### PR DESCRIPTION
We accidentally tested the config-files twice.