### PR TITLE
Add specific command arguments into error message

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -59,7 +59,9 @@ class Cli
 
   def self.check_exceeding_arguments(defined, parsed)
     if parsed.size > defined.size
-      message = "The given arguments don't match the command's specified arguments."
+      parsed_arguments = "#{parsed.size} #{Machinery.pluralize(parsed.size, "argument")}"
+      defined_arguments = defined.empty? ? "none" : "only: #{defined.map(&:name).join(", ")}"
+      message = "Too many arguments: got #{parsed_arguments}, expected #{defined_arguments}"
       raise GLI::BadCommandLine.new(message)
     end
     true

--- a/spec/integration/support/command_line_examples.rb
+++ b/spec/integration/support/command_line_examples.rb
@@ -94,13 +94,26 @@ shared_examples "CLI" do
       end
     end
 
-    describe "list" do
-      context "when more arguments than expected" do
+    describe "validate number of given arguments" do
+      context "when no arguments are expected" do
         it "fails with a message" do
           message = /Too many arguments: got 2 arguments, expected none/
           expect {
             @machinery.run_command(
               "#{machinery_command} list foo bar",
+              as: "vagrant",
+              stderr: :capture
+            )
+          }.to raise_error(Pennyworth::ExecutionFailed, message)
+        end
+      end
+
+      context "when a specific number of arguments are expected" do
+        it "fails with a message" do
+          message = /Too many arguments: got 2 arguments, expected only: NAME/
+          expect {
+            @machinery.run_command(
+              "#{machinery_command} show foo bar",
               as: "vagrant",
               stderr: :capture
             )

--- a/spec/integration/support/command_line_examples.rb
+++ b/spec/integration/support/command_line_examples.rb
@@ -97,7 +97,7 @@ shared_examples "CLI" do
     describe "list" do
       context "when more arguments than expected" do
         it "fails with a message" do
-          message = /The given arguments don't match the command's specified arguments/
+          message = /Too many arguments: got 2 arguments, expected none/
           expect {
             @machinery.run_command(
               "#{machinery_command} list foo bar",


### PR DESCRIPTION
When passing more arguments than expected, show the number that were
passed and the ones that are expected from the command.

Issue #997 