### PR TITLE
Edit changelog: The `validate port` fix was also related to `compare`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,8 +2,8 @@
 
 * Fix: Show `Files extracted` status in `compare --html` when both
   status are the same (gh#SUSE/machinery#1218)
-* Fix: Validate port option in the `show` and `serve` commands
-  (gh#SUSE/machinery#1316)
+* Fix: Validate port option in the `show`, `compare`,  and `serve`
+  commands (gh#SUSE/machinery#1316)
 * Align output of `machinery config`
 * Add rpc_pipefs to filtered filesystems (gh#SUSE/machinery#1250)
 * Handle socket errors for `-i` option


### PR DESCRIPTION
The `validate port` fix was also related to the `compare` command.