### PR TITLE
Disabling bundling for openSUSE Tumbleweed

### DIFF
--- a/RPM_CHANGES
+++ b/RPM_CHANGES
@@ -1,5 +1,6 @@
 # Machinery RPM Changelog
 
+* disable gem bundling for openSUSE Tumbleweed
 
 ## Version 1.12.0 - Fri Sep 04 16:51:10 CEST 2015 - cschum@suse.de
 

--- a/machinery.spec.erb
+++ b/machinery.spec.erb
@@ -25,6 +25,15 @@ Release:        0
 %define mod_branch -%{version}
 %define mod_weight 1
 
+%if %suse_version > 1320
+# openSUSE Factory
+%define bundlegems 0
+%else
+# SLES12, openSUSE 13.1/13.2/Leap
+# LEAP has the suse_Version 1315
+%define bundlegems 1
+%endif
+
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  machinery-helper-x86_64
 BuildRequires:  ruby-macros >= 5
@@ -37,9 +46,15 @@ BuildRequires:  fdupes
 BuildRequires:  %{rubydevel}
 BuildRequires:  %{rubygem gem2rpm}
 BuildRequires:  %{rubygem bundler}
+%if 0%{?bundlegems}
 <% build_requires.each do |require| -%>
 BuildRequires:  %{rubygem <%= require[:name] %> <%= require[:operator] %> <%= require[:version] %>}
 <% end -%>
+%else
+<% build_requires.each do |require| -%>
+Requires:  %{rubygem <%= require[:name] %> <%= require[:operator] %> <%= require[:version] %>}
+<% end -%>
+%endif
 %else
 BuildRequires:  ruby-devel
 BuildRequires:  rubygem(gem2rpm)
@@ -87,6 +102,7 @@ done
 
 %gem_install -f
 
+%if %{?bundlegems}
 # Bundle dependencies
 
 pushd %{buildroot}%{_libdir}/ruby/gems/%{rb_ver}/gems/%{mod_full_name}
@@ -127,6 +143,7 @@ rm -rf bundle/ruby/%{rb_ver}/extensions/*/%{rb_ver}/nokogiri-*/gem_make.out
 sed -i '\|%{buildroot}|d' bundle/bundler/setup.rb
 
 popd
+%endif
 
 # Adapt the binary
 
@@ -135,6 +152,7 @@ if [ ! -f "%{buildroot}%{_bindir}/%{binary_name}" ]; then
   mv "%{buildroot}%{_bindir}/%{binary_name}"* "%{buildroot}%{_bindir}/%{binary_name}"
 fi
 
+%if %{?bundlegems}
 # Here we do a surgery on the binary to actually load the bundled gems. This is
 # a hack, but it can't be done anywhere else because the binary is generated
 # during gem install.
@@ -142,6 +160,7 @@ sed -i '/gem /i \
 Gem.path.unshift("%{_libdir}/ruby/gems/%{rb_ver}/gems/%{mod_full_name}/bundle/ruby/%{rb_ver}")
 
 ' %{buildroot}%{_bindir}/%{binary_name}
+%endif
 
 # Man page & additional files
 

--- a/spec/definitions/boxes/definitions/machinery_opensuse_tumbleweed_kvm/config.sh
+++ b/spec/definitions/boxes/definitions/machinery_opensuse_tumbleweed_kvm/config.sh
@@ -60,7 +60,8 @@ UseDNS no
 # Repositories
 #--------------------------------------
 zypper -n --gpg-auto-import-keys ar --refresh --name "Main Repository (OSS)" http://download.opensuse.org/tumbleweed/repo/oss/ download.opensuse.org-oss
-zypper -n refresh
+zypper -n --gpg-auto-import-keys ar --refresh --name "Machinery" "http://download.opensuse.org/repositories/systemsmanagement:machinery/openSUSE_Tumbleweed/" machinery
+zypper -n --gpg-auto-import-keys refresh
 
 #======================================
 # Umount kernel filesystems


### PR DESCRIPTION
We wanted to submit machinery to openSUSE Factory where bundling of gems
isn't allowed.