### PR TITLE
[Review] Request from 'greygoo' @ 'SUSE/machinery/review_151106_fix_vagrantfile_to_work_with_later_vagrant_libvirt_versions'

### DIFF
--- a/spec/definitions/vagrant/Vagrantfile
+++ b/spec/definitions/vagrant/Vagrantfile
@@ -37,7 +37,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.define :machinery_openSUSE_13_1 do |machinery_131|
     machinery_131.vm.box = "machinery_opensuse13.1_kvm"
-    machinery_131.vm.network :private_network, network_name: "default"
+    machinery_131.vm.network :public_network,
+      :dev => "virbr0",
+      :mode => "bridge",
+      :type => "bridge"
 
     machinery_131.vm.provider :libvirt do |domain|
       domain.memory = 1024
@@ -68,7 +71,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.define :machinery_openSUSE_13_2 do |machinery_132|
     machinery_132.vm.box = "machinery_opensuse13.2_kvm"
-    machinery_132.vm.network :private_network, network_name: "default"
+    machinery_132.vm.network :public_network,
+      :dev => "virbr0",
+      :mode => "bridge",
+      :type => "bridge"
 
     machinery_132.vm.provider :libvirt do |domain|
       domain.memory = 1024
@@ -99,7 +105,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.define :machinery_Tumbleweed do |machinery_tumbleweed|
     machinery_tumbleweed.vm.box = "machinery_opensuse_tumbleweed_kvm"
-    machinery_tumbleweed.vm.network :private_network, network_name: "default"
+    machinery_tumbleweed.vm.network :public_network,
+      :dev => "virbr0",
+      :mode => "bridge",
+      :type => "bridge"
 
     machinery_tumbleweed.vm.provider :libvirt do |domain|
       domain.memory = 1024


### PR DESCRIPTION
Please review the following changes:
  * 0c7d126 Fix network setup to work with later versions of libvirt-vagrant.
  * 6825271 package 1.16.0
  * f5f2a71 Merge pull request #1606 from SUSE/add_tracking_bug_for_1_16
  * 4fbb810 Add Tracking bug for release 1.16
  * a75a08e Merge pull request #1604 from SUSE/modify_news_entry
  * 5f08eff Changelog: Clean up misleading error message about duplicate ports
  * 11d6b6c Merge pull request #1603 from SUSE/add_opensuse_leap_2
  * bfed9c4 Add openSUSE Leap support to NEWS file
  * b0f93e4 Add openSUSE Leap integration tests
  * 0c2a98e Fix Inspector Files script
  * dea2f62 Add openSUSE Leap recognition and support
  * d64bd2e Add Machinery Leap image
  * b255663 Add openSUSE Leap base image
  * 253d094 Merge pull request #1601 from SUSE/issue1541_2
  * f9ee17c Fix misleading `port already in use` message
  * 0ca2129 Merge pull request #1600 from SUSE/line_2
  * a1cff3e Split line which is too long (over 100 characters)
  * 24e8375 Merge pull request #1598 from SUSE/fix_mouse_pointer_in_diff_view
  * 0ed7d0f Add cursor to `(diff)` link in compare view
  * f266160 Merge pull request #1595 from SUSE/mark_html_compare_as_non_experimental_2
  * ab2bb97 Add NEWS entry for HTML comparison
  * 9b25a8c Remove experimental flag for HTML comparison
  * 5c2611e Merge pull request #1594 from SUSE/issue1580_2
  * 0a1832b Changelog: Fix crash with special characters in folder name
  * 99d4b10 Fix crash with special characters in folder name
  * 7850a30 Merge pull request #1592 from SUSE/fix_1490_2
  * 35592e9 Add error message when a container with slashes is inspected
  * ac652f3 Add NEWS entry for 1490 fix
  * dbe3ed9 Merge pull request #1590 from SUSE/review_151029_speed_up_config_files_and_changed_managed_files_inspection
  * 01cc626 Simplify the changed_files.sh script by moving the sudo failure check