### PR TITLE
Speed up comparing unmanaged-files from O(n²) to O(n)

### DIFF
--- a/plugins/unmanaged_files/unmanaged_files_model.rb
+++ b/plugins/unmanaged_files/unmanaged_files_model.rb
@@ -22,14 +22,20 @@ class UnmanagedFileList < Machinery::Array
   has_elements class: UnmanagedFile
 
   def compare_with(other)
-    only_self = elements.reject do |element|
-      other.elements.find { |other_element| files_match(element, other_element) }
+    self_hash = elements.inject({}) { |hash, e| hash[e.name] = e; hash }
+    other_hash = other.elements.inject({}) { |hash, e| hash[e.name] = e; hash }
+
+    both = []
+    only_self = []
+    elements.each do |element|
+      if other_hash.has_key?(element.name) && files_match(element, other_hash[element.name])
+        both << element
+      else
+        only_self << element
+      end
     end
     only_other = other.elements.reject do |element|
-      elements.find { |other_element| files_match(element, other_element) }
-    end
-    both = elements.select do |element|
-      other.elements.find { |other_element| files_match(element, other_element) }
+      self_hash.has_key?(element.name) && files_match(element, self_hash[element.name])
     end
 
     [


### PR DESCRIPTION
Results from my machine, comparing a 580-file description
with a 2800-file one:

                  user     system      total        real
    new:       0.040000   0.000000   0.040000 (  0.036712)
    original: 43.340000   0.020000  43.360000 ( 43.745186)
