### PR TITLE
Add .gitignore to gh-pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+*.gem
+*.swp
+Gemfile.lock
+Guardfile
+options-local.yml
+
+iso
+*.box
+box_state.yaml
+import_state.yaml
+.vagrant
+man/
+package/


### PR DESCRIPTION
to prevent issues when switching from the regular machinery branches.