### PR TITLE
Fix UTF-8 filtering on 13.1

### DIFF
--- a/plugins/environment/environment_inspector.rb
+++ b/plugins/environment/environment_inspector.rb
@@ -37,7 +37,7 @@ class EnvironmentInspector < Inspector
     output = nil
     begin
       output = @system.run_command("locale", "-a", stdout: :capture)
-      output.encode!("UTF-8", invalid: :replace, undef: :replace, replace: "?")
+      output.encode!("UTF-16be", invalid: :replace, undef: :replace, replace: "?").encode!("UTF-8")
     rescue
       return "C"
     end


### PR DESCRIPTION
In Ruby 2.0 the encode method is a no-op when encoding a string to its
current encoding. This prevented our method from filtering invalid
UTF-8 characters on openSUSE 13.1.

That's why we have to convert to another charset first.