### PR TITLE
Create version.go even if .git_revision does already exist

### DIFF
--- a/spec/unit/helper_builder_spec.rb
+++ b/spec/unit/helper_builder_spec.rb
@@ -97,6 +97,16 @@ describe HelperBuilder do
         expect(File.exist?(version_file)).to be(true)
       end
 
+      it "creates version.go if it got removed but .git_revision still exist" do
+        version_file = File.join(helper_dir, "version.go")
+        git_revision_file = File.join(helper_dir, "..", ".git_revision")
+        subject.write_git_revision_file
+        expect(File.exist?(git_revision_file)).to be(true)
+        expect(File.exist?(version_file)).to be(false)
+        expect(subject.run_build).to be(true)
+        expect(File.exist?(version_file)).to be(true)
+      end
+
       it "creates git revision file after successful build" do
         git_revision_file = File.join(helper_dir, "..", ".git_revision")
         expect(File.exist?(git_revision_file)).to be(false)
@@ -135,6 +145,7 @@ describe HelperBuilder do
       it "does not build go binary if source files are older than binary" do
         FileUtils.touch(File.join(helper_dir, "machinery-helper"))
         FileUtils.touch(File.join(helper_dir, "machinery_helper.go"), mtime: Time.now.to_i - 10)
+        FileUtils.touch(File.join(helper_dir, "version.go"), mtime: Time.now.to_i - 10)
         expect(subject).not_to receive(:run_go_build)
         expect(subject.run_build).to be(true)
       end

--- a/tools/helper_builder.rb
+++ b/tools/helper_builder.rb
@@ -31,7 +31,7 @@ class HelperBuilder
     return false if !go_available?
 
     # handle changed branches (where go files are older than the helper)
-    if runs_in_git? && changed_revision?
+    if runs_in_git? && (changed_revision? || !File.exist?(@go_version_file))
       write_go_version_file
       if build_machinery_helper
         write_git_revision_file

--- a/tools/helper_builder.rb
+++ b/tools/helper_builder.rb
@@ -22,6 +22,7 @@ class HelperBuilder
   def initialize(helper_dir)
     @helper_dir = helper_dir
     @git_revision_file = File.join(helper_dir, "..", ".git_revision")
+    @go_version_file = File.join(helper_dir, "version.go")
   end
 
   def run_build
@@ -56,7 +57,7 @@ package main
 
 const VERSION = "#{git_revision}"
     EOF
-    File.write(File.join(@helper_dir, "version.go"), file)
+    File.write(@go_version_file, file)
   end
 
   def build_machinery_helper


### PR DESCRIPTION
If `rake build` is run the first time in machinery-helper the file
.git_revision and machinery-helper/version.go is created.
If version.go is removed but .git_revision stays building of
machinery-helper fails. This is fixed by this additional check.
