### PR TITLE
Fix remote dir line break2

### DIFF
--- a/lib/renderer.rb
+++ b/lib/renderer.rb
@@ -254,7 +254,11 @@ class Renderer
 
   def print_indented(s)
     s.split("\n", -1).each do |line|
-      @buffer += " " * @indent + line + "\n"
+      if line.empty?
+        @buffer += "\n"
+      else
+        @buffer += " " * @indent + line + "\n"
+      end
     end
   end
 

--- a/lib/renderer.rb
+++ b/lib/renderer.rb
@@ -253,7 +253,7 @@ class Renderer
   private
 
   def print_indented(s)
-    s.split("\n").each do |line|
+    s.split("\n", -1).each do |line|
       @buffer += " " * @indent + line + "\n"
     end
   end

--- a/plugins/unmanaged_files/unmanaged_files_renderer.rb
+++ b/plugins/unmanaged_files/unmanaged_files_renderer.rb
@@ -30,9 +30,9 @@ class UnmanagedFilesRenderer < Renderer
 
       if description["unmanaged_files"].files
         description["unmanaged_files"].files.each do |p|
-          if p.user && p.group
+          if description["unmanaged_files"].extracted
             item "#{p.name} (#{p.type})" do
-              puts "User/Group: #{p.user}:#{p.group}"
+              puts "User/Group: #{p.user}:#{p.group}" if p.user || p.group
               puts "Mode: #{p.mode}" if p.mode
               puts "Size: #{number_to_human_size(p.size)}" if p.size
               puts "Files: #{p.files}" if p.files

--- a/spec/data/unmanaged_files/opensuse131
+++ b/spec/data/unmanaged_files/opensuse131
@@ -468,7 +468,9 @@
     Files: 1
 
   * /mnt/unmanaged/remote-dir/ (remote_dir)
+
   * /remote-dir/ (remote_dir)
+
   * /root/.bash_history (file)
     User/Group: root:root
     Mode: 600

--- a/spec/data/unmanaged_files/opensuse132
+++ b/spec/data/unmanaged_files/opensuse132
@@ -256,7 +256,9 @@
     Files: 1
 
   * /mnt/unmanaged/remote-dir/ (remote_dir)
+
   * /remote-dir/ (remote_dir)
+
   * /root/.bash_history (file)
     User/Group: root:root
     Mode: 600

--- a/spec/data/unmanaged_files/opensuse_leap
+++ b/spec/data/unmanaged_files/opensuse_leap
@@ -268,6 +268,7 @@
     Files: 2
 
   * /mnt/unmanaged/remote-dir/ (remote_dir)
+
   * /opt/test-quote-char/test-dir-name-with-' quote-char '/unmanaged-dir-with-' quote '/ (dir)
     User/Group: root:root
     Mode: 755
@@ -280,6 +281,7 @@
     Size: 3 B
 
   * /remote-dir/ (remote_dir)
+
   * /root/.bash_history (file)
     User/Group: root:root
     Mode: 600

--- a/spec/unit/unmanaged_files_renderer_spec.rb
+++ b/spec/unit/unmanaged_files_renderer_spec.rb
@@ -171,7 +171,7 @@ EOF
       actual_output = UnmanagedFilesRenderer.new.render(description_remote_dir)
       expected_output = <<EOF.chomp
   * /mnt/unmanaged/remote-dir/ (remote_dir)
-  
+
   * /etc/alternatives/awk (link)
     User/Group: root:root
 EOF


### PR DESCRIPTION
Squashed #1634

This fixes the remote_dir line break issue which looked like this:
```
  * /mnt/unmanaged/ (dir)
    User/Group: root:root
    Mode: 755
    Size: 0 B
    Files: 1

  * /mnt/unmanaged/remote-dir/ (remote_dir)
  * /remote-dir/ (remote_dir)
  * /root/.bash_history (file)
    User/Group: root:root
    Mode: 600
    Size: 0 B
```

```
  * /mnt/unmanaged/ (dir)
    User/Group: root:root
    Mode: 755
    Size: 0 B
    Files: 1

  * /mnt/unmanaged/remote-dir/ (remote_dir)

  * /remote-dir/ (remote_dir)

  * /root/.bash_history (file)
    User/Group: root:root
    Mode: 600
    Size: 0 B
```

I have changed the unmanaged-files renderer to relate to the extracted status so single lines don't get a break like it used to be before.
```
  * /etc/.pwd.lock (file)
  * /etc/ImageVersion (file)
  * /etc/YaST2/licenses/ (dir)
  * /etc/alternatives/openSUSE-default.xml (link)
  * /etc/auto.remote_dir (file)
```