### PR TITLE
Machinery helper

### DIFF
--- a/lib/machinery.rb
+++ b/lib/machinery.rb
@@ -93,6 +93,7 @@ require_relative "filter_option_parser"
 require_relative "file_scope"
 require_relative "system_file"
 require_relative "scope_file_access"
+require_relative "machinery_helper"
 
 Dir[File.join(Machinery::ROOT, "plugins", "**", "*.rb")].each { |f| require(f) }
 

--- a/lib/machinery_helper.rb
+++ b/lib/machinery_helper.rb
@@ -1,3 +1,20 @@
+# Copyright (c) 2015 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
 class MachineryHelper
   attr_accessor :local_helpers_path
 

--- a/lib/machinery_helper.rb
+++ b/lib/machinery_helper.rb
@@ -15,6 +15,18 @@
 # To contact SUSE about this file by physical or electronic mail,
 # you may find current contact information at www.suse.com
 
+# The MachineryHelper class handles the helper binaries Machinery can use to
+# do inspections. It provides methods to check, if a helper is available, to
+# inject it to the target machine, run it there, and clean up after it's done.
+#
+# The inspection checks, if a binary helper is available on the machine where
+# the inspection is started. It looks at the location
+#
+#    /usr/share/machinery/helpers/<arch>/machinery_helper
+#
+# where <arch> is the hardware architecture of the target system. Valid values
+# are x86_64, i586, s390x, and ppcle.
+
 class MachineryHelper
   attr_accessor :local_helpers_path
 

--- a/lib/machinery_helper.rb
+++ b/lib/machinery_helper.rb
@@ -1,0 +1,41 @@
+class MachineryHelper
+  attr_accessor :local_helpers_path
+
+  def initialize(s)
+    @system = s
+    @arch = nil
+
+    @local_helpers_path = "/usr/share/machinery/helpers"
+  end
+
+  def local_helper_path
+    if !@arch
+      description = SystemDescription.new("", SystemDescriptionMemoryStore.new)
+      inspector = OsInspector.new(@system, description)
+      inspector.inspect(nil)
+
+      @arch = description.os.architecture
+    end
+
+    File.join(@local_helpers_path, @arch, "machinery_helper")
+  end
+
+  # Returns true, if there is a helper binary matching the architecture of the
+  # inspected system. Return false, if not.
+  def can_help?
+    File.exist?(local_helper_path)
+  end
+
+  def inject_helper
+    @system.inject_file(local_helper_path, ".")
+  end
+
+  def run_helper(scope)
+    json = @system.run_command("./machinery_helper", stdout: :capture)
+    scope.set_attributes(JSON.parse(json)["unmanaged_files"])
+  end
+
+  def remove_helper
+    @system.remove_file("./machinery_helper")
+  end
+end

--- a/lib/remote_system.rb
+++ b/lib/remote_system.rb
@@ -140,4 +140,8 @@ class RemoteSystem < System
       raise
     end
   end
+
+  def inject_file(local_file, remote_path)
+    system("scp #{local_file} root@#{host}:#{remote_path}")
+  end
 end

--- a/spec/data/machinery_helper/x86_64/machinery_helper
+++ b/spec/data/machinery_helper/x86_64/machinery_helper
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+cat << EOT
+{
+  "unmanaged_files": {
+    "files": [
+      {
+        "name": "/opt/magic/file",
+        "type": "file",
+        "user": "root",
+        "group": "root",
+        "size": 0,
+        "mode": "644"
+      },
+      {
+        "name": "/opt/magic/other_file",
+        "type": "file",
+        "user": "root",
+        "group": "root",
+        "size": 0,
+        "mode": "644"
+      }
+    ]
+  }
+}
+EOT

