### PR TITLE
Don't show hint for `show`, when `inspect` is run with `--show` option

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,8 @@
 
 * Fix Machinery failing to inspect changed config files in case of restrictive
   permissions (gh#SUSE/machinery#1609)
+* Remove hint for `show`, when `inspect` is run with `--show` option
+  (gh#SUSE/machinery#1648)
 * Fix repository inspection on hosts that have a LANGUAGE variable set
 * Empty scopes now display a message in HTML & CLI views (gh#SUSE/machinery#1615)
 * Fix SLES 11 SP4 os inspector output to be similar to SLES 11 SP3

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -616,7 +616,7 @@ class Cli
         inspect_options
       )
 
-      Hint.print(:show_data, name: name)
+      Hint.print(:show_data, name: name) if options[:show] == false
 
       if !options["extract-files"] || Inspector.all_scopes.count != scope_list.count
         Hint.print(:do_complete_inspection, name: name, host: host)

--- a/spec/integration/support/command_line_examples.rb
+++ b/spec/integration/support/command_line_examples.rb
@@ -68,6 +68,24 @@ shared_examples "CLI" do
           )
         ).to fail.and include_stderr("The following scope is not supported: foobar")
       end
+
+      it "does not print a hint when --show is used" do
+        expect(
+          @machinery.run_command(
+            "sudo #{machinery_command} inspect localhost --scope=users --name=test --show",
+            as: "vagrant"
+          )
+        ).to succeed.and not_include_stdout("To show the data of the system you just inspected run")
+      end
+
+      it "does show a hint when --show is not used" do
+        expect(
+          @machinery.run_command(
+            "sudo #{machinery_command} inspect localhost --scope=users --name=test",
+            as: "vagrant"
+          )
+        ).to succeed.and include_stdout("To show the data of the system you just inspected run")
+      end
     end
 
     describe "build" do


### PR DESCRIPTION
Related to #1648
Squashes & Supersedes #1655 