### PR TITLE
Allow changed button to open a collapsed scope

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 # Machinery Release Notes
 
+* Fix: "changed" link in compare view is visible while scope is collapsed but
+  doesn't do anything (gh#SUSE/machinery#1555)
 
 ## Version 1.15.0 - Mon Oct 26 17:42:25 CET 2015 - thardeck@suse.de
 

--- a/html/assets/compare/machinery.js
+++ b/html/assets/compare/machinery.js
@@ -70,6 +70,18 @@ $(document).ready(function () {
     return false;
   });
 
+  $(".show-changed-elements").click(function(){
+    $scope = $(this).closest(".scope");
+    if ($scope.find(".toggle").hasClass("collapsed")){
+      $scope.find(".scope_content").collapse("show");
+      $scope.find(".toggle").removeClass("collapsed");
+    }
+    if ($(this).attr("href")){
+      $('html,body').animate({scrollTop: $($(this).attr("href")).offset().top}, 'slow');
+    }
+    return false;
+  });
+
   // Unmanaged files diffs
   $("#diff-unmanaged-files").on("show.bs.modal", function(e) {
     var trigger = $(e.relatedTarget);

--- a/html/partials/compare/services.html.haml
+++ b/html/partials/compare/services.html.haml
@@ -25,7 +25,7 @@
                 (#{@diff["services"].only_in2.init_system})
             - if @diff["services"].changed && @diff["services"].changed.length > 0
               %span.summary-part
-                %a{ href: "#services_changed" }
+                %a.show-changed-elements{ href: "#services_changed" }
                   changed
                 = ": #{pluralize_scope(@diff["services"].changed, "service", "services")}"
             - if @diff["services"].common && @diff["services"].common.length > 0

--- a/html/partials/compare/summary.html.haml
+++ b/html/partials/compare/summary.html.haml
@@ -7,7 +7,7 @@
       #{@description_b.name}: #{pluralize_scope(@diff[scope].only_in2, singular, plural)}
   - if @diff[scope].changed && @diff[scope].changed.length > 0
     %span.summary-part
-      %a{ href: "#" + scope + "_changed" }
+      %a.show-changed-elements{ href: "#" + scope + "_changed" }
         changed
       = ": #{pluralize_scope(@diff[scope].changed, singular, plural)}"
   - if @diff[scope].common && @diff[scope].common.length > 0

--- a/html/partials/compare/unmanaged_files.html.haml
+++ b/html/partials/compare/unmanaged_files.html.haml
@@ -23,7 +23,7 @@
                 = pluralize_scope(@diff["unmanaged_files"].only_in2, "file", "files")
             - if @diff["unmanaged_files"].changed
               %span.summary-part
-                %a{ href: "#unmanaged_files_changed" }
+                %a.show-changed-elements{ href: "#unmanaged_files_changed" }
                   changed
                 = ": #{pluralize_scope(@diff["unmanaged_files"].changed, "file", "files")}"
             - if @diff["unmanaged_files"].common

--- a/spec/features/compare_descriptions_spec.rb
+++ b/spec/features/compare_descriptions_spec.rb
@@ -65,4 +65,23 @@ RSpec::Steps.steps "Comparing two system descriptions in HTML format", type: :fe
       expect(page).to have_selector(".hide-common-elements")
     end
   end
+
+  it "expands a collapsed scope if `changed` is clicked" do
+    # Note: this reload is a workaround for some poltergeist/phantomjs issue with scrolling to
+    # anchors
+    visit("/compare/opensuse131/opensuse132")
+
+    within(".scope-navigation") do
+      find_link("G").click
+    end
+
+    within("#groups_container") do
+      expect(page).to have_selector(".scope_content table")
+      find(".toggle").trigger("click")
+      expect(page).to have_no_selector(".scope_content table")
+
+      find(".show-changed-elements").trigger("click")
+      expect(page).to have_selector(".scope_content table")
+    end
+  end
 end


### PR DESCRIPTION
supersedes #1560 
fixes #1555 