### PR TITLE
[Review] Request from 'aduffeck' @ 'SUSE/machinery/review_151019_fix_pluralization_in_html_view'

### DIFF
--- a/html/partials/compare/changed_managed_files.html.haml
+++ b/html/partials/compare/changed_managed_files.html.haml
@@ -11,25 +11,10 @@
       .col-xs-11
         %h2
           Changed Managed Files
-          .scope-summary
-            - if @diff["changed_managed_files"].only_in1
-              %span.summary-part
-                #{@description_a.name}:
-                #{safe_length(@diff["changed_managed_files"].only_in1, :files)} files
-            - if @diff["changed_managed_files"].only_in2
-              %span.summary-part
-                #{@description_b.name}:
-                #{safe_length(@diff["changed_managed_files"].only_in2, :files)} files
-            - if @diff["changed_managed_files"].changed
-              %span.summary-part
-                %a{ href: "#changed_managed_files_changed" }
-                  changed
-                = ": #{@diff["changed_managed_files"].changed.length} changed_managed_files"
-            - if @diff["changed_managed_files"].common
-              %span.summary-part
-                %a.show-common-elements{ href: "#changed_managed_files_both" }<
-                  both
-                = ": #{safe_length(@diff["changed_managed_files"].common, :files)} files"
+          = render_partial "compare/summary",
+            scope: "changed_managed_files",
+            singular: "file",
+            plural: "files"
     .row.scope_content.collapse.in
       .row
         .col-xs-1

--- a/html/partials/compare/config_files.html.haml
+++ b/html/partials/compare/config_files.html.haml
@@ -11,25 +11,10 @@
       .col-xs-11
         %h2
           Config Files
-          .scope-summary
-            - if @diff["config_files"].only_in1
-              %span.summary-part
-                #{@description_a.name}:
-                #{safe_length(@diff["config_files"].only_in1, :files)} files
-            - if @diff["config_files"].only_in2
-              %span.summary-part
-                #{@description_b.name}:
-                #{safe_length(@diff["config_files"].only_in2, :files)} files
-            - if @diff["config_files"].changed
-              %span.summary-part
-                %a{ href: "#config_files_changed" }
-                  changed
-                = ": #{@diff["config_files"].changed.length} config_files"
-            - if @diff["config_files"].common
-              %span.summary-part
-                %a.show-common-elements{ href: "#config_files_both" }<
-                  both
-                = ": #{safe_length(@diff["config_files"].common, :files)} files"
+          = render_partial "compare/summary",
+            scope: "config_files",
+            singular: "file",
+            plural: "files"
     .row.scope_content.collapse.in
       .row
         .col-xs-1

--- a/html/partials/compare/groups.html.haml
+++ b/html/partials/compare/groups.html.haml
@@ -11,23 +11,7 @@
       .col-xs-11
         %h2
           Groups
-          .scope-summary
-            - if @diff["groups"].only_in1
-              %span.summary-part
-                #{@description_a.name}: #{@diff["groups"].only_in1.length} groups
-            - if @diff["groups"].only_in2
-              %span.summary-part
-                #{@description_b.name}: #{@diff["groups"].only_in2.length} groups
-            - if @diff["groups"].changed
-              %span.summary-part
-                %a{ href: "#groups_changed" }
-                  changed
-                = ": #{@diff["groups"].changed.length} groups"
-            - if @diff["groups"].common
-              %span.summary-part
-                %a.show-common-elements{ href: "#groups_both" }<
-                  both
-                = ": #{@diff["groups"].common.length} groups"
+          = render_partial "compare/summary", scope: "groups", singular: "group", plural: "groups"
     .row.scope_content.collapse.in
       .row
         .col-xs-1

--- a/html/partials/compare/packages.html.haml
+++ b/html/partials/compare/packages.html.haml
@@ -11,23 +11,10 @@
       .col-xs-11
         %h2
           Packages
-          .scope-summary
-            - if @diff["packages"].only_in1
-              %span.summary-part
-                #{@description_a.name}: #{@diff["packages"].only_in1.length} packages
-            - if @diff["packages"].only_in2
-              %span.summary-part
-                #{@description_b.name}: #{@diff["packages"].only_in2.length} packages
-            - if @diff["packages"].changed
-              %span.summary-part
-                %a{ href: "#packages_changed" }
-                  changed
-                = ": #{@diff["packages"].changed.length} packages"
-            - if @diff["packages"].common
-              %span.summary-part
-                %a.show-common-elements{ href: "#packages_both" }<
-                  both
-                = ": #{@diff["packages"].common.length} packages"
+          = render_partial "compare/summary",
+            scope: "packages",
+            singular: "package",
+            plural: "packages"
     .row.scope_content.collapse.in
       .row
         .col-xs-1

