### PR TITLE
Add move command for machinery

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 # Machinery Release Notes
 
+* Add `move` command to rename system descriptions (gh#SUSE/machinery#1397)
 
 ## Version 1.13.0 - Tue Sep 15 18:06:00 CEST 2015 - thardeck@suse.de
 

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -404,6 +404,23 @@ class Cli
     end
   end
 
+  desc "Move system description"
+  long_desc <<-LONGDESC
+    Move a system description.
+
+    The system description name is changed to the provided name.
+  LONGDESC
+  arg "FROM_NAME"
+  arg "TO_NAME"
+  command "move" do |c|
+    c.action do |_global_options, _options, args|
+      from = shift_arg(args, "FROM_NAME")
+      to = shift_arg(args, "TO_NAME")
+      task = MoveTask.new
+      task.move(system_description_store, from, to)
+    end
+  end
+
 
   desc "Deploy image to OpenStack cloud"
   long_desc <<-LONGDESC

--- a/lib/machinery.rb
+++ b/lib/machinery.rb
@@ -107,6 +107,7 @@ require_relative "workload_mapper"
 require_relative "containerize_task"
 require_relative "workload_mapper_dsl"
 require_relative "containerized_app"
+require_relative "move_task"
 
 Dir[File.join(Machinery::ROOT, "plugins", "**", "*.rb")].each { |f| require(f) }
 

--- a/lib/move_task.rb
+++ b/lib/move_task.rb
@@ -1,0 +1,22 @@
+# Copyright (c) 2013-2015 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
+class MoveTask
+  def move(store, from, to)
+    store.move(from, to)
+  end
+end

--- a/lib/system_description_store.rb
+++ b/lib/system_description_store.rb
@@ -74,6 +74,16 @@ class SystemDescriptionStore
     FileUtils.cp_r(description_path(from), description_path(to))
   end
 
+  def move(from, to)
+    SystemDescription.validate_name(from)
+    SystemDescription.validate_name(to)
+
+    validate_existence_of_description(from)
+    validate_nonexistence_of_description(to)
+
+    FileUtils.mv(description_path(from), description_path(to))
+  end
+
   def backup(description_name)
     SystemDescription.validate_name(description_name)
     validate_existence_of_description(description_name)

--- a/man/machinery-move.1.md
+++ b/man/machinery-move.1.md
@@ -1,0 +1,29 @@
+
+## move — Move System Description
+
+### SYNOPSIS
+
+`machinery move`
+    FROM_NAME TO_NAME
+
+`machinery` help move
+
+
+### DESCRIPTION
+
+The `move` command renames a stored system description from `FROM_NAME` to `TO_NAME`.
+
+
+### ARGUMENTS
+  * `FROM_NAME` (required):
+    Current name of the system description.
+
+  * `TO_NAME` (required):
+    New name of the system description.
+
+
+### EXAMPLES
+
+  * Rename the system description `earth` to `moon`:
+
+    $ `machinery` move earth moon

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -565,6 +565,14 @@ describe Cli do
     end
   end
 
+  describe "#move" do
+    it "triggers the move task" do
+      expect_any_instance_of(MoveTask).to receive(:move).
+        with(an_instance_of(SystemDescriptionStore), "foo", "bar")
+      run_command(["move", "foo", "bar"])
+    end
+  end
+
   describe "#upgrade_format" do
     it "triggers the upgrade task for a specific description" do
       expect_any_instance_of(UpgradeFormatTask).to receive(:upgrade).

--- a/spec/unit/move_task_spec.rb
+++ b/spec/unit/move_task_spec.rb
@@ -1,0 +1,32 @@
+# Copyright (c) 2013-2015 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
+require_relative "spec_helper"
+
+describe MoveTask do
+  let(:move_task) { MoveTask.new }
+
+  describe "#move" do
+    it "moves the system description directory" do
+      store = double
+      from = "description1"
+      to = "description2"
+      expect(store).to receive(:move).with(from, to)
+      move_task.move(store, from, to)
+    end
+  end
+end

--- a/spec/unit/system_description_store_spec.rb
+++ b/spec/unit/system_description_store_spec.rb
@@ -176,6 +176,35 @@ describe SystemDescriptionStore do
     end
   end
 
+  describe "#move" do
+    let(:store) { SystemDescriptionStore.new(test_base_path) }
+    let(:new_name) { "description2" }
+
+    before(:each) do
+      create_machinery_dir
+    end
+
+    it "moves an existing SystemDescription" do
+      expect(store.list).to eq([test_name])
+      store.move(test_name, new_name)
+      expect(store.list).to eq([new_name])
+    end
+
+    it "throws an error when the to be moved SystemDescription does not exist" do
+      expect {
+        store.move("foo_bar_does_not_exist", new_name)
+      }.to raise_error(Machinery::Errors::SystemDescriptionNotFound, /foo_bar_does_not_exist/)
+    end
+
+    it "throws an error when the new name already exists" do
+      store.copy(test_name, new_name)
+      expect(store.list).to include(new_name)
+      expect {
+        store.move(test_name, new_name)
+      }.to raise_error(Machinery::Errors::SystemDescriptionError, /#{new_name}/)
+    end
+  end
+
   describe "#directory_for" do
     it "creates sub directory for system description" do
       path = "/tmp/test_dir"


### PR DESCRIPTION
Fixes #1397
Squashes #1408
The machinery move command moves a system-description to the specified
name.