### PR TITLE
Adapt man page to Red Hat support

### DIFF
--- a/man/machinery-inspect.1.md
+++ b/man/machinery-inspect.1.md
@@ -93,7 +93,7 @@ trigger errors.
   * The system to be inspected needs to have the following commands:
 
     * `rpm`
-    * `zypper`
+    * `zypper` or `yum`
     * `rsync`
     * `chkconfig`
     * `cat`


### PR DESCRIPTION
Machinery does also allow to use `yum` instead of `zypper` so `zypper`
is no exclusive requirement.