--- a/spec/unit/machinery_helper_spec.rb
+++ b/spec/unit/machinery_helper_spec.rb
@@ -1,0 +1,134 @@
+require_relative "spec_helper"
+
+include GivenFilesystemSpecHelpers
+
+describe MachineryHelper do
+  use_given_filesystem
+
+  before(:each) do
+    allow_any_instance_of(OsInspector).to receive(:inspect) do |instance|
+      json = <<-EOT
+        {
+          "os": {
+            "architecture": "x86_64"
+          }
+        }
+      EOT
+      system_description = create_test_description(json: json)
+      instance.description.os = system_description.os
+    end
+  end
+
+  describe "#can_help?" do
+    it "can help if helper exists" do
+      dummy_system = double
+      helper = MachineryHelper.new(dummy_system)
+      helper.local_helpers_path = File.join(Machinery::ROOT, "spec/data/machinery_helper")
+
+      expect(helper.can_help?).to be(true)
+    end
+
+    it "can not help if helper does not exist" do
+      dummy_system = double
+      helper = MachineryHelper.new(dummy_system)
+      helper.local_helpers_path = given_directory
+
+      expect(helper.can_help?).to be(false)
+    end
+  end
+
+  it "#inject_helper" do
+    dummy_system = double
+
+    helper = MachineryHelper.new(dummy_system)
+
+    local_helper_path = "ab/cd/x86_64/machinery_helper"
+    helper.local_helpers_path = "ab/cd"
+    remote_path = "."
+
+    expect(dummy_system).to receive(:inject_file).with(local_helper_path,
+      remote_path)
+
+    helper.inject_helper
+  end
+
+  it "#remove_helper" do
+    dummy_system = double
+
+    helper = MachineryHelper.new(dummy_system)
+
+    expect(dummy_system).to receive(:remove_file).with("./machinery_helper")
+
+    helper.remove_helper
+  end
+
+  it "#run_helper" do
+    dummy_system = double
+
+    helper = MachineryHelper.new(dummy_system)
+
+    json = <<-EOT
+      {
+        "unmanaged_files": {
+          "files": [
+            {
+              "name": "/opt/magic/file",
+              "type": "file",
+              "user": "root",
+              "group": "root",
+              "size": 0,
+              "mode": "644"
+            },
+            {
+              "name": "/opt/magic/other_file",
+              "type": "file",
+              "user": "root",
+              "group": "root",
+              "size": 0,
+              "mode": "644"
+            }
+          ]
+        }
+      }
+    EOT
+
+    expect(dummy_system).to receive(:run_command).with("./machinery_helper",
+      stdout: :capture).and_return(json)
+
+    scope = UnmanagedFilesScope.new
+    helper.run_helper(scope)
+
+    expect(scope.files.first.name).to eq("/opt/magic/file")
+    expect(scope.files.count).to eq(2)
+  end
+end
+
+describe UnmanagedFilesInspector do
+  before(:each) do
+    allow_any_instance_of(OsInspector).to receive(:inspect) do |instance|
+      json = <<-EOT
+        {
+          "os": {
+            "architecture": "x86_64"
+          }
+        }
+      EOT
+      system_description = create_test_description(json: json)
+      instance.description.os = system_description.os
+    end
+  end
+
+  it "runs helper" do
+    @system = double
+    allow(@system).to receive(:check_requirement)
+
+    description = SystemDescription.new("systemname", SystemDescriptionStore.new)
+    inspector = UnmanagedFilesInspector.new(@system, description)
+
+    allow_any_instance_of(MachineryHelper).to receive(:can_help?).and_return(true)
+    expect_any_instance_of(MachineryHelper).to receive(:inject_helper)
+    expect_any_instance_of(MachineryHelper).to receive(:run_helper)
+
+    inspector.inspect(Filter.from_default_definition("inspect"))
+  end
+end

--- a/spec/unit/unmanaged_files_inspector_spec.rb
+++ b/spec/unit/unmanaged_files_inspector_spec.rb
@@ -26,6 +26,11 @@ describe UnmanagedFilesInspector do
   }
   subject { UnmanagedFilesInspector.new(system, description) }
 
+  before(:each) do
+    allow_any_instance_of(MachineryHelper).to receive(:can_help?).
+      and_return(false)
+  end
+
   describe ".inspect" do
     include FakeFS::SpecHelpers
 


### PR DESCRIPTION
This is the prototype for using a helper binary to run an inspection. It only covers unmanaged files for now. It checks, if a helper binary exists for the architecture of the target system, and if one is there, it copies it to the target system and runs it there to do the inspection. If no helper binary is found it transparently falls back to the original method of inspection.

The first iteration of the prototype only covers pure inspection, no file extraction.

The code needs more tests and error handling before it can be merged to master. The basic architecture should be ok, though.

The same concept can be used for inspection of other scopes as well. This will need moving the code injecting and possibly running the binary to a more central place. The basic principle will stay the same, so this can be a later step.
