### PR TITLE
Machinery config --help mentions alternative `KEY=VALUE` syntax

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -729,6 +729,10 @@ class Cli
 
     The value of a key is shown when no value argument is passed.
     If neither the key argument nor the value argument are specified a list of all keys and their values are shown.
+
+    ALTERNATIVE SYNOPSIS:
+
+    machinery [global options] config [KEY][=VALUE]
   LONGDESC
   arg "KEY", :optional
   arg "VALUE", :optional

--- a/spec/integration/support/command_line_examples.rb
+++ b/spec/integration/support/command_line_examples.rb
@@ -84,6 +84,18 @@ shared_examples "CLI" do
       end
     end
 
+    describe "config" do
+      context "--help" do
+        it "shows the alternative synopsis" do
+          expect(
+            @machinery.run_command("#{machinery_command} config --help", as: "vagrant")
+          ).to succeed.and include_stdout(
+            "machinery [global options] config [KEY][=VALUE]"
+          )
+        end
+      end
+    end
+
     describe "validate number of given arguments" do
       context "when no arguments are expected" do
         it "fails with a message" do


### PR DESCRIPTION
Squashes #1196
