### PR TITLE
ChangeLog entry: Add rpc_pipefs to filtered filesystems

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 # Machinery Release Notes
 
+* Add rpc_pipefs to filtered filesystems (gh#SUSE/machinery#1250)
 * Add `containerize` command to the experimental features
 * Export of autoyast files is now possible with system descriptions,
   which have empty repository scopes (gh#SUSE/machinery#1268)


### PR DESCRIPTION
Fixed in machinery-helper

Fixes #1250