### PR TITLE
Parse YAML files during man page generation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -85,7 +85,7 @@ namespace :man_pages do
     manpage = ""
     Inspector.all_scopes.each do |scope|
       manpage += "* #{scope}\n\n"
-      manpage += File.read("plugins/#{scope}/#{scope}.md")
+      manpage += YAML.load_file("plugins/#{scope}/#{scope}.yml")[:description]
       manpage += "\n"
     end
     manpage += "\n"


### PR DESCRIPTION
The plugin md files were replaced by a YAML file. The man page
generation wasn't adapted before.