### PR TITLE
Add rspec_junit_formatter to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,5 +27,6 @@ group :test do
   gem "given_filesystem", ">= 0.1.1"
   gem "ruby-libvirt"
   gem "codeclimate-test-reporter"
+  gem "rspec_junit_formatter"
   gem "rodf", github: "mauromorales/rodf"
 end


### PR DESCRIPTION
currently we run this code and get this error in the unit tests

    rspec.ruby2.1 spec/unit -f RspecJunitFormatter ...

which returns an error for the gem that is installed with github

     require': cannot load such file -- odf/spreadsheet (LoadError)

running with bundle exec fixes the problem but the gem `rspec_junit_formatter` needs to be included in the Gemfile
