### PR TITLE
Build docker containers faster

### DIFF
--- a/workload_mapper/docker-registry/container/Dockerfile
+++ b/workload_mapper/docker-registry/container/Dockerfile
@@ -3,7 +3,7 @@ FROM opensuse:13.2
 RUN zypper -n --gpg-auto-import-keys ar http://download.opensuse.org/repositories/Virtualization:/containers/openSUSE_13.2/ virt
 RUN zypper -n --gpg-auto-import-keys refresh
 RUN zypper -n --gpg-auto-import-keys update
-RUN zypper -n --gpg-auto-import-keys install docker docker-distribution-registry
+RUN zypper -n --gpg-auto-import-keys install docker-distribution-registry
 
 ADD ./data/etc/registry /etc/registry
 

--- a/workload_mapper/rails/container/Dockerfile
+++ b/workload_mapper/rails/container/Dockerfile
@@ -32,6 +32,7 @@ RUN passenger-install-apache2-module.ruby2.1 -a
 RUN mkdir /srv/www/rails
 WORKDIR /srv/www/rails
 ADD ./data /srv/www/rails
+RUN echo "gem: --no-ri --no-rdoc" > /srv/www/rails/.gemrc
 RUN chown -R wwwrun:www  /srv/www/rails
 
 RUN bundle config build.nokogiri --use-system-libraries

--- a/workload_mapper/rails/container/Dockerfile
+++ b/workload_mapper/rails/container/Dockerfile
@@ -36,7 +36,7 @@ RUN echo "gem: --no-ri --no-rdoc" > /srv/www/rails/.gemrc
 RUN chown -R wwwrun:www  /srv/www/rails
 
 RUN bundle config build.nokogiri --use-system-libraries
-RUN bundle install
+RUN bundle install --without test development
 
 ADD apache2/sysconfig_apache2 /etc/sysconfig/apache2
 ADD apache2/httpd.conf.local /etc/apache2/httpd.conf.local


### PR DESCRIPTION
It's not necessary to install docker with the docker-registry so build gets faster