### PR TITLE
Fix wrong alert when a scope is missing from both descriptions

### DIFF
--- a/lib/server.rb
+++ b/lib/server.rb
@@ -231,7 +231,7 @@ class Server < Sinatra::Base
     Inspector.all_scopes.each do |scope|
       if @description_a[scope] && @description_b[scope]
         @diff[scope] = Comparison.compare_scope(@description_a, @description_b, scope)
-      else
+      elsif @description_a[scope] || @description_b[scope]
         @meta[:uninspected] ||= Hash.new
 
         if !@description_a[scope] && @description_b[scope]

--- a/lib/server.rb
+++ b/lib/server.rb
@@ -234,11 +234,11 @@ class Server < Sinatra::Base
       elsif @description_a[scope] || @description_b[scope]
         @meta[:uninspected] ||= Hash.new
 
-        if !@description_a[scope] && @description_b[scope]
+        if !@description_a[scope]
           @meta[:uninspected][@description_a.name] ||= Array.new
           @meta[:uninspected][@description_a.name] << scope
         end
-        if !@description_b[scope] && @description_a[scope]
+        if !@description_b[scope]
           @meta[:uninspected][@description_b.name] ||= Array.new
           @meta[:uninspected][@description_b.name] << scope
         end


### PR DESCRIPTION
Fixes #1508
