### PR TITLE
Add SLES11SP4 recognition

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 # Machinery Release Notes
 
+* Fix SLES 11 SP4 os inspector output to be similar to SLES 11 SP3
 
 ## Version 1.16.1 - Mon Nov 09 17:55:15 CET 2015 - thardeck@suse.de
 

--- a/plugins/os/os_inspector.rb
+++ b/plugins/os/os_inspector.rb
@@ -99,6 +99,13 @@ class OsInspector < Inspector
       if result["pretty_name"] =~ /^openSUSE.*Leap/
         result["pretty_name"] = "openSUSE Leap"
       end
+
+      # converts SLES11 SP4 result to SP3 style
+      # the results are different because SP4 has an os-release
+      if result["pretty_name"] =~ /^SUSE Linux Enterprise Server 11 (SP\d)$/
+        result["pretty_name"] = "SUSE Linux Enterprise Server 11"
+        result["version"] = "11 #{$1}"
+      end
     end
     # return pretty_name as name as it contains the actual full length
     # name instead of an abbreviation

--- a/spec/data/os/SLES11SP4/etc/SuSE-release
+++ b/spec/data/os/SLES11SP4/etc/SuSE-release
@@ -1,0 +1,3 @@
+SUSE Linux Enterprise Server 11 (x86_64)
+VERSION = 11
+PATCHLEVEL = 4

--- a/spec/data/os/SLES11SP4/etc/os-release
+++ b/spec/data/os/SLES11SP4/etc/os-release
@@ -1,0 +1,7 @@
+NAME="SLES"
+VERSION="11.4"
+VERSION_ID="11.4"
+PRETTY_NAME="SUSE Linux Enterprise Server 11 SP4"
+ID="sles"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sles:11:4"

--- a/spec/unit/os_inspector_spec.rb
+++ b/spec/unit/os_inspector_spec.rb
@@ -182,6 +182,21 @@ describe OsInspector do
       expect(description.os).to be_a(OsOpenSuseLeap)
     end
 
+    it "is able to recognize SLES11SP4" do
+      FakeFS::FileSystem.clone("spec/data/os/SLES11SP4/etc/",
+        "/etc/")
+
+      expect(system).to receive(:arch).and_return("x86_64")
+
+      inspector.inspect(filter)
+
+      expect(description.os.name).to eq "SUSE Linux Enterprise Server 11"
+      expect(description.os.version).to eq("11 SP4")
+      expect(description.os.architecture).to eq "x86_64"
+      expect(inspector.summary).to include("SUSE Linux Enterprise Server 11")
+      expect(description.os).to be_a(OsSles11)
+    end
+
     it "returns data containing additional version information if available" do
       FakeFS::FileSystem.clone("spec/data/os/SLES12/etc/os-release",
         "/etc/os-release")


### PR DESCRIPTION
SLES11 SP4 has unlike SP3 an os-release file which results in a
different output then the SP3 release which only ahd th deprecated
SuSE-release file.

Fixes #1614 