### PR TITLE
File access api

### DIFF
--- a/lib/file_scope.rb
+++ b/lib/file_scope.rb
@@ -16,11 +16,6 @@
 # you may find current contact information at www.suse.com
 
 class FileScope < Machinery::Object
-  def export_files_as_tarballs(destination)
-    Machinery::SystemFileUtils.write_files_tarball(self, destination)
-    Machinery::SystemFileUtils.write_directory_tarballs(self, destination)
-  end
-
   def compare_with(other)
     validate_attributes(other)
 

--- a/lib/kiwi_config.rb
+++ b/lib/kiwi_config.rb
@@ -124,7 +124,8 @@ class KiwiConfig < Exporter
       FileUtils.mkdir_p(destination, mode: 01777)
       filter = "unmanaged_files_#{@name}_excludes"
 
-      @system_description.unmanaged_files.export_files_as_tarballs(destination)
+      @system_description.unmanaged_files.file_access.
+        export_files_as_tarballs(destination)
 
       FileUtils.cp(
         File.join(Machinery::ROOT, "export_helpers/#{filter}"),

--- a/lib/kiwi_config.rb
+++ b/lib/kiwi_config.rb
@@ -108,8 +108,7 @@ class KiwiConfig < Exporter
           @sh << "chmod #{file.mode} '#{file.name}'\n"
           @sh << "chown #{file.user}:#{file.group} '#{file.name}'\n"
         elsif file.file?
-          file_access = @system_description[scope].file_access
-          file_access.write_file(file, output_root_path)
+          @system_description[scope].write_file(file, output_root_path)
           @sh << "chmod #{file.mode} '#{file.name}'\n"
           @sh << "chown #{file.user}:#{file.group} '#{file.name}'\n"
         elsif file.link?
@@ -125,8 +124,7 @@ class KiwiConfig < Exporter
       FileUtils.mkdir_p(destination, mode: 01777)
       filter = "unmanaged_files_#{@name}_excludes"
 
-      @system_description.unmanaged_files.file_access.
-        export_files_as_tarballs(destination)
+      @system_description.unmanaged_files.export_files_as_tarballs(destination)
 
       FileUtils.cp(
         File.join(Machinery::ROOT, "export_helpers/#{filter}"),

--- a/lib/kiwi_config.rb
+++ b/lib/kiwi_config.rb
@@ -29,7 +29,7 @@ class KiwiConfig < Exporter
       "packages",
       "os"
     )
-    check_existance_of_extraced_files
+    check_existance_of_extracted_files
 
     generate_config
   end
@@ -138,7 +138,7 @@ class KiwiConfig < Exporter
     end
   end
 
-  def check_existance_of_extraced_files
+  def check_existance_of_extracted_files
     missing_scopes = []
     ["config_files", "changed_managed_files", "unmanaged_files"].each do |scope|
 

--- a/lib/kiwi_config.rb
+++ b/lib/kiwi_config.rb
@@ -108,7 +108,8 @@ class KiwiConfig < Exporter
           @sh << "chmod #{file.mode} '#{file.name}'\n"
           @sh << "chown #{file.user}:#{file.group} '#{file.name}'\n"
         elsif file.file?
-          Machinery::SystemFileUtils.write_file(file, output_root_path)
+          file_access = @system_description[scope].file_access
+          file_access.write_file(file, output_root_path)
           @sh << "chmod #{file.mode} '#{file.name}'\n"
           @sh << "chown #{file.user}:#{file.group} '#{file.name}'\n"
         elsif file.link?

--- a/lib/machinery.rb
+++ b/lib/machinery.rb
@@ -94,6 +94,7 @@ require_relative "file_scope"
 require_relative "file_extractor"
 require_relative "system_file"
 require_relative "system_file_utils"
+require_relative "scope_file_access"
 
 Dir[File.join(Machinery::ROOT, "plugins", "**", "*.rb")].each { |f| require(f) }
 

--- a/lib/scope.rb
+++ b/lib/scope.rb
@@ -60,7 +60,7 @@ module Machinery
     end
 
     def file_access
-      ScopeFileAccess.new(scope_file_store)
+      ScopeFileAccess.new(self, scope_file_store)
     end
   end
 end

--- a/lib/scope.rb
+++ b/lib/scope.rb
@@ -58,13 +58,5 @@ module Machinery
     def is_extractable?
       SystemDescription::EXTRACTABLE_SCOPES.include?(self.scope_name)
     end
-
-    def file_access
-      if self.is_a?(UnmanagedFilesScope)
-        ScopeFileAccessArchive.new(self, scope_file_store)
-      else
-        ScopeFileAccessFlat.new(self, scope_file_store)
-      end
-    end
   end
 end

--- a/lib/scope.rb
+++ b/lib/scope.rb
@@ -58,5 +58,9 @@ module Machinery
     def is_extractable?
       SystemDescription::EXTRACTABLE_SCOPES.include?(self.scope_name)
     end
+
+    def file_access
+      ScopeFileAccess.new(scope_file_store)
+    end
   end
 end

--- a/lib/scope.rb
+++ b/lib/scope.rb
@@ -60,7 +60,11 @@ module Machinery
     end
 
     def file_access
-      ScopeFileAccess.new(self, scope_file_store)
+      if self.is_a?(UnmanagedFilesScope)
+        ScopeFileAccessArchive.new(self, scope_file_store)
+      else
+        ScopeFileAccessFlat.new(self, scope_file_store)
+      end
     end
   end
 end

--- a/lib/scope_file_access.rb
+++ b/lib/scope_file_access.rb
@@ -10,6 +10,20 @@ class ScopeFileAccess
     system.retrieve_files(paths, @scope_file_store.path)
   end
 
+  def write_file(system_file, target)
+    raise Machinery::Errors::FileUtilsError, "Not a file" if !system_file.file?
+
+    target_path = File.join(target, system_file.name)
+    FileUtils.mkdir_p(File.dirname(target_path))
+    FileUtils.cp(file_path(system_file), target_path)
+  end
+
+  def file_path(system_file)
+    raise Machinery::Errors::FileUtilsError, "Not a file" if !system_file.file?
+
+    File.join(@scope_file_store.path, system_file.name)
+  end
+
   # the following methods assume archive file storage
 
   def retrieve_files_from_system_as_archive(system, files, excluded_files)

--- a/lib/scope_file_access.rb
+++ b/lib/scope_file_access.rb
@@ -1,13 +1,6 @@
-class ScopeFileAccess
-  def initialize(scope, scope_file_store)
-    @scope = scope
-    @scope_file_store = scope_file_store
-  end
-end
-
-class ScopeFileAccessFlat < ScopeFileAccess
+module ScopeFileAccessFlat
   def retrieve_files_from_system(system, paths)
-    system.retrieve_files(paths, @scope_file_store.path)
+    system.retrieve_files(paths, scope_file_store.path)
   end
 
   def write_file(system_file, target)
@@ -21,26 +14,26 @@ class ScopeFileAccessFlat < ScopeFileAccess
   def file_path(system_file)
     raise Machinery::Errors::FileUtilsError, "Not a file" if !system_file.file?
 
-    File.join(@scope_file_store.path, system_file.name)
+    File.join(scope_file_store.path, system_file.name)
   end
 end
 
-class ScopeFileAccessArchive < ScopeFileAccess
+module ScopeFileAccessArchive
   def retrieve_files_from_system_as_archive(system, files, excluded_files)
-    extractor = FileExtractor.new(system, @scope_file_store)
+    extractor = FileExtractor.new(system, scope_file_store)
     extractor.extract_files(files, excluded_files)
   end
 
   def retrieve_trees_from_system_as_archive(system, trees, excluded_files)
-    extractor = FileExtractor.new(system, @scope_file_store)
+    extractor = FileExtractor.new(system, scope_file_store)
     extractor.extract_trees(trees, excluded_files)
   end
 
   def export_files_as_tarballs(destination)
-    FileUtils.cp(File.join(@scope_file_store.path, "files.tgz"), destination)
+    FileUtils.cp(File.join(scope_file_store.path, "files.tgz"), destination)
 
     target = File.join(destination, "trees")
-    @scope.files.select(&:directory?).each do |system_file|
+    self.files.select(&:directory?).each do |system_file|
       raise Machinery::Errors::FileUtilsError if !system_file.directory?
 
       tarball_target = File.join(target, File.dirname(system_file.name))

--- a/lib/scope_file_access.rb
+++ b/lib/scope_file_access.rb
@@ -8,4 +8,16 @@ class ScopeFileAccess
   def retrieve_files_from_system(system, paths)
     system.retrieve_files(paths, @scope_file_store.path)
   end
+
+  # the following methods assume archive file storage
+
+  def retrieve_files_from_system_as_archive(system, files, excluded_files)
+    extractor = FileExtractor.new(system, @scope_file_store)
+    extractor.extract_files(files, excluded_files)
+  end
+
+  def retrieve_trees_from_system_as_archive(system, trees, excluded_files)
+    extractor = FileExtractor.new(system, @scope_file_store)
+    extractor.extract_trees(trees, excluded_files)
+  end
 end

--- a/lib/scope_file_access.rb
+++ b/lib/scope_file_access.rb
@@ -3,9 +3,9 @@ class ScopeFileAccess
     @scope = scope
     @scope_file_store = scope_file_store
   end
+end
 
-  # the following methods assume flat file storage
-
+class ScopeFileAccessFlat < ScopeFileAccess
   def retrieve_files_from_system(system, paths)
     system.retrieve_files(paths, @scope_file_store.path)
   end
@@ -23,9 +23,9 @@ class ScopeFileAccess
 
     File.join(@scope_file_store.path, system_file.name)
   end
+end
 
-  # the following methods assume archive file storage
-
+class ScopeFileAccessArchive < ScopeFileAccess
   def retrieve_files_from_system_as_archive(system, files, excluded_files)
     extractor = FileExtractor.new(system, @scope_file_store)
     extractor.extract_files(files, excluded_files)

--- a/lib/scope_file_access.rb
+++ b/lib/scope_file_access.rb
@@ -1,0 +1,11 @@
+class ScopeFileAccess
+  def initialize(scope_file_store)
+    @scope_file_store = scope_file_store
+  end
+
+  # the following methods assume flat file storage
+
+  def retrieve_files_from_system(system, paths)
+    system.retrieve_files(paths, @scope_file_store.path)
+  end
+end

--- a/lib/scope_file_access.rb
+++ b/lib/scope_file_access.rb
@@ -33,7 +33,7 @@ module ScopeFileAccessArchive
     FileUtils.cp(File.join(scope_file_store.path, "files.tgz"), destination)
 
     target = File.join(destination, "trees")
-    self.files.select(&:directory?).each do |system_file|
+    files.select(&:directory?).each do |system_file|
       raise Machinery::Errors::FileUtilsError if !system_file.directory?
 
       tarball_target = File.join(target, File.dirname(system_file.name))

--- a/lib/scope_file_access.rb
+++ b/lib/scope_file_access.rb
@@ -37,7 +37,7 @@ class ScopeFileAccessArchive < ScopeFileAccess
   end
 
   def export_files_as_tarballs(destination)
-    FileUtils.cp( File.join(@scope_file_store.path, "files.tgz"), destination )
+    FileUtils.cp(File.join(@scope_file_store.path, "files.tgz"), destination)
 
     target = File.join(destination, "trees")
     @scope.files.select(&:directory?).each do |system_file|

--- a/lib/scope_file_access.rb
+++ b/lib/scope_file_access.rb
@@ -1,5 +1,6 @@
 class ScopeFileAccess
-  def initialize(scope_file_store)
+  def initialize(scope, scope_file_store)
+    @scope = scope
     @scope_file_store = scope_file_store
   end
 
@@ -19,5 +20,32 @@ class ScopeFileAccess
   def retrieve_trees_from_system_as_archive(system, trees, excluded_files)
     extractor = FileExtractor.new(system, @scope_file_store)
     extractor.extract_trees(trees, excluded_files)
+  end
+
+  def export_files_as_tarballs(destination)
+    FileUtils.cp( File.join(@scope_file_store.path, "files.tgz"), destination )
+
+    target = File.join(destination, "trees")
+    @scope.files.select(&:directory?).each do |system_file|
+      raise Machinery::Errors::FileUtilsError if !system_file.directory?
+
+      tarball_target = File.join(target, File.dirname(system_file.name))
+
+      FileUtils.mkdir_p(tarball_target)
+      FileUtils.cp(tarball_path(system_file), tarball_target)
+    end
+  end
+
+  def tarball_path(system_file)
+    if system_file.directory?
+      File.join(
+        system_file.scope.scope_file_store.path,
+        "trees",
+        File.dirname(system_file.name),
+        File.basename(system_file.name) + ".tgz"
+      )
+    else
+      File.join(system_file.scope.scope_file_store.path, "files.tgz")
+    end
   end
 end

--- a/lib/system_file_utils.rb
+++ b/lib/system_file_utils.rb
@@ -17,7 +17,7 @@
 
 module Machinery
   class SystemFileUtils
-    class <<self
+    class << self
       def tarball_path(system_file)
         if system_file.directory?
           File.join(

--- a/plugins/changed_managed_files/changed_managed_files_inspector.rb
+++ b/plugins/changed_managed_files/changed_managed_files_inspector.rb
@@ -48,7 +48,8 @@ class ChangedManagedFilesInspector < Inspector
         f.name == "/"
       end
 
-      system.retrieve_files(existing_files.map(&:name), file_store.path)
+      scope.file_access.retrieve_files_from_system(@system,
+        existing_files.map(&:name))
     end
 
     scope.extracted = !!options[:extract_changed_managed_files]

--- a/plugins/changed_managed_files/changed_managed_files_inspector.rb
+++ b/plugins/changed_managed_files/changed_managed_files_inspector.rb
@@ -29,7 +29,10 @@ class ChangedManagedFilesInspector < Inspector
     system.check_requirement("rsync", "--version") if options[:extract_changed_managed_files]
 
     @system = system
+
+    scope = ChangedManagedFilesScope.new
     file_store = @description.scope_file_store("changed_managed_files")
+    scope.scope_file_store = file_store
 
     result = changed_files
 
@@ -48,11 +51,9 @@ class ChangedManagedFilesInspector < Inspector
       system.retrieve_files(existing_files.map(&:name), file_store.path)
     end
 
-    json = {
-      extracted: !!options[:extract_changed_managed_files],
-      files: ChangedManagedFileList.new(result.sort_by(&:name))
-    }
-    scope = Machinery::Scope.for("changed_managed_files", json, file_store)
+    scope.extracted = !!options[:extract_changed_managed_files]
+    scope.files = ChangedManagedFileList.new(result.sort_by(&:name))
+
     @description["changed_managed_files"] = scope
   end
 

--- a/plugins/changed_managed_files/changed_managed_files_inspector.rb
+++ b/plugins/changed_managed_files/changed_managed_files_inspector.rb
@@ -48,8 +48,7 @@ class ChangedManagedFilesInspector < Inspector
         f.name == "/"
       end
 
-      scope.file_access.retrieve_files_from_system(@system,
-        existing_files.map(&:name))
+      scope.retrieve_files_from_system(@system, existing_files.map(&:name))
     end
 
     scope.extracted = !!options[:extract_changed_managed_files]

--- a/plugins/changed_managed_files/changed_managed_files_inspector.rb
+++ b/plugins/changed_managed_files/changed_managed_files_inspector.rb
@@ -48,10 +48,12 @@ class ChangedManagedFilesInspector < Inspector
       system.retrieve_files(existing_files.map(&:name), file_store.path)
     end
 
-    @description["changed_managed_files"] = ChangedManagedFilesScope.new(
+    json = {
       extracted: !!options[:extract_changed_managed_files],
       files: ChangedManagedFileList.new(result.sort_by(&:name))
-    )
+    }
+    scope = Machinery::Scope.for("changed_managed_files", json, file_store)
+    @description["changed_managed_files"] = scope
   end
 
   def summary

--- a/plugins/changed_managed_files/changed_managed_files_model.rb
+++ b/plugins/changed_managed_files/changed_managed_files_model.rb
@@ -24,5 +24,6 @@ end
 
 class ChangedManagedFilesScope < FileScope
   include Machinery::Scope
+  include ScopeFileAccessFlat
   has_property :files, class: ChangedManagedFileList
 end

--- a/plugins/config_files/config_files_inspector.rb
+++ b/plugins/config_files/config_files_inspector.rb
@@ -108,7 +108,10 @@ class ConfigFilesInspector < Inspector
       end
     end
 
+    scope = ConfigFilesScope.new
     file_store = @description.scope_file_store("config_files")
+    scope.scope_file_store = file_store
+
     file_store.remove
     if do_extract
       file_store.create
@@ -119,11 +122,9 @@ class ConfigFilesInspector < Inspector
       @system.retrieve_files(extracted_paths, file_store.path)
     end
 
-    json = {
-      extracted: !!do_extract,
-      files: ConfigFileList.new(result.sort_by(&:name))
-    }
-    scope = Machinery::Scope.for("config_files", json, file_store)
+    scope.extracted = !!do_extract
+    scope.files = ConfigFileList.new(result.sort_by(&:name))
+
     @description["config_files"] = scope
   end
 

--- a/plugins/config_files/config_files_inspector.rb
+++ b/plugins/config_files/config_files_inspector.rb
@@ -119,7 +119,7 @@ class ConfigFilesInspector < Inspector
         file.changes == Machinery::Array.new(["deleted"]) ||
         file.link? || file.directory?
       end.map(&:name)
-      @system.retrieve_files(extracted_paths, file_store.path)
+      scope.file_access.retrieve_files_from_system(@system, extracted_paths)
     end
 
     scope.extracted = !!do_extract

--- a/plugins/config_files/config_files_inspector.rb
+++ b/plugins/config_files/config_files_inspector.rb
@@ -119,7 +119,7 @@ class ConfigFilesInspector < Inspector
         file.changes == Machinery::Array.new(["deleted"]) ||
         file.link? || file.directory?
       end.map(&:name)
-      scope.file_access.retrieve_files_from_system(@system, extracted_paths)
+      scope.retrieve_files_from_system(@system, extracted_paths)
     end
 
     scope.extracted = !!do_extract

--- a/plugins/config_files/config_files_inspector.rb
+++ b/plugins/config_files/config_files_inspector.rb
@@ -119,10 +119,12 @@ class ConfigFilesInspector < Inspector
       @system.retrieve_files(extracted_paths, file_store.path)
     end
 
-    @description["config_files"] = ConfigFilesScope.new(
+    json = {
       extracted: !!do_extract,
       files: ConfigFileList.new(result.sort_by(&:name))
-    )
+    }
+    scope = Machinery::Scope.for("config_files", json, file_store)
+    @description["config_files"] = scope
   end
 
   def summary

--- a/plugins/config_files/config_files_model.rb
+++ b/plugins/config_files/config_files_model.rb
@@ -24,5 +24,6 @@ end
 
 class ConfigFilesScope < FileScope
   include Machinery::Scope
+  include ScopeFileAccessFlat
   has_property :files, class: ConfigFileList
 end

--- a/plugins/unmanaged_files/unmanaged_files_inspector.rb
+++ b/plugins/unmanaged_files/unmanaged_files_inspector.rb
@@ -334,9 +334,9 @@ class UnmanagedFilesInspector < Inspector
         file_store_tmp.remove
         file_store_tmp.create
 
-        scope.file_access.retrieve_files_from_system_as_archive(@system,
+        scope.retrieve_files_from_system_as_archive(@system,
           unmanaged_files, excluded_files)
-        scope.file_access.retrieve_trees_from_system_as_archive(@system,
+        scope.retrieve_trees_from_system_as_archive(@system,
           unmanaged_trees, excluded_files)
       else
         file_store_final.remove

--- a/plugins/unmanaged_files/unmanaged_files_inspector.rb
+++ b/plugins/unmanaged_files/unmanaged_files_inspector.rb
@@ -216,8 +216,12 @@ class UnmanagedFilesInspector < Inspector
     do_extract = options && options[:extract_unmanaged_files]
     check_requirements(do_extract)
 
+    scope = UnmanagedFilesScope.new
+
     file_store_tmp = @description.scope_file_store("unmanaged_files.tmp")
     file_store_final = @description.scope_file_store("unmanaged_files")
+
+    scope.scope_file_store = file_store_final
 
     mount_points = MountPoints.new(@system)
 
@@ -363,11 +367,9 @@ class UnmanagedFilesInspector < Inspector
       osl << UnmanagedFile.new( name: remote_dir + "/", type: "remote_dir")
     end
 
-    json = {
-      extracted: !!do_extract,
-      files: UnmanagedFileList.new(osl.sort_by(&:name))
-    }
-    scope = Machinery::Scope.for("unmanaged_files", json, file_store_final)
+    scope.extracted = !!do_extract
+    scope.files = UnmanagedFileList.new(osl.sort_by(&:name))
+
     @description["unmanaged_files"] = scope
   end
 

--- a/plugins/unmanaged_files/unmanaged_files_inspector.rb
+++ b/plugins/unmanaged_files/unmanaged_files_inspector.rb
@@ -363,10 +363,12 @@ class UnmanagedFilesInspector < Inspector
       osl << UnmanagedFile.new( name: remote_dir + "/", type: "remote_dir")
     end
 
-    @description["unmanaged_files"] = UnmanagedFilesScope.new(
+    json = {
       extracted: !!do_extract,
       files: UnmanagedFileList.new(osl.sort_by(&:name))
-    )
+    }
+    scope = Machinery::Scope.for("unmanaged_files", json, file_store_final)
+    @description["unmanaged_files"] = scope
   end
 
   def summary

--- a/plugins/unmanaged_files/unmanaged_files_model.rb
+++ b/plugins/unmanaged_files/unmanaged_files_model.rb
@@ -51,6 +51,7 @@ end
 
 class UnmanagedFilesScope < FileScope
   include Machinery::Scope
+  include ScopeFileAccessArchive
   has_property :files, class: UnmanagedFileList
 
   def compare_with(other)

--- a/spec/unit/scope_file_access_spec.rb
+++ b/spec/unit/scope_file_access_spec.rb
@@ -1,0 +1,20 @@
+require_relative "spec_helper"
+
+describe ScopeFileAccess do
+  initialize_system_description_factory_store
+
+  describe "#export_files_as_tarballs" do
+    it "should copy all tarballs to the destination" do
+      description = create_test_description(
+        store_on_disk: true,
+        extracted_scopes: ["unmanaged_files"]
+      )
+
+      target = given_directory
+      description.unmanaged_files.file_access.export_files_as_tarballs(target)
+
+      expect(File.exists?(File.join(target, "files.tgz"))).to be(true)
+      expect(File.exists?(File.join(target, "trees/etc/tarball with spaces.tgz"))).to be(true)
+    end
+  end
+end

--- a/spec/unit/scope_file_access_spec.rb
+++ b/spec/unit/scope_file_access_spec.rb
@@ -1,6 +1,6 @@
 require_relative "spec_helper"
 
-describe ScopeFileAccess do
+describe "ScopeFileAccess" do
   initialize_system_description_factory_store
 
   describe "#export_files_as_tarballs" do
@@ -11,7 +11,7 @@ describe ScopeFileAccess do
       )
 
       target = given_directory
-      description.unmanaged_files.file_access.export_files_as_tarballs(target)
+      description.unmanaged_files.export_files_as_tarballs(target)
 
       expect(File.exists?(File.join(target, "files.tgz"))).to be(true)
       expect(File.exists?(File.join(target, "trees/etc/tarball with spaces.tgz"))).to be(true)

--- a/spec/unit/support/file_scope_examples.rb
+++ b/spec/unit/support/file_scope_examples.rb
@@ -34,21 +34,6 @@ shared_examples "FileScope" do
     }
   }
 
-  describe "#export_files_as_tarballs" do
-    it "should copy all tarballs to the destination" do
-      description = create_test_description(
-        store_on_disk: true,
-        extracted_scopes: ["unmanaged_files"]
-      )
-
-      target = given_directory
-      description.unmanaged_files.export_files_as_tarballs(target)
-
-      expect(File.exists?(File.join(target, "files.tgz"))).to be(true)
-      expect(File.exists?(File.join(target, "trees/etc/tarball with spaces.tgz"))).to be(true)
-    end
-  end
-
   describe "#compare_with" do
     it "compares for equal objects" do
       a = scope.class.new(


### PR DESCRIPTION
This pull request is for reviewing the file access API. It's not meant to directly be merged.

Access to the scope file storage is abstracted through the `ScopeFileAccess` class, which is obtained through the scope object. There are two different backends for storing scope file data and according to scope the right one is returned from the scope.

This pull requests consolidates the API to consolidate the different classes accessing scope file into one API.

There still are a couple of places which use no abstraction at all and directly work on the file system, e.g. `AutoYasT#apply_unmanaged_files` or `UnmanagedFilesInspector#extract_tar_metadata`. These places can all be abstracted in the same way going through the `ScopeFileAccess` class. It might need additional methods to fit all use cases, though.

When the API from the application's point of view is ok, the next steps would be to remove redundant, obsolete abstractions, add tests for `ScopeFileAccess` and abstract the places, where there is no abstraction yet.

Unit tests work, I haven't run integration tests. If there are integration tests failing, we should probably add unit tests to capture these cases, so we have full test coverage of the scope file access.