--- a/html/partials/compare/patterns.html.haml
+++ b/html/partials/compare/patterns.html.haml
@@ -11,23 +11,10 @@
       .col-xs-11
         %h2
           Patterns
-          .scope-summary
-            - if @diff["patterns"].only_in1
-              %span.summary-part
-                #{@description_a.name}: #{@diff["patterns"].only_in1.length} patterns
-            - if @diff["patterns"].only_in2
-              %span.summary-part
-                #{@description_b.name}: #{@diff["patterns"].only_in2.length} patterns
-            - if @diff["patterns"].changed
-              %span.summary-part
-                %a{ href: "#patterns_changed" }
-                  changed
-                = ": #{@diff["patterns"].changed.length} patterns"
-            - if @diff["patterns"].common
-              %span.summary-part
-                %a.show-common-elements{ href: "#patterns_both" }<
-                  both
-                = ": #{@diff["patterns"].common.length} patterns"
+          = render_partial "compare/summary",
+            scope: "patterns",
+            singular: "pattern",
+            plural: "patterns"
     .row.scope_content.collapse.in
       .row
         .col-xs-1

--- a/html/partials/compare/repositories.html.haml
+++ b/html/partials/compare/repositories.html.haml
@@ -11,23 +11,10 @@
       .col-xs-11
         %h2
           Repositories
-          .scope-summary
-            - if @diff["repositories"].only_in1
-              %span.summary-part
-                #{@description_a.name}: #{@diff["repositories"].only_in1.length} repositories
-            - if @diff["repositories"].only_in2
-              %span.summary-part
-                #{@description_b.name}: #{@diff["repositories"].only_in2.length} repositories
-            - if @diff["repositories"].changed
-              %span.summary-part
-                %a{ href: "#repositories_changed" }
-                  changed
-                = ": #{@diff["repositories"].changed.length} repositories"
-            - if @diff["repositories"].common
-              %span.summary-part
-                %a.show-common-elements{ href: "#repositories_both" }<
-                  both
-                = ": #{@diff["repositories"].common.length} repositories"
+          = render_partial "compare/summary",
+            scope: "repositories",
+            singular: "repository",
+            plural: "repositories"
     .row.scope_content.collapse.in
       .row
         .col-xs-1

--- a/html/partials/compare/services.html.haml
+++ b/html/partials/compare/services.html.haml
@@ -12,26 +12,26 @@
         %h2
           Services
           .scope-summary
-            - if @diff["services"].only_in1
+            - if @diff["services"].only_in1 && @diff["services"].only_in1.length > 0
               %span.summary-part
                 #{@description_a.name}:
