### PR TITLE
Fix connection errors caused by reading from stdin (gh#SUSE/machinery…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 # Machinery Release Notes
 
+* Fix connection errors caused by reading from stdin (gh#SUSE/machinery#1050)
 
 ## Version 1.10.0 - Thu Jul 09 16:26:35 CEST 2015 - thardeck@suse.de
 

--- a/lib/remote_system.rb
+++ b/lib/remote_system.rb
@@ -83,10 +83,10 @@ class RemoteSystem < System
     end
   end
 
-  # Tries to connect to the remote system as root (without a password or passphrase)
+  # Tries to run the noop-command(:) on the remote system as root (without a password or passphrase)
   # and raises an Machinery::Errors::SshConnectionFailed exception when it's not successful.
   def connect
-    LoggedCheetah.run "ssh", "-q", "-o", "BatchMode=yes", "#{remote_user}@#{host}"
+    LoggedCheetah.run "ssh", "-q", "-o", "BatchMode=yes", "#{remote_user}@#{host}", ":"
   rescue Cheetah::ExecutionFailed
     raise Machinery::Errors::SshConnectionFailed.new(
       "Could not establish SSH connection to host '#{host}'. Please make sure that " \

--- a/spec/unit/remote_system_spec.rb
+++ b/spec/unit/remote_system_spec.rb
@@ -23,7 +23,7 @@ describe RemoteSystem do
   describe "#initialize" do
     it "raises ConnectionFailed when it can't connect" do
       expect(Cheetah).to receive(:run).with(
-         "ssh", "-q", "-o", "BatchMode=yes", "root@example.com"
+        "ssh", "-q", "-o", "BatchMode=yes", "root@example.com", ":"
       ).and_raise(Cheetah::ExecutionFailed.new(nil, nil, nil, nil))
 
       expect {


### PR DESCRIPTION
…#1050)

On certain systems (e.g. debian) the connection check failed with 'stdin is not a tty'.
To fix this we don't read from stdin but run the noop command(:).