### PR TITLE
Handle socket errors in `-i` option

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 # Machinery Release Notes
 
+* Handle socket errors for `-i` option
 * Add `containerize` command to the experimental features
 * Export of autoyast files is now possible with system descriptions,
   which have empty repository scopes (gh#SUSE/machinery#1268)

--- a/lib/compare_task.rb
+++ b/lib/compare_task.rb
@@ -34,7 +34,7 @@ class CompareTask
 
     Machinery::Ui.use_pager = false
     Machinery::Ui.puts <<EOF
-There is a web server running, serving the comparison result on #{url}.
+I will try to start a web server for serving the comparison result on #{url}.
 
 The server can be closed with Ctrl+C.
 EOF

--- a/lib/compare_task.rb
+++ b/lib/compare_task.rb
@@ -34,7 +34,7 @@ class CompareTask
 
     Machinery::Ui.use_pager = false
     Machinery::Ui.puts <<EOF
-I will try to start a web server for serving the comparison result on #{url}.
+Machinery will try to start a web server for serving the comparison result on #{url}.
 
 The server can be closed with Ctrl+C.
 EOF

--- a/lib/html.rb
+++ b/lib/html.rb
@@ -45,6 +45,23 @@ Port #{Server.settings.port} is already in use.
 Stop the already running server on port #{Server.settings.port} or specify a new port by using --port option.
 EOF
           raise Machinery::Errors::ServeFailed, servefailed_error
+        rescue SocketError => e
+          servefailed_error = <<-EOF.chomp
+Cannot start server on #{opts[:ip]}:#{Server.settings.port}.
+ERROR: #{e.message}
+EOF
+          raise Machinery::Errors::ServeFailed, servefailed_error
+        rescue Errno::EADDRNOTAVAIL
+          servefailed_error = <<-EOF.chomp
+The IP-Address #{opts[:ip]} is not available. Please choose a different IP-Address.
+EOF
+          raise Machinery::Errors::ServeFailed, servefailed_error
+        rescue Errno::EACCES => e
+          servefailed_error = <<-EOF.chomp
+You are not allowed to start the server on port #{Server.settings.port}. You need root privileges for ports between 1 and 1023!
+ERROR: #{e.message}
+EOF
+          raise Machinery::Errors::ServeFailed, servefailed_error
         end
         remove_output_redirection
       rescue => e

--- a/lib/show_task.rb
+++ b/lib/show_task.rb
@@ -36,7 +36,7 @@ class ShowTask
 
       Machinery::Ui.use_pager = false
       Machinery::Ui.puts <<EOF
-I will try to start a web server for serving the description on #{url}.
+Machinery will try to start a web server for serving the description on #{url}.
 
 The server can be closed with Ctrl+C.
 EOF

--- a/lib/show_task.rb
+++ b/lib/show_task.rb
@@ -36,7 +36,7 @@ class ShowTask
 
       Machinery::Ui.use_pager = false
       Machinery::Ui.puts <<EOF
-There is a web server running, serving the description on #{url}.
+I will try to start a web server for serving the description on #{url}.
 
 The server can be closed with Ctrl+C.
 EOF

--- a/spec/integration/support/serve_examples.rb
+++ b/spec/integration/support/serve_examples.rb
@@ -129,7 +129,7 @@ shared_examples "serve html" do
 
     it "tests the output when we use ports which needs root privileges" do
       cmd = "#{machinery_command} serve --ip 127.0.0.1 --port 1023 opensuse131"
-      expect(@machinery.run_command(cmd)).to fail.and
+      expect(@machinery.run_command(cmd)).to fail.and \
         have_stderr(/You need root privileges for ports between 1 and 1023!/)
     end
   end

--- a/spec/integration/support/serve_examples.rb
+++ b/spec/integration/support/serve_examples.rb
@@ -47,13 +47,17 @@ shared_examples "serve html" do
       @machinery.run_command("pkill -f 'machinery serve' --signal 9")
     end
 
-    it "makes the system description HTML and extracted files available at the specified port" do
+    before(:each) do
       @machinery.inject_directory(
         system_description_dir,
         machinery_config[:machinery_dir],
         owner: machinery_config[:owner],
         group: machinery_config[:group]
       )
+    end
+
+    it "makes the system description HTML and extracted files available at the specified port and " \
+      "checks if the port is already in use when we run that command twice" do
 
       cmd = "#{machinery_command} serve opensuse131 --port 5000"
       Thread.new do
@@ -74,13 +78,6 @@ shared_examples "serve html" do
     end
 
     it "makes the system description HTML available at the config-file port" do
-      @machinery.inject_directory(
-        system_description_dir,
-        machinery_config[:machinery_dir],
-        owner: machinery_config[:owner],
-        group: machinery_config[:group]
-      )
-
       @machinery.run_command("MACHINERY_CONFIG_FILE=#{config_tmp_file} #{machinery_command} config http-server-port=7500")
 
       cmd = "#{machinery_command} serve opensuse131"
@@ -91,6 +88,22 @@ shared_examples "serve html" do
 
       test_basic_html(7500)
       @machinery.run_command("rm -f '#{config_tmp_file}'")
+    end
+
+    it "checks for the correctness of hostnames" do
+      cmd = "#{machinery_command} serve --ip blabla --port 5000 opensuse131"
+      expect(@machinery.run_command(cmd)).to fail.and have_stderr(/Cannot start server on blabla\:5000\./)
+    end
+
+    it "checks if an IP-Address can be used for the web server binding" do
+      # use the suse.com ip address for test
+      cmd = "#{machinery_command} serve --ip 130.57.5.70 --port 5000 opensuse131"
+      expect(@machinery.run_command(cmd)).to fail.and have_stderr(/The IP\-Address 130\.57\.5\.70 is not available\. Please choose a different IP\-Address\./)
+    end
+
+    it "test the output when we use ports which needs root privileges" do
+      cmd = "#{machinery_command} serve --ip 127.0.0.1 --port 1023 opensuse131"
+      expect(@machinery.run_command(cmd)).to fail.and have_stderr(/You need root privileges for ports between 1 and 1023!/)
     end
   end
 end

--- a/spec/integration/support/serve_examples.rb
+++ b/spec/integration/support/serve_examples.rb
@@ -56,9 +56,8 @@ shared_examples "serve html" do
       )
     end
 
