### PR TITLE
Remove file type from deleted changed files

### DIFF
--- a/spec/data/descriptions/jeos/manifest.json
+++ b/spec/data/descriptions/jeos/manifest.json
@@ -3062,8 +3062,7 @@
         "status": "changed",
         "changes": [
           "deleted"
-        ],
-        "type": "file"
+        ]
       },
       {
         "name": "/usr/share/bash/helpfiles/read",

--- a/spec/data/descriptions/validation/changed-managed-files-additional-files/manifest.json
+++ b/spec/data/descriptions/validation/changed-managed-files-additional-files/manifest.json
@@ -22,8 +22,7 @@
         "status": "changed",
         "changes": [
           "deleted"
-        ],
-        "type": "file"
+        ]
       }
     ]
   },

--- a/spec/data/descriptions/validation/changed-managed-files-good/manifest.json
+++ b/spec/data/descriptions/validation/changed-managed-files-good/manifest.json
@@ -35,8 +35,7 @@
         "status": "changed",
         "changes": [
           "deleted"
-        ],
-        "type": "file"
+        ]
       }
     ]
   },

--- a/spec/data/descriptions/validation/config-files-additional-files/manifest.json
+++ b/spec/data/descriptions/validation/config-files-additional-files/manifest.json
@@ -23,8 +23,7 @@
         "status": "changed",
         "changes": [
           "deleted"
-        ],
-        "type": "file"
+        ]
       }
     ]
   },

--- a/spec/data/descriptions/validation/config-files-good/manifest.json
+++ b/spec/data/descriptions/validation/config-files-good/manifest.json
@@ -36,8 +36,7 @@
         "status": "changed",
         "changes": [
           "deleted"
-        ],
-        "type": "file"
+        ]
       }
     ]
   },


### PR DESCRIPTION
Our format version 3 to 4 migration accidentally added a file type to
files marked as deleted (config and changed managed files) so it needs
to be removed in our test data.