-                #{safe_length(@diff["services"].only_in1, :services)} services
+                #{pluralize_scope(@diff["services"].only_in1, "service", "services")}
                 (#{@diff["services"].only_in1.init_system})
-            - if @diff["services"].only_in2
+            - if @diff["services"].only_in2 && @diff["services"].only_in2.length > 0
               %span.summary-part
                 #{@description_b.name}:
-                #{safe_length(@diff["services"].only_in2, :services)} services
+                #{pluralize_scope(@diff["services"].only_in2, "service", "services")}
                 (#{@diff["services"].only_in2.init_system})
-            - if @diff["services"].changed
+            - if @diff["services"].changed && @diff["services"].changed.length > 0
               %span.summary-part
                 %a{ href: "#services_changed" }
                   changed
-                = ": #{@diff["services"].changed.length} services"
-            - if @diff["services"].common
+                = ": #{pluralize_scope(@diff["services"].changed, "service", "services")}"
+            - if @diff["services"].common && @diff["services"].common.length > 0
               %span.summary-part
                 %a.show-common-elements{ href: "#services_both" }<
                   both
-                = ": #{safe_length(@diff["services"].common, :services)} services"
+                = ": #{pluralize_scope(@diff["services"].common, "service", "services")}"
     .row.scope_content.collapse.in
       .row
         .col-xs-1

--- a/html/partials/compare/summary.html.haml
+++ b/html/partials/compare/summary.html.haml
@@ -1,16 +1,16 @@
 .scope-summary
-  - if @diff[scope].only_in1
+  - if @diff[scope].only_in1 && @diff[scope].only_in1.length > 0
     %span.summary-part
       #{@description_a.name}: #{pluralize_scope(@diff[scope].only_in1, singular, plural)}
-  - if @diff[scope].only_in2
+  - if @diff[scope].only_in2 && @diff[scope].only_in2.length > 0
     %span.summary-part
       #{@description_b.name}: #{pluralize_scope(@diff[scope].only_in2, singular, plural)}
-  - if @diff[scope].changed
+  - if @diff[scope].changed && @diff[scope].changed.length > 0
     %span.summary-part
       %a{ href: "#" + scope + "_changed" }
         changed
       = ": #{pluralize_scope(@diff[scope].changed, singular, plural)}"
-  - if @diff[scope].common
+  - if @diff[scope].common && @diff[scope].common.length > 0
     %span.summary-part
       %a.show-common-elements{ href: "#" + scope + "_both" }<
         both

--- a/html/partials/compare/summary.html.haml
+++ b/html/partials/compare/summary.html.haml
@@ -1,0 +1,17 @@
+.scope-summary
+  - if @diff[scope].only_in1
+    %span.summary-part
+      #{@description_a.name}: #{pluralize_scope(@diff[scope].only_in1, singular, plural)}
+  - if @diff[scope].only_in2
+    %span.summary-part
+      #{@description_b.name}: #{pluralize_scope(@diff[scope].only_in2, singular, plural)}
+  - if @diff[scope].changed
+    %span.summary-part
+      %a{ href: "#" + scope + "_changed" }
+        changed
+      = ": #{pluralize_scope(@diff[scope].changed, singular, plural)}"
+  - if @diff[scope].common
+    %span.summary-part
+      %a.show-common-elements{ href: "#" + scope + "_both" }<
+        both
+      = ": #{pluralize_scope(@diff[scope].common, singular, plural)}"

--- a/html/partials/compare/unmanaged_files.html.haml
+++ b/html/partials/compare/unmanaged_files.html.haml
@@ -15,21 +15,21 @@
             - if @diff["unmanaged_files"].only_in1
               %span.summary-part
                 #{@description_a.name}:
-                #{safe_length(@diff["unmanaged_files"].only_in1, :files)} files
+                = pluralize_scope(@diff["unmanaged_files"].only_in1, "file", "files")
             - if @diff["unmanaged_files"].only_in2
               %span.summary-part
                 #{@description_b.name}:
-                #{safe_length(@diff["unmanaged_files"].only_in2, :files)} files
+                = pluralize_scope(@diff["unmanaged_files"].only_in2, "file", "files")
             - if @diff["unmanaged_files"].changed
               %span.summary-part
                 %a{ href: "#unmanaged_files_changed" }
                   changed
-                = ": #{@diff["unmanaged_files"].changed.length} files"
+                = ": #{pluralize_scope(@diff["unmanaged_files"].changed, "file", "files")}"
             - if @diff["unmanaged_files"].common
               %span.summary-part
                 %a.show-common-elements{ href: "#unmanaged_files_both" }<
                   both
-                = ": #{safe_length(@diff["unmanaged_files"].common, :files)} files"
+                = ": #{pluralize_scope(@diff["unmanaged_files"].common, "file", "files")}"
             - if diffable_unmanaged_files.length > 0
               %span.summary-part
                 %a#diff-unmanaged-files{ "data-toggle" => "modal",

--- a/html/partials/compare/users.html.haml
+++ b/html/partials/compare/users.html.haml
@@ -11,23 +11,10 @@
       .col-xs-11
         %h2
           Users
-          .scope-summary
-            - if @diff["users"].only_in1
-              %span.summary-part
-                #{@description_a.name}: #{@diff["users"].only_in1.length} users
-            - if @diff["users"].only_in2
-              %span.summary-part
-                #{@description_b.name}: #{@diff["users"].only_in2.length} users
-            - if @diff["users"].changed
-              %span.summary-part
-                %a{ href: "#users_changed" }
-                  changed
-                = ": #{@diff["users"].changed.length} users"
-            - if @diff["users"].common
-              %span.summary-part
-                %a.show-common-elements{ href: "#users_both" }<
-                  both
-                = ": #{@diff["users"].common.length} users"
+          = render_partial "compare/summary",
+            scope: "users",
+            singular: "user",
+            plural: "users"
     .row.scope_content.collapse.in
       .row
         .col-xs-1

--- a/lib/file_scope.rb
+++ b/lib/file_scope.rb
@@ -32,6 +32,10 @@ class FileScope < Machinery::Object
     [only_self, only_other, changed, shared]
   end
 
+  def length
+    files.try(:length) || 0
+  end
+
   private
 
   def validate_attributes(other)

--- a/lib/server.rb
+++ b/lib/server.rb
@@ -83,6 +83,10 @@ class Server < Sinatra::Base
       "<h3>In both with different attributes:</h3>"
     end
 
+    def pluralize_scope(object, singular, plural)
+      object.length.to_s + " " + Machinery.pluralize(object.length, singular, plural)
+    end
+
     def changed_elements(scope, opts)
       optional_attributes = opts[:optional_attributes] || []
 

--- a/plugins/services/services_model.rb
+++ b/plugins/services/services_model.rb
@@ -55,6 +55,10 @@ class ServicesScope < Machinery::Object
     end
   end
 
+  def length
+    services.try(:length) || 0
+  end
+
   private
 
   def service_list_to_scope(services)

--- a/spec/unit/models/services_model_spec.rb
+++ b/spec/unit/models/services_model_spec.rb
@@ -27,91 +27,97 @@ describe "services model" do
 
   specify { expect(scope.services).to be_a(ServiceList) }
   specify { expect(scope.services.first).to be_a(Service) }
-end
 
-describe ServicesScope do
-  describe "#compare_with" do
-    let(:service_a) { Service::new(name: "a", state: "enabled") }
-    let(:service_b) { Service::new(name: "b", state: "enabled") }
-    let(:service_c) { Service::new(name: "c", state: "enabled") }
-    let(:service_d) { Service::new(name: "d", state: "enabled") }
-    let(:service_e) { Service::new(name: "e", state: "enabled") }
-    let(:service_f) { Service::new(name: "f", state: "enabled") }
-
-    context "when init systems are the same" do
-      it "returns correct result when service lists are equal" do
-        data_a = ServicesScope.new(
-          init_system: "systemd",
-          services: [service_a, service_b, service_c]
-        )
-        data_b = ServicesScope.new(
-          init_system: "systemd",
-          services: [service_a, service_b, service_c]
-        )
-
-        comparison = data_a.compare_with(data_b)
-        expect(comparison).to eq([nil, nil, nil, data_a])
-      end
-
-      it "returns correct result when service lists aren't equal and don't have common elements" do
-        data_a = ServicesScope.new(
-          init_system: "systemd",
-          services: [service_a, service_b, service_c]
-        )
-        data_b = ServicesScope.new(
-          init_system: "systemd",
-          services: [service_d, service_e, service_f]
-        )
-
-        comparison = data_a.compare_with(data_b)
-
-        expect(comparison).to eq([data_a, data_b, nil, nil])
-      end
-
-      it "returns correct result when service lists aren't equal but have common elements" do
-        data_a = ServicesScope.new(
-          init_system: "systemd",
-          services: [service_a, service_b, service_c, service_d]
-        )
-        data_b = ServicesScope.new(
-          init_system: "systemd",
-          services: [service_a, service_b, service_e, service_f]
-        )
-
-        comparison = data_a.compare_with(data_b)
-
-        expect(comparison).to eq([
-          ServicesScope.new(
-            init_system: "systemd",
-            services: [service_c, service_d]
-          ),
-          ServicesScope.new(
-            init_system: "systemd",
-            services: [service_e, service_f]
-          ),
-          nil,
-          ServicesScope.new(
-            init_system: "systemd",
-            services: [service_a, service_b]
-          )
-        ])
+  describe ServicesScope do
+    describe "#length" do
+      it "returns the number of services" do
+        expect(scope.length).to eq(10)
       end
     end
 
-    context "when init systems are different" do
-      it "treats the data as completely different" do
-        data_a = ServicesScope.new(
-          init_system: "sysvinit",
-          services: [service_a, service_b, service_c]
-        )
-        data_b = ServicesScope.new(
-          init_system: "systemd",
-          services: [service_a, service_b, service_c]
-        )
+    describe "#compare_with" do
+      let(:service_a) { Service.new(name: "a", state: "enabled") }
+      let(:service_b) { Service.new(name: "b", state: "enabled") }
+      let(:service_c) { Service.new(name: "c", state: "enabled") }
+      let(:service_d) { Service.new(name: "d", state: "enabled") }
+      let(:service_e) { Service.new(name: "e", state: "enabled") }
+      let(:service_f) { Service.new(name: "f", state: "enabled") }
 
-        comparison = data_a.compare_with(data_b)
+      context "when init systems are the same" do
+        it "returns correct result when service lists are equal" do
+          data_a = ServicesScope.new(
+            init_system: "systemd",
+            services:    [service_a, service_b, service_c]
+          )
+          data_b = ServicesScope.new(
+            init_system: "systemd",
+            services:    [service_a, service_b, service_c]
+          )
 
-        expect(comparison).to eq([data_a, data_b, nil, nil])
+          comparison = data_a.compare_with(data_b)
+          expect(comparison).to eq([nil, nil, nil, data_a])
+        end
+
+        it "returns correct result when service lists aren't equal and don't have common elements" do
+          data_a = ServicesScope.new(
+            init_system: "systemd",
+            services:    [service_a, service_b, service_c]
+          )
+          data_b = ServicesScope.new(
+            init_system: "systemd",
+            services:    [service_d, service_e, service_f]
+          )
+
+          comparison = data_a.compare_with(data_b)
+
+          expect(comparison).to eq([data_a, data_b, nil, nil])
+        end
+
+        it "returns correct result when service lists aren't equal but have common elements" do
+          data_a = ServicesScope.new(
+            init_system: "systemd",
+            services: [service_a, service_b, service_c, service_d]
+          )
+          data_b = ServicesScope.new(
+            init_system: "systemd",
+            services: [service_a, service_b, service_e, service_f]
+          )
+
+          comparison = data_a.compare_with(data_b)
+
+          expect(comparison).to eq([
+            ServicesScope.new(
+              init_system: "systemd",
+              services:    [service_c, service_d]
+            ),
+            ServicesScope.new(
+              init_system: "systemd",
+              services:    [service_e, service_f]
+            ),
+            nil,
+            ServicesScope.new(
+              init_system: "systemd",
+              services:    [service_a, service_b]
+            )
+          ])
+        end
+      end
+
+      context "when init systems are different" do
+        it "treats the data as completely different" do
+          data_a = ServicesScope.new(
+            init_system: "sysvinit",
+            services:    [service_a, service_b, service_c]
+          )
+          data_b = ServicesScope.new(
+            init_system: "systemd",
+            services:    [service_a, service_b, service_c]
+          )
+
+          comparison = data_a.compare_with(data_b)
+
+          expect(comparison).to eq([data_a, data_b, nil, nil])
+        end
       end
     end
   end

--- a/spec/unit/models/services_model_spec.rb
+++ b/spec/unit/models/services_model_spec.rb
@@ -58,7 +58,7 @@ describe "services model" do
           expect(comparison).to eq([nil, nil, nil, data_a])
         end
 
-        it "returns correct result when service lists aren't equal and don't have common elements" do
+        it "returns correct result when lists aren't equal and don't have common elements" do
           data_a = ServicesScope.new(
             init_system: "systemd",
             services:    [service_a, service_b, service_c]
@@ -76,11 +76,11 @@ describe "services model" do
         it "returns correct result when service lists aren't equal but have common elements" do
           data_a = ServicesScope.new(
             init_system: "systemd",
-            services: [service_a, service_b, service_c, service_d]
+            services:    [service_a, service_b, service_c, service_d]
           )
           data_b = ServicesScope.new(
             init_system: "systemd",
-            services: [service_a, service_b, service_e, service_f]
+            services:    [service_a, service_b, service_e, service_f]
           )
 
           comparison = data_a.compare_with(data_b)

--- a/spec/unit/models/unmanaged_files_model_spec.rb
+++ b/spec/unit/models/unmanaged_files_model_spec.rb
@@ -30,6 +30,12 @@ describe "unmanaged_files model" do
   specify { expect(scope.files.first).to be_a(UnmanagedFile) }
 
   describe UnmanagedFilesScope do
+    describe "#length" do
+      it "returns the number of files" do
+        expect(scope.length).to eq(3)
+      end
+    end
+
     describe "#compare_with" do
       it "shows a warning when comparing unextracted with extracted files" do
         scope_a = UnmanagedFilesScope.new(extracted: false, files: UnmanagedFileList.new([]))


### PR DESCRIPTION
Please review the following changes:
  * 4d7f4f0 Only show summary sections if there is according content
  * 4019918 DRY up the scope summary section. Fix pluralization.
  * dec2a05 Make `scope.length` also work for non-array scopes