### PR TITLE
Add /var/lock/ to filter file

### DIFF
--- a/helpers/default_filters.json
+++ b/helpers/default_filters.json
@@ -7,6 +7,7 @@
     "/unmanaged_files/files/name=/var/tmp",
     "/unmanaged_files/files/name=/lost+found",
     "/unmanaged_files/files/name=/var/run",
+    "/unmanaged_files/files/name=/var/lock",
     "/unmanaged_files/files/name=/var/lib/rpm",
     "/unmanaged_files/files/name=/.snapshots",
     "/unmanaged_files/files/name=/proc",


### PR DESCRIPTION
The machinery_helper was filtering /var/lock but not machinery itself.
Since it does not make sense to inspect /var/lock we added it to the
filter list.