### PR TITLE
Add missing helper requirement to gemspec

### DIFF
--- a/machinery.gemspec
+++ b/machinery.gemspec
@@ -64,6 +64,7 @@ Gem::Specification.new do |s|
     "machinery-helper/*.go",
     "machinery-helper/Rakefile",
     "machinery-helper/README.md",
+    "tools/build_helper.rb",
     ".git_revision"
   ]
   s.executables  = "machinery"


### PR DESCRIPTION
tools/build_helper.rb is required for the machinery-helper Rake task.