### PR TITLE
Add package building to prophet integration test

### DIFF
--- a/prophet/prophet_integration.rb
+++ b/prophet/prophet_integration.rb
@@ -78,7 +78,10 @@ Prophet.setup do |config|
     config.execution do
       log.info "Running tests ..."
 
-      system("cd ..; (bundle check || sudo bundle install) && rspec spec/integration --tag=ci")
+      system(
+        "cd ..; (bundle check || sudo bundle install) && rake rpm:build &&" \
+          " rspec spec/integration --tag=ci"
+      )
       config.success = ($? == 0)
 
       log.info "Tests are #{config.success ? "passing" : "failing"}."


### PR DESCRIPTION
We had two cases of broken integration tests because the package
building was broken in master.
This change should prevent it for most parts.

Squashed #1517 