### PR TITLE
Add test matrix sources to machinery

### DIFF
--- a/spec/data/test_matrix/integration_tests.yml
+++ b/spec/data/test_matrix/integration_tests.yml
@@ -1,0 +1,120 @@
+inspect:
+  supported:
+    "openSUSE_13_2:x86_64":
+      "openSUSE_13_2:x86_64": minimal_test
+    "openSUSE_13_1:x86_64":
+      "openSUSE_13_1:x86_64": full_test
+  working:
+    "openSUSE_13_2:x86_64":
+      "openSUSE_13_1:x86_64":
+      "Tumbleweed:x86_64":
+    "openSUSE_13_1:x86_64":
+      "openSUSE_13_2:x86_64":
+      "Tumbleweed:x86_64":
+    "Tumbleweed:x86_64":
+      "openSUSE_13_2:x86_64":
+      "openSUSE_13_1:x86_64":
+      "Tumbleweed:x86_64":
+build:
+  supported:
+    "openSUSE_13_2:x86_64":
+      "openSUSE_13_2:x86_64": full_test
+  future_support:
+  working:
+    "openSUSE_13_2:x86_64":
+      "openSUSE_13_1:x86_64":
+    "openSUSE_13_1:x86_64":
+      "openSUSE_13_1:x86_64":
+    "Tumbleweed:x86_64":
+      "openSUSE_13_2:x86_64":
+      "openSUSE_13_1:x86_64":
+      "Tumbleweed:x86_64":
+  unsupported:
+    "openSUSE_13_2:x86_64":
+      "Tumbleweed:x86_64":
+      "Tumbleweed:arm":
+      "fedora":
+    "openSUSE_13_1:x86_64":
+      "openSUSE_13_2:x86_64":
+      "Tumbleweed:x86_64":
+      "Tumbleweed:arm":
+      "fedora":
+    "Tumbleweed:x86_64":
+      "fedora":
+export:
+  supported:
+    "openSUSE_13_2:x86_64":
+      "openSUSE_13_2:x86_64": acceptance_test
+    "openSUSE_13_1:x86_64":
+      "openSUSE_13_1:x86_64": full_test
+  working:
+    "openSUSE_13_2:x86_64":
+      "openSUSE_13_1:x86_64":
+      "Tumbleweed:x86_64":
+    "openSUSE_13_1:x86_64":
+      "openSUSE_13_2:x86_64":
+      "Tumbleweed:x86_64":
+    "Tumbleweed:x86_64":
+      "openSUSE_13_1:x86_64":
+      "Tumbleweed:x86_64":
+  unsupported:
+    "openSUSE_13_2:x86_64":
+      "Tumbleweed:arm":
+      "fedora":
+    "openSUSE_13_1:x86_64":
+      "Tumbleweed:arm":
+      "fedora":
+    "Tumbleweed:x86_64":
+      "Tumbleweed:arm":
+      "fedora":
+analyze:
+  supported:
+    "openSUSE_13_2:x86_64":
+      "openSUSE_13_2:x86_64": acceptance_test
+    "openSUSE_13_1:x86_64":
+      "openSUSE_13_1:x86_64": full_test
+  future_support:
+  working:
+    "openSUSE_13_2:x86_64":
+      "openSUSE_13_1:x86_64":
+      "Tumbleweed:x86_64":
+    "openSUSE_13_1:x86_64":
+      "openSUSE_13_2:x86_64":
+      "Tumbleweed:x86_64":
+    "Tumbleweed:x86_64":
+      "openSUSE_13_2:x86_64":
+      "openSUSE_13_1:x86_64":
+      "Tumbleweed:x86_64":
+  unsupported:
+deploy:
+  supported:
+    "openSUSE_13_2:x86_64":
+      "openSUSE_13_2:x86_64":
+  future_support:
+  working:
+    "openSUSE_13_1:x86_64":
+      "openSUSE_13_1:x86_64":
+    "Tumbleweed:x86_64":
+      "Tumbleweed:x86_64":
+  unsupported:
+    "openSUSE_13_2:x86_64":
+      "openSUSE_13_2:arm":
+      "openSUSE_13_1:x86_64":
+      "openSUSE_13_1:arm":
+      "Tumbleweed:x86_64":
+      "Tumbleweed:arm":
+      "fedora":
+    "openSUSE_13_1:x86_64":
+      "openSUSE_13_2:x86_64":
+      "openSUSE_13_2:arm":
+      "openSUSE_13_1:arm":
+      "Tumbleweed:x86_64":
+      "Tumbleweed:arm":
+      "fedora":
+    "Tumbleweed:x86_64":
+      "openSUSE_13_2:x86_64":
+      "openSUSE_13_2:arm":
+      "openSUSE_13_1:x86_64":
+      "openSUSE_13_1:arm":
+      "Tumbleweed:arm":
+      "fedora":

--- a/spec/data/test_matrix/runs_on.yml
+++ b/spec/data/test_matrix/runs_on.yml
@@ -1,0 +1,12 @@
+---
+supported:
+  "openSUSE_13_1:x86_64":
+    "Package installation": full_test
+    "General commands": minimal_test
+working:
+  "openSUSE_13_1:x86_64":
+    "Package installation": full_test
+    "General commands":
+  "Tumbleweed:x86_64":
+    "Package installation": full_test
+    "General commands":

--- a/spec/data/test_matrix/unit_tests.yml
+++ b/spec/data/test_matrix/unit_tests.yml
@@ -1,0 +1,5 @@
+---
+# Test once per Ruby version
+tested:
+  "openSUSE_13_1:x86_64" #ruby2.0
+  "openSUSE_13_2:x86_64" #ruby2.1


### PR DESCRIPTION
If the tests are running according to the test matrix we need to
separate alfred and machinery only data.