### PR TITLE
Use our own scrub method to fix broken UTF-8

### DIFF
--- a/plugins/environment/environment_inspector.rb
+++ b/plugins/environment/environment_inspector.rb
@@ -36,8 +36,7 @@ class EnvironmentInspector < Inspector
   def get_locale
     output = nil
     begin
-      output = @system.run_command("locale", "-a", stdout: :capture)
-      output.encode!("UTF-16be", invalid: :replace, undef: :replace, replace: "?").encode!("UTF-8")
+      output = Machinery.scrub(@system.run_command("locale", "-a", stdout: :capture))
     rescue
       return "C"
     end


### PR DESCRIPTION
instead of the newly added encode method.