### PR TITLE
Rearrange the exclude option in the inspect and build test.

### DIFF
--- a/spec/integration/support/inspect_and_build_examples.rb
+++ b/spec/integration/support/inspect_and_build_examples.rb
@@ -34,7 +34,7 @@ shared_examples "inspect and build" do |bases|
         measure("Inspect") do
           expect(
             @machinery.run_command(
-              "machinery --exclude=/packages/name=test-quote-char inspect #{@subject_system.ip} " \
+              "machinery inspect --exclude=/packages/name=test-quote-char #{@subject_system.ip} " \
               " -x --name=build_test --remote-user=machinery",
               as: "vagrant"
             )


### PR DESCRIPTION
- We made the exclude option a inspect specific option and not global
  option. Thus the inspect test needs to be adjusted.
