### PR TITLE
Filter RHEL5 non-deterministic unmanaged file

### DIFF
--- a/spec/integration/support/inspect_unmanaged_files_examples.rb
+++ b/spec/integration/support/inspect_unmanaged_files_examples.rb
@@ -23,7 +23,8 @@ shared_examples "inspect unmanaged files" do |base|
         "/var/spool/cron/lastrun/cron.daily",
         "/var/log/sa",
         "/root/.local",
-        "/etc/ssh"
+        "/etc/ssh",
+        "/var/log/mcelog"
       ]
     }
 


### PR DESCRIPTION
/var/log/mcelog was on some occurences there and sometimes not so we
filter it to prevent failing tests.