### PR TITLE
Add package 'man' to machinery integration-test hosts

### DIFF
--- a/spec/definitions/boxes/definitions/machinery_opensuse_tumbleweed_kvm/config.xml
+++ b/spec/definitions/boxes/definitions/machinery_opensuse_tumbleweed_kvm/config.xml
@@ -66,6 +66,7 @@
         <package name="db45-utils"/>
         <package name="db-utils"/>
         <package name="grub"/>
+        <package name="man"/>
     </packages>
     <packages type="bootstrap">
         <package name="udev"/>


### PR DESCRIPTION
Superseeds #1040 

- Add 'man' package to openSUSE Tumbleweed

- Package 'man' is needed on the machinery integration-test hosts to test the new machinery man function