### PR TITLE
Handle missing yum python api gracefully

### DIFF
--- a/plugins/repositories/repositories_inspector.rb
+++ b/plugins/repositories/repositories_inspector.rb
@@ -82,7 +82,7 @@ class RepositoriesInspector < Inspector
           )
         end
       end
-    rescue JSON::ParserError
+    rescue JSON::ParserError, Cheetah::ExecutionFailed
       raise Machinery::Errors::InspectionFailed.new("Extraction of YUM repositories failed.")
     end
 

--- a/plugins/repositories/repositories_inspector.rb
+++ b/plugins/repositories/repositories_inspector.rb
@@ -82,8 +82,12 @@ class RepositoriesInspector < Inspector
           )
         end
       end
-    rescue JSON::ParserError, Cheetah::ExecutionFailed
+    rescue JSON::ParserError
       raise Machinery::Errors::InspectionFailed.new("Extraction of YUM repositories failed.")
+    rescue Cheetah::ExecutionFailed => e
+      raise Machinery::Errors::InspectionFailed.new(
+        "Extraction of YUM repositories failed:\n#{e.stderr}"
+      )
     end
 
     RepositoriesScope.new(repositories)

--- a/spec/unit/repositories_inspector_spec.rb
+++ b/spec/unit/repositories_inspector_spec.rb
@@ -318,11 +318,11 @@ EOF
 
     it "handles failing of the python yum api gracefully" do
       expect(system).to receive(:run_command).and_raise(
-        Cheetah::ExecutionFailed.new(nil, nil, nil, nil)
+        Cheetah::ExecutionFailed.new(nil, nil, nil, "Some error")
       )
 
       expect { inspector.inspect(filter) }.to raise_error(
-        Machinery::Errors::InspectionFailed, /Extraction of YUM repositories failed./
+        Machinery::Errors::InspectionFailed, /Extraction of YUM repositories failed:\nSome error/
       )
     end
 

--- a/spec/unit/repositories_inspector_spec.rb
+++ b/spec/unit/repositories_inspector_spec.rb
@@ -316,6 +316,16 @@ EOF
       )
     end
 
+    it "handles failing of the python yum api gracefully" do
+      expect(system).to receive(:run_command).and_raise(
+        Cheetah::ExecutionFailed.new(nil, nil, nil, nil)
+      )
+
+      expect { inspector.inspect(filter) }.to raise_error(
+        Machinery::Errors::InspectionFailed, /Extraction of YUM repositories failed./
+      )
+    end
+
     # We don't support Yum Metalink repositories atm
     it "throws an Machinery AnalysisFailed error when the url is empty" do
       expect(system).to receive(:run_command).and_return(unsupported_metalink_repo)


### PR DESCRIPTION
Don't show backtrace if the python api is missing.