### PR TITLE
Add parent directories of managed dirs to managed dir list

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 # Machinery Release Notes
 
+* Fix for unmanaged-file inspector to not mark directories as unmanaged if they
+  only consist managed sub directories
 
 ## Version 1.11.2 - Thu Jul 30 14:42:44 CEST 2015 - thardeck@suse.de
 

--- a/plugins/unmanaged_files/unmanaged_files_inspector.rb
+++ b/plugins/unmanaged_files/unmanaged_files_inspector.rb
@@ -55,8 +55,8 @@ class UnmanagedFilesInspector < Inspector
     end
     # make sure that all parent directories of managed rpm directories are considered
     # managed
-    dirh.dup.each do |d, _e|
-      dir, _sep, _file = d.rpartition("/")
+    dirh.dup.keys.each do |d|
+      dir = d.rpartition("/").first
 
       while !dirh.has_key?(dir) && dir.size > 1
         dirh[dir] = false

--- a/plugins/unmanaged_files/unmanaged_files_inspector.rb
+++ b/plugins/unmanaged_files/unmanaged_files_inspector.rb
@@ -53,6 +53,17 @@ class UnmanagedFilesInspector < Inspector
         files[pair.first] = pair[1]
       end
     end
+    # make sure that all parent directories of managed rpm directories are considered
+    # managed
+    dirh.dup.each do |d, _e|
+      dir, _sep, _file = d.rpartition("/")
+
+      while !dirh.has_key?(dir) && dir.size > 1
+        dirh[dir] = false
+        dir = dir[0..dir.rindex("/") - 1]
+      end
+    end
+
     files.each do |f,e|
       dir, sep, file = f.rpartition("/")
 


### PR DESCRIPTION
The original unmanaged-file inspector was changed to not mark
directories as unmanaged if they only consist managed sub directories.