### PR TITLE
Add note for `serve --public` that every description is accessible

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,8 @@
   directory for the `build` command (gh#SUSE/machinery#1667)
 * Fix wrong hint for docker containers while running `analyze` command
   (gh#SUSE/machinery#1632)
+* Add a new hint when using the `--public` option for the `serve` command that it
+  makes all descriptions publicly available
 * Fix Machinery failing to inspect changed config files in case of restrictive
   permissions (gh#SUSE/machinery#1609)
 * Remove hint for `show`, when `inspect` is run with `--show` option

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -920,6 +920,10 @@ class Cli
 
       if options[:public]
         ip = "0.0.0.0"
+
+        Machinery::Ui.warn("The --public option makes ALL of your system descriptions publicly " \
+          "available. Take care if there are system descriptions that should not be read by " \
+          "others!\n\n")
       else
         ip = "127.0.0.1"
       end

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -451,6 +451,24 @@ describe Cli do
 
         run_command(["serve", "description1", "--port=3000", "--public"])
       end
+
+      it "prints a hint when --public is used" do
+        allow_any_instance_of(ServeHtmlTask).to receive(:serve)
+
+        run_command(["serve", "description1", "--port=3000", "--public"])
+
+        expect(captured_machinery_output).to include("The --public option makes ALL of your " \
+          "system descriptions publicly available. Take care if there are system descriptions " \
+          "that should not be read by others!")
+      end
+
+      it "does not print a hint when --public is not used" do
+        allow_any_instance_of(ServeHtmlTask).to receive(:serve)
+
+        run_command(["serve", "description1", "--port=3000"])
+
+        expect(captured_machinery_output).not_to include("publicly available")
+      end
     end
 
     describe "#show" do


### PR DESCRIPTION
Supersedes & Squashes #1680 