### PR TITLE
Set status context to allow triggered prophet job to run actual tests.

### DIFF
--- a/prophet/prophet_integration.rb
+++ b/prophet/prophet_integration.rb
@@ -70,7 +70,9 @@ Prophet.setup do |config|
   # 0 (= success).
   if ENV["PROPHET_TRIGGER_RUN"]
     config.execution do
+      config.status_context = "prophet/trigger"
       @run_main_jenkins_job = true
+      config.success = ($? == 0)
     end
   else
     config.execution do


### PR DESCRIPTION
When running the trigger job in the integration context, it already adds
a comment to the pull request which then indicates to the triggered actual
test run that tests ran already, making it skip the test execution. By
setting a own context called trigger we avoid this. The backdraw of this
approach however is an additional status entry for each pull request called
prophet trigger.
