### PR TITLE
Remove `-i` and `-p` from `show` and add a `--public` option to `serve`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 # Machinery Release Notes
 
+* Fix: Clean up binding the server for HTML view to IP addresses
+  (gh#SUSE/machinery#1341)
 * Fix: Make links to sections with common elements clearer in HTML comparison
   view
 * Fix: Scrolling issue of file view (gh#SUSE/machinery#1155)

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -892,19 +892,23 @@ class Cli
       desc: "Listen on port PORT. Ports can be selected in a range between 2-65535. Ports between
         2 and 1023 can only be chosen when `machinery` will be executed as `root` user.",
         arg_name: "PORT"
-    c.flag [:ip, :i], type: String, required: false, default_value: "127.0.0.1",
-      desc: "Listen on ip address IP. It's only possible to use an IP address (or hostnames
-        resolving to an IP address) which is assigned to a network interface on the local
-        machine.", arg_name: "IP"
+    c.switch "public", required: false, negatable: false,
+      desc: "Makes the server reachable from all IP addresses."
 
     c.action do |_global_options, options, args|
       name = shift_arg(args, "NAME")
 
       check_port_validity(options[:port])
 
+      if options[:public]
+        ip = "0.0.0.0"
+      else
+        ip = "127.0.0.1"
+      end
+
       description = SystemDescription.load(name, system_description_store)
       task = ServeHtmlTask.new
-      task.serve(description, options[:ip], options[:port])
+      task.serve(description, ip, options[:port])
     end
   end
 

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -248,10 +248,13 @@ class Cli
 
   def self.check_port_validity(port)
     if port < 2 || port > 65535
-      raise Machinery::Errors::InvalidServerPortSpecified
+      raise Machinery::Errors::ServerPortError.new("The specified port '#{port}' is not " \
+        "valid. A valid port can be in a range between 2 and 65535.")
     else
       if port >= 2 && port <= 1023 && !CurrentUser.new.is_root?
-        raise Machinery::Errors::ServerNeedRootPrivileges
+        raise Machinery::Errors::ServerPortError.new("The specified port '#{port}' needs " \
+          "root privileges. Otherwise, the server cannot be started. All ports in a range " \
+          "of 2-1023 need root privileges.")
       end
     end
   end
@@ -360,16 +363,9 @@ class Cli
       if options[:html]
         begin
           check_port_validity(@config.http_server_port)
-        rescue Machinery::Errors::InvalidServerPortSpecified
-          raise Machinery::Errors::InvalidCommandLine.new("You have to specify a valid server " \
-            "port in the 'http_server_port' section of the configuration file. The specified " \
-            "port '#{@config.http_server_port}' is not valid. A valid port can be in a range " \
-            "between 2 and 65535.")
-        rescue Machinery::Errors::ServerNeedRootPrivileges
-          raise Machinery::Errors::InvalidCommandLine.new("You specified the port " \
-            "'#{@config.http_server_port}' in the 'http_server_port' section. To start the " \
-            "server, you need root privileges. If you don't want to start the server as root " \
-            "user, you must choose a port between 1024 and 65535.")
+        rescue Machinery::Errors::ServerPortError => e
+          raise Machinery::Errors::InvalidCommandLine.new(e.message +  " The port can be " \
+            "specified in the 'http_server_port' section of the configuration file.")
         end
       end
 
@@ -760,16 +756,9 @@ class Cli
       if options[:html]
         begin
           check_port_validity(@config.http_server_port)
-        rescue Machinery::Errors::InvalidServerPortSpecified
-          raise Machinery::Errors::InvalidCommandLine.new("You have to specify a valid server " \
-            "port in the 'http_server_port' section of the configuration file. The specified " \
-            "port '#{@config.http_server_port}' is not valid. A valid port can be in a range " \
-            "between 2 and 65535.")
-        rescue Machinery::Errors::ServerNeedRootPrivileges
-          raise Machinery::Errors::InvalidCommandLine.new("You specified the port " \
-            "'#{@config.http_server_port}' in the 'http_server_port' section. To start the " \
-            "server, you need root privileges. If you don't want to start the server as root " \
-            "user, you must choose a port between 1024 and 65535.")
+        rescue Machinery::Errors::ServerPortError => e
+          raise Machinery::Errors::InvalidCommandLine.new(e.message +  " The port can be " \
+            "specified in the 'http_server_port' section of the configuration file.")
         end
       end
 
@@ -905,17 +894,10 @@ class Cli
 
       begin
         check_port_validity(options[:port])
-      rescue Machinery::Errors::InvalidServerPortSpecified
-        raise Machinery::Errors::InvalidCommandLine.new("You have to specify a valid server " \
-          "port either in the 'http_server_port' section of the configuration file or " \
-          "via the --port option. The specified port '#{options[:port]}' is not valid. A valid " \
-          "port can be in a range between 2 and 65535.")
-      rescue Machinery::Errors::ServerNeedRootPrivileges
-        raise Machinery::Errors::InvalidCommandLine.new("You specified the port " \
-          "'#{options[:port]}' either in the 'http_server_port' section of the configuration " \
-          "file or via the --port option. To start the server, you need root privileges. If " \
-          "you don't want to start the server as root user, you must choose a port between " \
-          "1024 and 65535.")
+      rescue Machinery::Errors::ServerPortError => e
+        raise Machinery::Errors::InvalidCommandLine.new(e.message +  " The port can be " \
+          "either specified in the 'http_server_port' section of the configuration file " \
+          "or via the --port option.")
       end
 
       if options[:public]

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -364,7 +364,7 @@ class Cli
         begin
           check_port_validity(@config.http_server_port)
         rescue Machinery::Errors::ServerPortError => e
-          raise Machinery::Errors::InvalidCommandLine.new(e.message +  " The port can be " \
+          raise Machinery::Errors::InvalidCommandLine.new(e.message + " The port can be " \
             "specified in the 'http_server_port' section of the configuration file.")
         end
       end
@@ -757,7 +757,7 @@ class Cli
         begin
           check_port_validity(@config.http_server_port)
         rescue Machinery::Errors::ServerPortError => e
-          raise Machinery::Errors::InvalidCommandLine.new(e.message +  " The port can be " \
+          raise Machinery::Errors::InvalidCommandLine.new(e.message + " The port can be " \
             "specified in the 'http_server_port' section of the configuration file.")
         end
       end
@@ -895,7 +895,7 @@ class Cli
       begin
         check_port_validity(options[:port])
       rescue Machinery::Errors::ServerPortError => e
-        raise Machinery::Errors::InvalidCommandLine.new(e.message +  " The port can be " \
+        raise Machinery::Errors::InvalidCommandLine.new(e.message + " The port can be " \
           "either specified in the 'http_server_port' section of the configuration file " \
           "or via the --port option.")
       end

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -140,7 +140,12 @@ module Machinery
     class UnexpectedInputData < MachineryError; end
     class ComposeServiceLink < MachineryError; end
     class UnsupportedHelperVersion < MachineryError; end
-    class InvalidServerPortSpecified < MachineryError; end
-    class ServerNeedRootPrivileges < MachineryError; end
+    class ServerPortError < MachineryError
+      attr_reader :message
+
+      def initialize(message)
+        @message = message
+      end
+    end
   end
 end

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -140,5 +140,7 @@ module Machinery
     class UnexpectedInputData < MachineryError; end
     class ComposeServiceLink < MachineryError; end
     class UnsupportedHelperVersion < MachineryError; end
+    class InvalidServerPortSpecified < MachineryError; end
+    class ServerNeedRootPrivileges < MachineryError; end
   end
 end

--- a/lib/html.rb
+++ b/lib/html.rb
@@ -26,11 +26,19 @@ class Html
       Server.set :public_folder, File.join(Machinery::ROOT, "html")
 
       if opts[:ip] != "localhost" && opts[:ip] != "127.0.0.1"
-        Machinery::Ui.puts <<EOF
+        if opts[:ip] == "0.0.0.0"
+          Machinery::Ui.puts <<EOF
+Warning:
+The server is listening on all configured IP addresses.
+This could lead to confidential data like passwords or private keys being readable by others.
+EOF
+        else
+          Machinery::Ui.puts <<EOF
 Warning:
 You specified an IP address other than '127.0.0.1', your server may be reachable from the network.
 This could lead to confidential data like passwords or private keys being readable by others.
 EOF
+        end
       end
 
       begin

--- a/man/machinery-serve.1.md
+++ b/man/machinery-serve.1.md
@@ -3,7 +3,7 @@
 
 ### SYNOPSIS
 
-`machinery serve` [-p PORT | --port=PORT] [-i IP | --ip=IP] NAME
+`machinery serve` [-p PORT | --port=PORT] [--public] NAME
 
 `machinery` help serve
 
@@ -30,11 +30,9 @@ IP address and the port can be configured using the according options.
     Ports can be selected in a range between 2-65535. Ports between 2 and 1023 can only be
     chosen when `machinery` will be executed as `root` user.
 
-  * `-i IP`, `--ip=IP` (optional):
-    Specify the IP address on which the web server will be made available. Default: 127.0.0.1
-
-    It's only possible to use an IP address (or hostnames resolving to an IP address) which
-    is assigned to a network interface on the local machine.
+  * `--public` (optional):
+    Specifying this option, lets the server listen on each configured IP address. By default
+    the server will only listen on the localhost IP address 127.0.0.1
 
 ### EXAMPLES
 
@@ -42,6 +40,6 @@ IP address and the port can be configured using the according options.
 
     $ `machinery` serve earth
 
-  * Make the system description available to other machines on the network:
+  * Make the system description available to other machines on the network on port 3000:
 
-    $ `machinery` serve earth -i 10.10.100.123 -p 3000
+    $ `machinery` serve earth --public --port 3000

--- a/man/machinery-show.1.md
+++ b/man/machinery-show.1.md
@@ -3,7 +3,7 @@
 
 ### SYNOPSIS
 
-`machinery show` [-s SCOPE | --scope=SCOPE] [-e EXCLUDE-SCOPE | --exclude-scope=EXCLUDE-SCOPE] [--no-pager] [--show-diffs] [--html] [-p PORT | --port=PORT] [-i IP | --ip=IP] NAME
+`machinery show` [-s SCOPE | --scope=SCOPE] [-e EXCLUDE-SCOPE | --exclude-scope=EXCLUDE-SCOPE] [--no-pager] [--show-diffs] [--html] NAME
 
 `machinery` help show
 
@@ -44,18 +44,6 @@ in local time are shown in the title of each scope section.
   * `--html` (optional):
     Run a web server and open the system description in HTML format in your web browser using the
     `xdg-open` command.
-
-  * `-p PORT`, `--port=PORT` (optional):
-    Specify the port on which the web server will serve the system description: Default: 7585
-
-    Ports can be selected in a range between 2-65535. Ports between 2 and 1023 can only be
-    chosen when `machinery` will be executed as `root` user.
-
-  * `-i IP`, `--ip=IP` (optional):
-    Specify the IP address on which the web server will be made available. Default: 127.0.0.1
-
-    It's only possible to use an IP address (or hostnames resolving to an IP address) which
-    is assigned to a network interface on the local machine.
 
   * `--verbose` (optional):
     Display the filters which were applied before showing the system description.

--- a/spec/integration/support/command_line_examples.rb
+++ b/spec/integration/support/command_line_examples.rb
@@ -97,32 +97,40 @@ shared_examples "CLI" do
     end
 
     describe "compare" do
+      let(:config_tmp_file) { "/tmp/machinery/http_port_tests" }
+
       before(:each) do
-        @machinery.run_command("#{machinery_command} config experimental_features true", \
-          as: "vagrant")
+        @machinery.run_command("MACHINERY_CONFIG_FILE=#{config_tmp_file} #{machinery_command} " \
+          "config experimental_features true", as: "vagrant")
       end
 
-      it "checks if a port gets validated" do
-        expect(@machinery.run_command("#{machinery_command} compare description1 description2 " \
-          "--port=1 --html", as: "vagrant")).to fail.and include_stderr(
-            "Please choose a port between 2 and 65535."
-          )
+      it "fails when a port is invalid" do
+        @machinery.run_command("MACHINERY_CONFIG_FILE=#{config_tmp_file} #{machinery_command} " \
+          "config http_server_port 1", as: "vagrant")
+        expect(@machinery.run_command("MACHINERY_CONFIG_FILE=#{config_tmp_file} " \
+          "#{machinery_command} compare description1 description2 --html", as: "vagrant")).to fail.
+          and include_stderr("A valid port can be in a range between 2 and 65535.")
       end
     end
 
     describe "show" do
-      it "checks if a port gets validated" do
-        expect(@machinery.run_command("#{machinery_command} show description1 " \
-          "--port=1 --html", as: "vagrant")).to fail.and include_stderr(
-            "Please choose a port between 2 and 65535."
-          )
+      let(:config_tmp_file) { "/tmp/machinery/http_port_tests" }
+
+      it "fails when a port is invalid" do
+        @machinery.run_command("MACHINERY_CONFIG_FILE=#{config_tmp_file} #{machinery_command} " \
+          "config http_server_port 1", as: "vagrant")
+        expect(@machinery.run_command("MACHINERY_CONFIG_FILE=#{config_tmp_file} " \
+          "#{machinery_command} show description1 --html", as: "vagrant")).to fail.
+          and include_stderr("A valid port can be in a range between 2 and 65535.")
       end
     end
 
     describe "serve" do
-      it "checks if a port gets validated" do
-        expect(@machinery.run_command("#{machinery_command} serve description1 --port=1", \
-          as: "vagrant")).to fail.and include_stderr("Please choose a port between 2 and 65535.")
+      it "fails when a port is invalid" do
+        expect(@machinery.run_command("#{machinery_command} serve description1 --port 1",
+          as: "vagrant")).to fail.and include_stderr(
+            "A valid port can be in a range between 2 and 65535."
+          )
       end
     end
 

--- a/spec/integration/support/serve_examples.rb
+++ b/spec/integration/support/serve_examples.rb
@@ -88,7 +88,7 @@ shared_examples "serve html" do
     end
 
     it "makes sure a port can't be used twice" do
-      cmd = "#{machinery_command} serve --ip 127.0.0.1 --port 5000 opensuse131"
+      cmd = "#{machinery_command} serve --port 5000 opensuse131"
       Thread.new do
         @machinery.run_command(cmd)
       end
@@ -110,20 +110,6 @@ shared_examples "serve html" do
       end
 
       expect(@machinery.run_command(cmd)).to fail.and have_stderr(/Port 5000 is already in use.\n/)
-    end
-
-    it "checks for the correctness of hostnames" do
-      cmd = "#{machinery_command} serve --ip blabla --port 5000 opensuse131"
-      expect(@machinery.run_command(cmd)).to fail.and \
-        have_stderr(/Cannot start server on blabla\:5000\./)
-    end
-
-    it "checks if an IP-Address can be used for the web server binding" do
-      # use the suse.com ip address for test
-      cmd = "#{machinery_command} serve --ip 130.57.5.70 --port 5000 opensuse131"
-      expect(@machinery.run_command(cmd)).to fail.and have_stderr(
-        /The IP\-Address 130\.57\.5\.70 is not available\. Please choose a different IP\-Address\./
-      )
     end
   end
 end

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -766,40 +766,24 @@ Backtrace:
 
   describe ".check_port_validity" do
     it "checks if a port is invalid below 2" do
-      expect { Cli.check_port_validity(1) }.to raise_error(Machinery::Errors::InvalidCommandLine, \
-        "Please choose a port between 2 and 65535.")
-      expect { Cli.check_port_validity(1, true) }.to raise_error(
-        Machinery::Errors::InvalidCommandLine, "You have to specify a valid default " \
-          "server port in the 'http_server_port' section of the configuration file. A valid " \
-          "port can be in a range between 2 and 65535.")
+      expect { Cli.check_port_validity(1) }.to raise_error(
+        Machinery::Errors::InvalidServerPortSpecified
+      )
     end
 
     it "checks if a port is invalid above 65535" do
       expect { Cli.check_port_validity(65536) }.to raise_error(
-        Machinery::Errors::InvalidCommandLine, "Please choose a port between 2 and 65535."
-      )
-      expect { Cli.check_port_validity(65536, true) }.to raise_error(
-        Machinery::Errors::InvalidCommandLine, "You have to specify a valid default " \
-          "server port in the 'http_server_port' section of the configuration file. A valid " \
-          "port can be in a range between 2 and 65535."
+        Machinery::Errors::InvalidServerPortSpecified
       )
     end
 
     it "checks if a port is valid between 2 and 65535" do
       expect { Cli.check_port_validity(5000) }.to_not raise_error
-      expect { Cli.check_port_validity(5000, true) }.to_not raise_error
     end
 
     it "checks if a port requires root privileges" do
       expect { Cli.check_port_validity(1000) }.to raise_error(
-        Machinery::Errors::InvalidCommandLine, "You need root rights when you want to use a port " \
-          "between 2 and 1023."
-      )
-      expect { Cli.check_port_validity(1000, true) }.to raise_error(
-        Machinery::Errors::InvalidCommandLine, "You specified the port '1000' " \
-          "in the 'http_server_port' section of the configuration file. To start the server, " \
-          "you need root rights. If you don't want to start the server as root user, you must " \
-          "choose a port between 1024 and 65535."
+        Machinery::Errors::ServerNeedRootPrivileges
       )
     end
   end

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -767,13 +767,13 @@ Backtrace:
   describe ".check_port_validity" do
     it "checks if a port is invalid below 2" do
       expect { Cli.check_port_validity(1) }.to raise_error(
-        Machinery::Errors::InvalidServerPortSpecified
+        Machinery::Errors::ServerPortError
       )
     end
 
     it "checks if a port is invalid above 65535" do
       expect { Cli.check_port_validity(65536) }.to raise_error(
-        Machinery::Errors::InvalidServerPortSpecified
+        Machinery::Errors::ServerPortError
       )
     end
 
@@ -783,7 +783,7 @@ Backtrace:
 
     it "checks if a port requires root privileges" do
       expect { Cli.check_port_validity(1000) }.to raise_error(
-        Machinery::Errors::ServerNeedRootPrivileges
+        Machinery::Errors::ServerPortError
       )
     end
   end

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -759,22 +759,38 @@ Backtrace:
     it "checks if a port is invalid below 2" do
       expect { Cli.check_port_validity(1) }.to raise_error(Machinery::Errors::InvalidCommandLine, \
         "Please choose a port between 2 and 65535.")
+      expect { Cli.check_port_validity(1, true) }.to raise_error(
+        Machinery::Errors::InvalidCommandLine, "You have to specify a valid default " \
+          "server port in the 'http_server_port' section of the configuration file. A valid " \
+          "port can be in a range between 2 and 65535.")
     end
 
     it "checks if a port is invalid above 65535" do
       expect { Cli.check_port_validity(65536) }.to raise_error(
         Machinery::Errors::InvalidCommandLine, "Please choose a port between 2 and 65535."
       )
+      expect { Cli.check_port_validity(65536, true) }.to raise_error(
+        Machinery::Errors::InvalidCommandLine, "You have to specify a valid default " \
+          "server port in the 'http_server_port' section of the configuration file. A valid " \
+          "port can be in a range between 2 and 65535."
+      )
     end
 
     it "checks if a port is valid between 2 and 65535" do
       expect { Cli.check_port_validity(5000) }.to_not raise_error
+      expect { Cli.check_port_validity(5000, true) }.to_not raise_error
     end
 
     it "checks if a port requires root privileges" do
       expect { Cli.check_port_validity(1000) }.to raise_error(
         Machinery::Errors::InvalidCommandLine, "You need root rights when you want to use a port " \
           "between 2 and 1023."
+      )
+      expect { Cli.check_port_validity(1000, true) }.to raise_error(
+        Machinery::Errors::InvalidCommandLine, "You specified the port '1000' " \
+          "in the 'http_server_port' section of the configuration file. To start the server, " \
+          "you need root rights. If you don't want to start the server as root user, you must " \
+          "choose a port between 1024 and 65535."
       )
     end
   end

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -422,18 +422,6 @@ describe Cli do
         run_command(["show", "description1", "--scope=packages", "--no-pager"])
       end
 
-      context "with --html" do
-        it "forwards the specified port and IP" do
-          description = create_test_description(json: test_manifest)
-          expect_any_instance_of(ShowTask).to receive(:show).with(description, ["packages"],
-            an_instance_of(Filter), show_diffs: false, show_html: true, ip: "0.0.0.0", port: 3000)
-
-          run_command(
-            ["show", "description1", "--scope=packages", "--html", "--port=3000", "--ip=0.0.0.0"]
-          )
-        end
-      end
-
       describe "--verbose" do
         before(:each) do
           expect_any_instance_of(ShowTask).to receive(:show)
@@ -786,7 +774,7 @@ Backtrace:
     it "checks if a port requires root privileges" do
       expect { Cli.check_port_validity(1000) }.to raise_error(
         Machinery::Errors::InvalidCommandLine, "You need root rights when you want to use a port " \
-          "between 2 and 65535."
+          "between 2 and 1023."
       )
     end
   end

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -404,10 +404,19 @@ describe Cli do
       it "triggers the serve task" do
         description = create_test_description(json: test_manifest)
         expect_any_instance_of(ServeHtmlTask).to receive(:serve).with(
+          description, "127.0.0.1", 3000
+        )
+
+        run_command(["serve", "description1", "--port=3000"])
+      end
+
+      it "checks if the --public option works" do
+        description = create_test_description(json: test_manifest)
+        expect_any_instance_of(ServeHtmlTask).to receive(:serve).with(
           description, "0.0.0.0", 3000
         )
 
-        run_command(["serve", "description1", "--ip=0.0.0.0", "--port=3000"])
+        run_command(["serve", "description1", "--port=3000", "--public"])
       end
     end
 


### PR DESCRIPTION
For cleaning up some network binding commands, I removed the `-i` and `-p` function from `show` and `compare`. Both functions will now only listen on `127.0.0.1` because they are not intended to be an alias for `serve`. Since no port can be specified, the port will be set by the configuration in the `http_server_port` section. For the `serve` command, I replaced the `-i` option with the new option `--public` which makes the server listen on all configured IP addresses on the local machine.

The man page is up to date. I didn't mention my changes in the `compare` man page because the network features are still experimental.

This fixes #1341 
