### PR TITLE
Fix faulty escaping of single quotes

### DIFF
--- a/lib/exporter.rb
+++ b/lib/exporter.rb
@@ -23,6 +23,6 @@ class Exporter
   abstract_method :export_name
 
   def quote(name)
-    name.gsub("'", "\\\\'")
+    name.gsub("'", "'\\\\''")
   end
 end

--- a/spec/unit/autoyast_spec.rb
+++ b/spec/unit/autoyast_spec.rb
@@ -61,7 +61,7 @@ describe Autoyast do
       autoyast = Autoyast.new(description)
 
       expect(autoyast.profile).to include(
-        "ln -s '/opt/test-quote-char/target-with-quote\\\'-foo' '/mnt/opt/test-quote-char/link'"
+        "ln -s '/opt/test-quote-char/target-with-quote'\\\''-foo' '/mnt/opt/test-quote-char/link'"
       )
     end
 

--- a/spec/unit/exporter_spec.rb
+++ b/spec/unit/exporter_spec.rb
@@ -21,9 +21,10 @@ describe Exporter do
   describe "#quote" do
     it "returns the quoted name" do
       expect(subject.quote("/bla/single-quote-file'-foo/")).to eq(
-        "/bla/single-quote-file\\'-foo/"
+        "/bla/single-quote-file'\\''-foo/"
       )
     end
+
     it "returns the name without escaping anything" do
       expect(subject.quote("/bla/no-single-quote-file-foo/")).to eq(
         "/bla/no-single-quote-file-foo/"

--- a/spec/unit/kiwi_config_spec.rb
+++ b/spec/unit/kiwi_config_spec.rb
@@ -251,7 +251,7 @@ describe KiwiConfig do
       config = KiwiConfig.new(system_description_with_modified_files)
       config.write(export_dir)
       expect(config.sh).to include(
-        "ln -s '/opt/test-quote-char/target-with-quote\\'-foo' '/opt/test-quote-char/link'"
+        "ln -s '/opt/test-quote-char/target-with-quote'\\''-foo' '/opt/test-quote-char/link'"
       )
     end
 


### PR DESCRIPTION
There is no escape character in single quote strings so our approach
didn't work.

Instead I am just replacing a single quote by '\'' .