### PR TITLE
Add the public support matrix data sources

### DIFF
--- a/spec/definitions/support/integration_tests.yml
+++ b/spec/definitions/support/integration_tests.yml
@@ -1,0 +1,118 @@
+inspect:
+  supported:
+    "openSUSE_13_2:x86_64":
+      "openSUSE_13_2:x86_64": minimal_test
+    "openSUSE_13_1:x86_64":
+      "openSUSE_13_1:x86_64": full_test
+  working:
+    "openSUSE_13_2:x86_64":
+      "openSUSE_13_1:x86_64":
+      "Tumbleweed:x86_64":
+    "openSUSE_13_1:x86_64":
+      "openSUSE_13_2:x86_64":
+      "Tumbleweed:x86_64":
+    "Tumbleweed:x86_64":
+      "openSUSE_13_2:x86_64":
+      "openSUSE_13_1:x86_64":
+      "Tumbleweed:x86_64":
+build:
+  supported:
+    "openSUSE_13_2:x86_64":
+      "openSUSE_13_2:x86_64": full_test
+  working:
+    "openSUSE_13_2:x86_64":
+      "openSUSE_13_1:x86_64":
+    "openSUSE_13_1:x86_64":
+      "openSUSE_13_1:x86_64":
+    "Tumbleweed:x86_64":
+      "openSUSE_13_2:x86_64":
+      "openSUSE_13_1:x86_64":
+      "Tumbleweed:x86_64":
+  unsupported:
+    "openSUSE_13_2:x86_64":
+      "Tumbleweed:x86_64":
+      "Tumbleweed:arm":
+      "fedora":
+    "openSUSE_13_1:x86_64":
+      "openSUSE_13_2:x86_64":
+      "Tumbleweed:x86_64":
+      "Tumbleweed:arm":
+      "fedora":
+    "Tumbleweed:x86_64":
+      "fedora":
+export:
+  supported:
+    "openSUSE_13_2:x86_64":
+      "openSUSE_13_2:x86_64": acceptance_test
+    "openSUSE_13_1:x86_64":
+      "openSUSE_13_1:x86_64": full_test
+  working:
+    "openSUSE_13_2:x86_64":
+      "openSUSE_13_1:x86_64":
+      "Tumbleweed:x86_64":
+    "openSUSE_13_1:x86_64":
+      "openSUSE_13_2:x86_64":
+      "Tumbleweed:x86_64":
+    "Tumbleweed:x86_64":
+      "openSUSE_13_2:x86_64":
+      "openSUSE_13_1:x86_64":
+      "Tumbleweed:x86_64":
+  unsupported:
+    "openSUSE_13_2:x86_64":
+      "Tumbleweed:arm":
+      "fedora":
+    "openSUSE_13_1:x86_64":
+      "Tumbleweed:arm":
+      "fedora":
+    "Tumbleweed:x86_64":
+      "Tumbleweed:arm":
+      "fedora":
+analyze:
+  supported:
+    "openSUSE_13_2:x86_64":
+      "openSUSE_13_2:x86_64": acceptance_test
+    "openSUSE_13_1:x86_64":
+      "openSUSE_13_1:x86_64": full_test
+  working:
+    "openSUSE_13_2:x86_64":
+      "openSUSE_13_1:x86_64":
+      "Tumbleweed:x86_64":
+    "openSUSE_13_1:x86_64":
+      "openSUSE_13_2:x86_64":
+      "Tumbleweed:x86_64":
+    "Tumbleweed:x86_64":
+      "openSUSE_13_2:x86_64":
+      "openSUSE_13_1:x86_64":
+      "Tumbleweed:x86_64":
+deploy:
+  supported:
+    "openSUSE_13_2:x86_64":
+      "openSUSE_13_2:x86_64":
+  working:
+    "openSUSE_13_1:x86_64":
+      "openSUSE_13_1:x86_64":
+    "Tumbleweed:x86_64":
+      "Tumbleweed:x86_64":
+  unsupported:
+    "openSUSE_13_2:x86_64":
+      "openSUSE_13_2:arm":
+      "openSUSE_13_1:x86_64":
+      "openSUSE_13_1:arm":
+      "Tumbleweed:x86_64":
+      "Tumbleweed:arm":
+      "fedora":
+    "openSUSE_13_1:x86_64":
+      "openSUSE_13_2:x86_64":
+      "openSUSE_13_2:arm":
+      "openSUSE_13_1:arm":
+      "Tumbleweed:x86_64":
+      "Tumbleweed:arm":
+      "fedora":
+    "Tumbleweed:x86_64":
+      "openSUSE_13_2:x86_64":
+      "openSUSE_13_2:arm":
+      "openSUSE_13_1:x86_64":
+      "openSUSE_13_1:arm":
+      "Tumbleweed:arm":
+      "fedora":
+

--- a/spec/definitions/support/runs_on.yml
+++ b/spec/definitions/support/runs_on.yml
@@ -1,0 +1,13 @@
+---
+supported:
+  "openSUSE_13_2:x86_64":
+    "Package installation": full_test
+    "General commands": minimal_test
+working:
+  "openSUSE_13_1:x86_64":
+    "Package installation": full_test
+    "General commands":
+  "Tumbleweed:x86_64":
+    "Package installation": full_test
+    "General commands":
+

--- a/spec/definitions/support/unit_tests.yml
+++ b/spec/definitions/support/unit_tests.yml
@@ -1,0 +1,6 @@
+---
+# Test once per Ruby version
+tested:
+  "openSUSE_13_1:x86_64": "ruby2.0"
+  "openSUSE_13_2:x86_64": "ruby2.1"
+


### PR DESCRIPTION
Use the spec/definitions folder since it exists in alfred and machinery