-    it "makes the system description HTML and extracted files available at the specified port and " \
-      "checks if the port is already in use when we run that command twice" do
-
+    it "makes the system description HTML and extracted files available at the specified " \
+      "port" do
       cmd = "#{machinery_command} serve opensuse131 --port 5000"
       Thread.new do
         @machinery.run_command(cmd)
@@ -89,7 +88,7 @@ shared_examples "serve html" do
       @machinery.run_command("rm -f '#{config_tmp_file}'")
     end
 
-    it "make sure that we cannot use ports two time" do
+    it "makes sure a port can't be used twice" do
       cmd = "#{machinery_command} serve --ip 127.0.0.1 --port 5000 opensuse131"
       Thread.new do
         @machinery.run_command(cmd)
@@ -116,18 +115,22 @@ shared_examples "serve html" do
 
     it "checks for the correctness of hostnames" do
       cmd = "#{machinery_command} serve --ip blabla --port 5000 opensuse131"
-      expect(@machinery.run_command(cmd)).to fail.and have_stderr(/Cannot start server on blabla\:5000\./)
+      expect(@machinery.run_command(cmd)).to fail.and \
+        have_stderr(/Cannot start server on blabla\:5000\./)
     end
 
     it "checks if an IP-Address can be used for the web server binding" do
       # use the suse.com ip address for test
       cmd = "#{machinery_command} serve --ip 130.57.5.70 --port 5000 opensuse131"
-      expect(@machinery.run_command(cmd)).to fail.and have_stderr(/The IP\-Address 130\.57\.5\.70 is not available\. Please choose a different IP\-Address\./)
+      expect(@machinery.run_command(cmd)).to fail.and have_stderr(
+        /The IP\-Address 130\.57\.5\.70 is not available\. Please choose a different IP\-Address\./
+      )
     end
 
-    it "test the output when we use ports which needs root privileges" do
+    it "tests the output when we use ports which needs root privileges" do
       cmd = "#{machinery_command} serve --ip 127.0.0.1 --port 1023 opensuse131"
-      expect(@machinery.run_command(cmd)).to fail.and have_stderr(/You need root privileges for ports between 1 and 1023!/)
+      expect(@machinery.run_command(cmd)).to fail.and
+        have_stderr(/You need root privileges for ports between 1 and 1023!/)
     end
   end
 end

--- a/spec/integration/support/serve_examples.rb
+++ b/spec/integration/support/serve_examples.rb
@@ -56,8 +56,7 @@ shared_examples "serve html" do
       )
     end
 
-    it "makes the system description HTML and extracted files available at the specified " \
-      "port" do
+    it "makes the system description HTML and extracted files available at the specified port" do
       cmd = "#{machinery_command} serve opensuse131 --port 5000"
       Thread.new do
         @machinery.run_command(cmd)

--- a/spec/integration/support/serve_examples.rb
+++ b/spec/integration/support/serve_examples.rb
@@ -74,7 +74,6 @@ shared_examples "serve html" do
         "curl http://localhost:5000/descriptions/opensuse131/files/config_files/etc/crontab"
       )
       expect(curl_command).to succeed.with_stderr.and have_stdout(expected_content)
-      expect(@machinery.run_command(cmd)).to fail.and have_stderr(/Port 5000 is already in use.\n/)
     end
 
     it "makes the system description HTML available at the config-file port" do
@@ -88,6 +87,31 @@ shared_examples "serve html" do
 
       test_basic_html(7500)
       @machinery.run_command("rm -f '#{config_tmp_file}'")
+    end
+
+    it "make sure that we cannot use ports two time" do
+      cmd = "#{machinery_command} serve --ip 127.0.0.1 --port 5000 opensuse131"
+      Thread.new do
+        @machinery.run_command(cmd)
+      end
+
+      wait_time = 0
+
+      loop do
+        curl_command = @machinery.run_command("curl http://127.0.0.1:5000/opensuse131")
+
+        if curl_command.stderr =~ /Failed to connect/
+          raise "Could not connect to webserver" if wait_time >= 10
+
+          sleep 0.5
+          wait_time += 0.5
+          next
+        end
+
+        break
+      end
+
+      expect(@machinery.run_command(cmd)).to fail.and have_stderr(/Port 5000 is already in use.\n/)
     end
 
     it "checks for the correctness of hostnames" do


### PR DESCRIPTION
Trello card: https://trello.com/c/mlSoveiF/859-p13-3-machinery-option-i-unexpected-error-for-unknown-ip-address-1186

Issue: https://github.com/SUSE/machinery/issues/1186