### PR TITLE
[Review] Request from 'tgoettlicher' @ 'SUSE/machinery/review_150923_check_for_command_xdg_open_instead_of_package_xdg_utils_'

### DIFF
--- a/lib/local_system.rb
+++ b/lib/local_system.rb
@@ -67,6 +67,18 @@ You can install it by running `zypper install #{missing_packages.join(" ")}`.
       end
     end
 
+    def validate_existence_of_command(command, package)
+      begin
+        Cheetah.run("which", command)
+      rescue Cheetah::ExecutionFailed
+        output = <<-EOF
+You need the command '#{command}' from package '#{package}'.
+You can install it by running `zypper install #{package}`.
+        EOF
+        raise(Machinery::Errors::MissingRequirement.new(output))
+      end
+    end
+
     def validate_machinery_compatibility
       return if !Machinery::Config.new.perform_support_check || os.can_run_machinery?
 

--- a/lib/show_task.rb
+++ b/lib/show_task.rb
@@ -30,7 +30,7 @@ class ShowTask
 
   def show_html(description, options)
     begin
-      LocalSystem.validate_existence_of_package("xdg-utils")
+      LocalSystem.validate_existence_of_command("xdg-open", "xdg-utils")
 
       url = "http://#{options[:ip]}:#{options[:port]}/#{CGI.escape(description.name)}"
 

--- a/spec/unit/local_system_spec.rb
+++ b/spec/unit/local_system_spec.rb
@@ -186,6 +186,26 @@ EOF
     end
   end
 
+  describe ".validate_existence_of_command" do
+    it "raises an Machinery::Errors::MissingRequirementsError error if the command isn't found" do
+      allow(LocalSystem).to receive(:os).and_return(Os.new)
+      output = <<-EOF
+You need the command 'does_not_exist' from package 'not_installed_package'.
+You can install it by running `zypper install not_installed_package`.
+EOF
+
+      command = "does_not_exist"
+      package = "not_installed_package"
+      expect { LocalSystem.validate_existence_of_command(command, package) }.to raise_error(
+        Machinery::Errors::MissingRequirement, output
+      )
+    end
+
+    it "doesn't raise an error if the command exists" do
+      expect { LocalSystem.validate_existence_of_command("bash", "bash") }.not_to raise_error
+    end
+  end
+
   describe ".validate_existence_of_packages" do
     it "raises an error if packages doesn't exist" do
       allow(LocalSystem).to receive(:os).and_return(Os.new)


### PR DESCRIPTION
Please review the following changes:
  * 6e9a1c0 Check for command 'xdg-open' instead of package 'xdg-utils'
  * f263036 Add validate_existence_of_command() to LocalSystem