### PR TITLE
Implementation of `machinery config foo=bar` syntax

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 # Machinery Release Notes
 
+* `machinery config` takes arguments of the form 'key=value' as well
 
 ## Version 1.9.0 - Wed Jun 17 09:57:07 CEST 2015 - thardeck@suse.de
 

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -46,9 +46,9 @@ class Cli
 
       Machinery::Ui.puts "\nMachinery can show hints which guide through a typical workflow."
       if @config.hints
-        Machinery::Ui.puts "These hints can be switched off by '#{$0} config hints off'."
+        Machinery::Ui.puts "These hints can be switched off by '#{$0} config hints=off'."
       else
-        Machinery::Ui.puts "These hints can be switched on by '#{$0} config hints on'."
+        Machinery::Ui.puts "These hints can be switched on by '#{$0} config hints=on'."
       end
 
       Hint.print(:get_started)
@@ -732,7 +732,7 @@ class Cli
       task.config(key, value)
 
       if key == "hints" && !@config.hints
-        Machinery::Ui.puts "Hints can be switched on again by '#{$0} config hints on'."
+        Machinery::Ui.puts "Hints can be switched on again by '#{$0} config hints=on'."
       end
     end
   end

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -717,8 +717,16 @@ class Cli
   arg "VALUE", :optional
   command "config" do |c|
     c.action do |global_options,options,args|
-      key = args[0]
-      value = args[1]
+      if args[0] && args[0].include?("=")
+        if args[1]
+          raise GLI::BadCommandLine, "Too many arguments: got 2 arguments, expected only: KEY=VALUE"
+        else
+          key, value = args[0].split("=")
+        end
+      else
+        key = args[0]
+        value = args[1]
+      end
 
       task = ConfigTask.new
       task.config(key, value)

--- a/lib/local_system.rb
+++ b/lib/local_system.rb
@@ -52,7 +52,7 @@ You are running Machinery on a platform we do not explicitly support and test.
 It still could work very well. If you run into issues or would like to provide us feedback, you are welcome to file an issue at https://github.com/SUSE/machinery/issues/new or write an email to machinery@lists.suse.com.
 Oficially supported operating systems are: '#{supported_oses}'
 
-To disable this message in the machinery configuration use 'machinery config perform-support-check false'
+To disable this message in the machinery configuration use 'machinery config perform-support-check=false'
 EOF
 
       Machinery::Ui.warn message

--- a/man/machinery-config.1.md
+++ b/man/machinery-config.1.md
@@ -4,7 +4,7 @@
 ### SYNOPSIS
 
 `machinery config`
-    [KEY] [VALUE]
+    [KEY]=[VALUE]
 
 `machinery` help config
 
@@ -31,7 +31,7 @@ The configuration is stored in `~/.machinery/machinery.config`.
 
   * Turn off hints:
 
-    $ `machinery` config hints off
+    $ `machinery` config hints=off
 
   * Show current configuration of hints:
 

--- a/man/machinery-inspect.1.md
+++ b/man/machinery-inspect.1.md
@@ -46,7 +46,7 @@ trigger errors.
     Defines the user which is used to access the inspected system via SSH.
     This user needs to be allowed to run certain commands using sudo (see
     PREREQUISITES for more information).
-    To change the default-user use `machinery config remote-user USER`
+    To change the default-user use `machinery config remote-user=USER`
 
   * `-x`, `--extract-files` (optional):
     Extract changed configuration and unmanaged files from the inspected system.

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -559,6 +559,12 @@ describe Cli do
         with("foo", "bar")
       run_command(["config", "foo", "bar"])
     end
+
+    it "handles parameter with equal sign syntax" do
+      expect_any_instance_of(ConfigTask).to receive(:config).
+        with("foo", "bar")
+      run_command(["config", "foo=bar"])
+    end
   end
 
   describe ".process_scope_option" do

--- a/spec/unit/local_system_spec.rb
+++ b/spec/unit/local_system_spec.rb
@@ -133,7 +133,9 @@ describe LocalSystem do
         it "shows how to turn off the warning" do
           LocalSystem.validate_machinery_compatibility
 
-          expect(captured_machinery_stderr).to include("'machinery config perform-support-check false'")
+          expect(captured_machinery_stderr).to include(
+            "'machinery config perform-support-check=false'"
+          )
         end
       end
 


### PR DESCRIPTION
Superseds #1013