### PR TITLE
Handle error if machinery-helper cannot be copied/executed

### DIFF
--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -21,4 +21,5 @@ module Machinery
   DEFAULT_LOG_FILE = File.join(DEFAULT_CONFIG_DIR, "machinery.log")
   DEFAULT_CONFIG_FILE = File.join(DEFAULT_CONFIG_DIR, "machinery.config")
   IMAGE_META_DATA_FILE = "machinery.meta"
+  REMOTE_HELPERS_PATH = "/root"
 end

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -135,5 +135,7 @@ module Machinery
     class UnknownConfig < MachineryError; end
     class UnsupportedArchitecture < MachineryError; end
     class ServeFailed < MachineryError; end
+    class RemoveFileFailed < MachineryError; end
+    class InjectFileFailed < MachineryError; end
   end
 end

--- a/lib/local_system.rb
+++ b/lib/local_system.rb
@@ -161,7 +161,7 @@ EOF
 
   # Removes a file from the System
   def remove_file(file)
-    File.delete(file)
+    File.delete(file) if File.exist?(file)
   rescue => e
     raise Machinery::Errors::RemoveFileFailed.new(
       "Could not remove file '#{file}' on local system'.\n" \

--- a/lib/local_system.rb
+++ b/lib/local_system.rb
@@ -152,7 +152,7 @@ EOF
   # Copies a file to the local system
   def inject_file(source, destination)
     FileUtils.copy(source, destination)
-  rescue
+  rescue => e
     raise Machinery::Errors::InjectFileFailed.new(
       "Could not inject file '#{source}' to local system.\n" \
       "Error: #{e}"

--- a/lib/machinery_helper.rb
+++ b/lib/machinery_helper.rb
@@ -48,15 +48,19 @@ class MachineryHelper
   end
 
   def inject_helper
-    @system.inject_file(local_helper_path, "/root/")
+    @system.inject_file(local_helper_path, Machinery::REMOTE_HELPERS_PATH)
   end
 
   def run_helper(scope)
-    json = @system.run_command("/root/machinery-helper", stdout: :capture, stderr: STDERR)
+    json = @system.run_command(
+      File.join(
+        Machinery::REMOTE_HELPERS_PATH, "machinery-helper"
+      ), stdout: :capture, stderr: STDERR
+    )
     scope.set_attributes(JSON.parse(json))
   end
 
   def remove_helper
-    @system.remove_file("/root/machinery-helper")
+    @system.remove_file(File.join(Machinery::REMOTE_HELPERS_PATH, "machinery-helper"))
   end
 end


### PR DESCRIPTION
Fixes #1191
Supersedes #1204