### PR TITLE
Add check if services which are intended to be linked are detected

### DIFF
--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -138,5 +138,6 @@ module Machinery
     class RemoveFileFailed < MachineryError; end
     class InjectFileFailed < MachineryError; end
     class UnexpectedInputData < MachineryError; end
+    class ComposeServiceLink < MachineryError; end
   end
 end

--- a/lib/workload_mapper.rb
+++ b/lib/workload_mapper.rb
@@ -32,8 +32,14 @@ class WorkloadMapper
     services.each do |service, config|
       config.fetch("links", {}).each do |linked_service|
         services[service]["environment"] ||= {}
-        vars = services[linked_service].fetch("environment", {})
-        services[service]["environment"].merge!(vars)
+        if services[linked_service]
+          vars = services[linked_service].fetch("environment", {})
+          services[service]["environment"].merge!(vars)
+        else
+          raise Machinery::Errors::ComposeServiceLink.new(
+            "Could not detect '#{linked_service}', which is referenced by '#{service}'."\
+          )
+        end
       end
     end
   end

--- a/spec/unit/workload_mapper_spec.rb
+++ b/spec/unit/workload_mapper_spec.rb
@@ -212,6 +212,15 @@ describe WorkloadMapper do
         }
       }
     }
+
+    let(:unlinked_services_one_missing) {
+      {
+        "web" => {
+          "links" => ["db"]
+        }
+      }
+    }
+
     let(:linked_services) {
       {
         "db" => {
@@ -229,9 +238,23 @@ describe WorkloadMapper do
         }
       }
     }
-    it "adds the environment variables to the linked workload" do
-      subject.link_compose_services(unlinked_services)
-      expect(unlinked_services).to eq(linked_services)
+
+    context "if the services which are intended to link are detected" do
+      it "adds the environment variables to the linked workload" do
+        subject.link_compose_services(unlinked_services)
+        expect(unlinked_services).to eq(linked_services)
+      end
+    end
+
+    context "if the services which are intended to link are not detected" do
+      it "throws an error which identifies the failed linking" do
+        expect {
+          subject.link_compose_services(unlinked_services_one_missing)
+        }.to raise_error(
+          Machinery::Errors::ComposeServiceLink,
+          /Could not detect 'db', which is referenced by 'web'./
+          )
+      end
     end
   end
 end


### PR DESCRIPTION
Supersedes #1265 

- #link_compose_services checks if the services, which are intended to
  be linked are detected and throws a proper error-message when linking
  failed.