### PR TITLE
Allow os inspector to handle dummy os-release files

### DIFF
--- a/plugins/os/os_inspector.rb
+++ b/plugins/os/os_inspector.rb
@@ -50,7 +50,7 @@ class OsInspector < Inspector
     os = get_os
     if os
       os.architecture = get_arch
-      os.version += get_additional_version
+      os.version += get_additional_version if os.version
     else
       raise Machinery::Errors::UnknownOs
     end
@@ -101,7 +101,7 @@ class OsInspector < Inspector
     end
     # return pretty_name as name as it contains the actual full length
     # name instead of an abbreviation
-    os = Os.for(result["pretty_name"])
+    os = Os.for(result["pretty_name"] || result["name"])
     os.version = result["version"]
     os
   end

--- a/spec/data/os/dummy/etc/issue
+++ b/spec/data/os/dummy/etc/issue
@@ -1,0 +1,4 @@
+
+Welcome to Dummy Product - Kernel \r (\l).
+
+

--- a/spec/data/os/dummy/etc/os-release
+++ b/spec/data/os/dummy/etc/os-release
@@ -1,0 +1,2 @@
+NAME=Dummy
+ID_LIKE="suse"

--- a/spec/unit/os_inspector_spec.rb
+++ b/spec/unit/os_inspector_spec.rb
@@ -197,6 +197,25 @@ describe OsInspector do
       expect(description.os.name).to eq("openSUSE 11.2")
     end
 
+    it "returns correct data if an unsupported SLES (marked as Dummy) is inspected" do
+      FakeFS::FileSystem.clone("spec/data/os/dummy/etc/os-release",
+        "/etc/os-release")
+      FakeFS::FileSystem.clone("spec/data/os/dummy/etc/issue",
+        "/etc/issue")
+
+      expect(inspector).to receive(:get_arch).and_return("i586")
+
+      inspector.inspect(filter)
+
+      expect(description.os).to eq(
+        OsUnknown.new(
+          name: "Dummy",
+          version: nil,
+          architecture: "i586"
+        )
+      )
+    end
+
     it "throws exception when the operation system cannot be determined" do
       expect {
         inspector.inspect(filter)


### PR DESCRIPTION
If banned packages are installed on SLES12 certain release packages
need to be removed which replace os-release by a dummy version which
misses most common parameters.

Fixes #980