### PR TITLE
[Review] Request from 'greygoo' @ 'SUSE/machinery/review_151021_use_encodeuri_to_escape_download_links_in_the_browser_view_'

### DIFF
--- a/html/assets/show/machinery.js
+++ b/html/assets/show/machinery.js
@@ -84,7 +84,7 @@ $(document).ready(function () {
     var file = $(this);
     var scope = file.parents(".scope").data("scope");
     var description = $("body").data("description");
-    var url = "/descriptions/" + description + "/files/" + scope + file.text().trim();
+    var url = encodeURI("/descriptions/" + description + "/files/" + scope + file.text().trim());
 
     $("#file-modal-download-link").attr("href", url);
     $.get(url, function(res) {


### PR DESCRIPTION
Please review the following changes:
  * 8696e05 Use encodeURI to escape the download urls in the html view.
  * d5ae93d Merge pull request #1535 from SUSE/show_container_type_3
  * 6e5c45b Improve layout for show --verbose
  * 8b498cd Merge pull request #1534 from SUSE/add_html_file_progress_indicator2
  * 4f38350 Show progress indicator while loading file content in HTML view