### PR TITLE
Remove curl from base images as it is only required in machinery images.

### DIFF
--- a/spec/definitions/boxes/definitions/base_opensuse13.1_kvm/config.xml
+++ b/spec/definitions/boxes/definitions/base_opensuse13.1_kvm/config.xml
@@ -48,7 +48,6 @@
         <package name="cronie"/>
         <package name="nfs-kernel-server"/>
         <package name="autofs"/>
-        <package name="curl"/>
     </packages>
     <packages type="bootstrap">
         <package name="udev"/>

--- a/spec/definitions/boxes/definitions/base_opensuse13.2_kvm/config.xml
+++ b/spec/definitions/boxes/definitions/base_opensuse13.2_kvm/config.xml
@@ -48,7 +48,6 @@
         <package name="cronie"/>
         <package name="nfs-kernel-server"/>
         <package name="autofs"/>
-        <package name="curl"/>
     </packages>
     <packages type="bootstrap">
         <package name="udev"/>

--- a/spec/definitions/boxes/definitions/base_opensuse_tumbleweed_kvm/config.xml
+++ b/spec/definitions/boxes/definitions/base_opensuse_tumbleweed_kvm/config.xml
@@ -48,7 +48,6 @@
         <package name="cronie"/>
         <package name="nfs-kernel-server"/>
         <package name="autofs"/>
-        <package name="curl"/>
     </packages>
     <packages type="bootstrap">
         <package name="udev"/>


### PR DESCRIPTION
- The addition to the base images is not required by the serve html
  testcase and thus they are removed again to avoid sideffects with other
  testcases.
