### PR TITLE
[Review] Request from 'tgoettlicher' @ 'SUSE/machinery/review_150709_fix_connection_errors_on_debian_inspections_gh_suse_machinery_1050_'

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 # Machinery Release Notes
 
+* Fix connection errors on debian inspections (gh#SUSE/machinery#1050)
 * Data which hasn't changed is not shown in the comparison HTML view by default
 * Improve display of package differences in compare command
 * Add `man` command to show the Machinery man page

--- a/lib/remote_system.rb
+++ b/lib/remote_system.rb
@@ -83,10 +83,10 @@ class RemoteSystem < System
     end
   end
 
-  # Tries to connect to the remote system as root (without a password or passphrase)
+  # Tries to run the noop-command(:) on the remote system as root (without a password or passphrase)
   # and raises an Machinery::Errors::SshConnectionFailed exception when it's not successful.
   def connect
-    LoggedCheetah.run "ssh", "-q", "-o", "BatchMode=yes", "#{remote_user}@#{host}"
+    LoggedCheetah.run "ssh", "-q", "-o", "BatchMode=yes", "#{remote_user}@#{host}", ":"
   rescue Cheetah::ExecutionFailed
     raise Machinery::Errors::SshConnectionFailed.new(
       "Could not establish SSH connection to host '#{host}'. Please make sure that " \


### PR DESCRIPTION
Please review the following changes:
  * 0cb9a32 Fix connection errors on debian inspections (gh#SUSE/machinery#1050)
  * de3d40b package 1.10.0
  * 4b1070f Merge pull request #1110 from SUSE/improve_error_message_when_command_options_are_missing_2
  * 27f339a Improve error message when export-autoyast/kiwi command options are missing
  * a78f4f1 Merge pull request #1104 from SUSE/review_150708_reverse_addition_of_curl_to_base_images
  * 1d7f1fe Merge pull request #1108 from SUSE/run_local_integration_tests_from_matrix
  * 3a955ab Run local integration tests based on the matrix
  * 9656b5c Merge pull request #1107 from SUSE/run_integration_tests_through_test_matrix_5
  * 6f8fb9e Adjust serve html testcase to fetch manifest from correct folder.
  * 3de4245 Merge pull request #1106 from SUSE/check_build_iso
  * 1bcffa6 Check for iso image
  * b78c26c Remove curl from base images as it is only required in machinery images.
  * 2e6c31d Provide export integration test descriptions for multiple systems.
  * a7161ae Adjust existing tests to new way of execution.
  * 68441f3 Run integration tests controlled by a jeos file.