### PR TITLE
Fix: Show `Files extracted` status in `compare --html`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 # Machinery Release Notes
 
+* Fix: Show `Files extracted` status in `compare --html` when both
+  status are the same (gh#SUSE/machinery#1218)
 * Fix: Validate port option in the `show` and `serve` commands
   (gh#SUSE/machinery#1316)
 * Align output of `machinery config`

--- a/html/comparison.html.haml
+++ b/html/comparison.html.haml
@@ -269,7 +269,7 @@
 
     %script#scope_unmanaged_files_partial{:type => "text/ng-template"}
       %p
-        <strong>Files extracted:</strong> {{object.extracted}}
+        <strong>Files extracted:</strong> {{object.extracted ? "yes" : "no"}}
       %table.table.table-striped.table-hover.table-condensed.files-table{{"ng-show" => "object.files"}}
         %thead
           %tr
@@ -457,7 +457,7 @@
 
     %script#scope_changed_managed_files_partial{:type => "text/ng-template"}
       %p
-        <strong>Files extracted:</strong> {{object.extracted}}
+        <strong>Files extracted:</strong> {{object.extracted ? "yes" : "no"}}
       %table.table.table-striped.table-hover.table-condensed.files-table{{"ng-show" => "object.files"}}
         %thead
           %tr
@@ -524,7 +524,7 @@
 
     %script#scope_config_files_partial{:type => "text/ng-template"}
       %p
-        <strong>Files extracted:</strong> {{object.extracted}}
+        <strong>Files extracted:</strong> {{object.extracted ? "yes" : "no"}}
       %table.table.table-striped.table-hover.table-condensed.files-table{{"ng-show" => "object.files"}}
         %thead
           %tr


### PR DESCRIPTION
Supersedes #1344 