### PR TITLE
Re-use existing SSH connection

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 # Machinery Release Notes
 
+* Speed up inspection by reusing the ssh connection between remote commands
 * Export of autoyast files is now possible with system descriptions,
   which have empty repository scopes (gh#SUSE/machinery#1268)
 * Inspection of unmanaged-files is now also using the faster machinery-helper

--- a/lib/remote_system.rb
+++ b/lib/remote_system.rb
@@ -19,6 +19,9 @@ class RemoteSystem < System
   attr_accessor :host
   attr_accessor :remote_user
 
+  SSH_BASIC_OPTIONS = ["-o", "ControlMaster=auto", "-o",
+    "ControlPath=~/.ssh/socket%r@%h-%p", "-o", "ControlPersist=600"]
+
   def initialize(host, remote_user = "root")
     @host = host
     @remote_user = remote_user
@@ -74,7 +77,8 @@ class RemoteSystem < System
 
     sudo = ["sudo", "-n"] if options[:privileged] && remote_user != "root"
     cmds = [
-      "ssh", "#{remote_user}@#{host}", sudo, "LC_ALL=en_US.utf8", *piped_args, options
+      "ssh", *SSH_BASIC_OPTIONS, "#{remote_user}@#{host}", sudo, "LC_ALL=en_US.utf8", *piped_args,
+      options
     ].compact.flatten
     cheetah_class.run(*cmds)
   rescue Cheetah::ExecutionFailed => e
@@ -85,19 +89,22 @@ class RemoteSystem < System
     end
   end
 
-  # Tries to run the noop-command(:) on the remote system as root (without a password or passphrase)
-  # and raises an Machinery::Errors::SshConnectionFailed exception when it's not successful.
+  # Tries to run the noop-command(:) on the remote system and raises an
+  # Machinery::Errors::SshConnectionFailed exception when it's not successful.
+  #
+  # We don't use Cheetah here because it would hang due to a bug in openssh.
+  # See: https://bugzilla.mindrot.org/show_bug.cgi?id=1988
   def connect
-    LoggedCheetah.run "ssh", "-q", "-o", "BatchMode=yes", "#{remote_user}@#{host}", ":"
-  rescue Cheetah::ExecutionFailed
-    raise Machinery::Errors::SshConnectionFailed.new(
-      "Could not establish SSH connection to host '#{host}'. Please make sure that " \
-      "you can connect non-interactively as #{remote_user}, e.g. using ssh-agent.\n\n" \
-      "To copy your default ssh key to the machine run:\n" \
-      "ssh-copy-id #{remote_user}@#{host}"
-    )
+    if !system("ssh", *SSH_BASIC_OPTIONS, "-q", "-o", "BatchMode=yes",
+      "#{Shellwords.escape(remote_user)}@#{Shellwords.escape(host)}", ":")
+      raise Machinery::Errors::SshConnectionFailed.new(
+        "Could not establish SSH connection to host '#{host}'. Please make sure that " \
+        "you can connect non-interactively as #{remote_user}, e.g. using ssh-agent.\n\n" \
+        "To copy your default ssh key to the machine run:\n" \
+        "ssh-copy-id #{remote_user}@#{host}"
+      )
+    end
   end
-
 
   # Retrieves files specified in filelist from the remote system and raises an
   # Machinery::Errors::RsyncFailed exception when it's not successful. Destination is

--- a/spec/unit/remote_system_spec.rb
+++ b/spec/unit/remote_system_spec.rb
@@ -19,12 +19,16 @@ require_relative "spec_helper"
 
 describe RemoteSystem do
   let(:remote_system) { RemoteSystem.new("remotehost") }
+  let(:ssh_basic_options) {
+    ["-o", "ControlMaster=auto", "-o",
+      "ControlPath=~/.ssh/socket%r@%h-%p", "-o", "ControlPersist=600"]
+  }
 
   describe "#initialize" do
     it "raises ConnectionFailed when it can't connect" do
-      expect(Cheetah).to receive(:run).with(
-        "ssh", "-q", "-o", "BatchMode=yes", "root@example.com", ":"
-      ).and_raise(Cheetah::ExecutionFailed.new(nil, nil, nil, nil))
+      expect_any_instance_of(RemoteSystem).to receive(:system).with(
+        "ssh", any_args
+      ).and_return(false)
 
       expect {
         RemoteSystem.new("example.com")
@@ -46,7 +50,7 @@ describe RemoteSystem do
     describe "#run_command" do
       it "executes commands via ssh" do
         expect(Cheetah).to receive(:run).with(
-          "ssh", "root@remotehost", "LC_ALL=en_US.utf8", "ls", "/tmp", {}
+          "ssh", *ssh_basic_options, "root@remotehost", "LC_ALL=en_US.utf8", "ls", "/tmp", {}
         )
 
         remote_system.run_command("ls", "/tmp")
@@ -54,8 +58,8 @@ describe RemoteSystem do
 
       it "executes piped commands via ssh" do
         expect(Cheetah).to receive(:run).with(
-          "ssh", "root@remotehost", "LC_ALL=en_US.utf8", "ls", "/tmp", "|", "grep", "foo",
-            "|", "wc", "-l", {}
+          "ssh", *ssh_basic_options, "root@remotehost", "LC_ALL=en_US.utf8", "ls", "/tmp", "|",
+            "grep", "foo", "|", "wc", "-l", {}
         )
 
         remote_system.run_command(["ls", "/tmp"], ["grep", "foo"], ["wc", "-l"])
@@ -76,7 +80,7 @@ describe RemoteSystem do
 
       it "adheres to the remote_user option" do
         expect(Cheetah).to receive(:run).with(
-          "ssh", "machinery@remotehost", "LC_ALL=en_US.utf8", "ls", "/tmp", {}
+          "ssh", *ssh_basic_options, "machinery@remotehost", "LC_ALL=en_US.utf8", "ls", "/tmp", {}
         )
 
         remote_system.remote_user = "machinery"
@@ -85,7 +89,7 @@ describe RemoteSystem do
 
       it "uses sudo when necessary" do
         expect(Cheetah).to receive(:run).with(
-          "ssh", "machinery@remotehost", "sudo", "-n", "LC_ALL=en_US.utf8",
+          "ssh", *ssh_basic_options, "machinery@remotehost", "sudo", "-n", "LC_ALL=en_US.utf8",
             "ls", "/tmp", privileged: true
         )
 
@@ -95,7 +99,8 @@ describe RemoteSystem do
 
       it "raises an exception if the user is not allowed to run sudo" do
         expect(Cheetah).to receive(:run).with(
-          "ssh", "machinery@remotehost", "sudo", "-n", "LC_ALL=en_US.utf8", "ls", "/tmp",
+          "ssh", *ssh_basic_options, "machinery@remotehost", "sudo", "-n", "LC_ALL=en_US.utf8",
+            "ls", "/tmp",
             privileged: true
         ).and_raise(Cheetah::ExecutionFailed.new(nil, 1, "", "sudo: a password is required"))
 


### PR DESCRIPTION
Supersedes #1296 

Opening multiple ssh connection could accidentally be considered as:
- ssh brute-force or
- some other kind of malicious network activity

This does also improve the speed of calling remote commands.