### PR TITLE
Allow copy and paste for config options

### DIFF
--- a/lib/config_task.rb
+++ b/lib/config_task.rb
@@ -24,15 +24,15 @@ class ConfigTask
     if !key
       # show all config entries
       @config.each do |key, value|
-        Machinery::Ui.puts "#{key} = #{value[:value]} (#{value[:description]})"
+        Machinery::Ui.puts "#{key}=#{value[:value]} (#{value[:description]})"
       end
     elsif !value_string
       # show one specific config entry
-      Machinery::Ui.puts "#{key} = #{@config.get(key)}"
+      Machinery::Ui.puts "#{key}=#{@config.get(key)}"
     else
       # set one specific config entry
       @config.set(key, parse_value_string(key, value_string))
-      Machinery::Ui.puts "#{key} = #{@config.get(key)}"
+      Machinery::Ui.puts "#{key}=#{@config.get(key)}"
     end
   end
 

--- a/spec/unit/config_task_spec.rb
+++ b/spec/unit/config_task_spec.rb
@@ -20,6 +20,7 @@ require_relative "spec_helper"
 describe ConfigTask do
   include FakeFS::SpecHelpers
   let(:config_task) { ConfigTask.new }
+  let(:key) { "hints" }
 
   describe "#config" do
     before(:each) do
@@ -27,7 +28,6 @@ describe ConfigTask do
     end
 
     it "sets a bool config variable to false" do
-      key = "my_config"
       allow_any_instance_of(Machinery::Config).to receive(:get).with(key).and_return(true)
       expect_any_instance_of(Machinery::Config).to receive(:set).with(key, false)
       expect_any_instance_of(Machinery::Config).to receive(:get).with(key)
@@ -35,7 +35,6 @@ describe ConfigTask do
     end
 
     it "sets a bool config variable to true" do
-      key = "my_config"
       allow_any_instance_of(Machinery::Config).to receive(:get).with(key).and_return(true)
       expect_any_instance_of(Machinery::Config).to receive(:set).with(key, true)
       expect_any_instance_of(Machinery::Config).to receive(:get).with(key)
@@ -43,7 +42,6 @@ describe ConfigTask do
     end
 
     it "sets a string config variable" do
-      key = "my_config"
       allow_any_instance_of(Machinery::Config).to receive(:get).with(key).and_return("foo")
       expect_any_instance_of(Machinery::Config).to receive(:set).with(key, "foo")
       expect_any_instance_of(Machinery::Config).to receive(:get).with(key)
@@ -51,7 +49,6 @@ describe ConfigTask do
     end
 
     it "sets an integer config variable" do
-      key = "my_config"
       allow_any_instance_of(Machinery::Config).to receive(:get).with(key).and_return(42)
       expect_any_instance_of(Machinery::Config).to receive(:set).with(key, 21)
       expect_any_instance_of(Machinery::Config).to receive(:get).with(key)
@@ -59,7 +56,6 @@ describe ConfigTask do
     end
 
     it "retrieves the value of a config variable" do
-      key = "my_config"
       expect_any_instance_of(Machinery::Config).to receive(:get).with(key)
       config_task.config(key)
     end

--- a/spec/unit/config_task_spec.rb
+++ b/spec/unit/config_task_spec.rb
@@ -18,15 +18,13 @@
 require_relative "spec_helper"
 
 describe ConfigTask do
+  capture_machinery_output
+
   include FakeFS::SpecHelpers
   let(:config_task) { ConfigTask.new }
   let(:key) { "hints" }
 
   describe "#config" do
-    before(:each) do
-      allow(Machinery::Ui).to receive(:puts)
-    end
-
     it "sets a bool config variable to false" do
       allow_any_instance_of(Machinery::Config).to receive(:get).with(key).and_return(true)
       expect_any_instance_of(Machinery::Config).to receive(:set).with(key, false)
@@ -55,14 +53,15 @@ describe ConfigTask do
       config_task.config(key, "21")
     end
 
-    it "retrieves the value of a config variable" do
-      expect_any_instance_of(Machinery::Config).to receive(:get).with(key)
+    it "shows the value of a config variable if a key is provided" do
       config_task.config(key)
+      expect(captured_machinery_output).to include("#{key}=")
     end
 
-    it "retrieves the values of all config variables" do
-      expect_any_instance_of(Machinery::Config).to receive(:each)
+    it "shows the values of all config variables if no key provided" do
       config_task.config()
+      expect(captured_machinery_output).to include("#{key}=")
+      expect(captured_machinery_output).to include("remote-user=")
     end
   end
 


### PR DESCRIPTION
If you run `machinery config` and just copy the option the command
fails because there are spaces between the key and the value.