### PR TITLE
Fix disk-full problem in the ubuntu VM

### DIFF
--- a/spec/definitions/boxes/definitions/base_ubuntu14.04_kvm/cleanup.sh
+++ b/spec/definitions/boxes/definitions/base_ubuntu14.04_kvm/cleanup.sh
@@ -13,4 +13,6 @@ rm -rf /dev/.udev/
 rm /lib/udev/rules.d/75-persistent-net-generator.rules
 
 echo "pre-up sleep 2" >> /etc/network/interfaces
+
+sync
 exit

--- a/spec/definitions/boxes/definitions/base_ubuntu14.04_kvm/definition.rb
+++ b/spec/definitions/boxes/definitions/base_ubuntu14.04_kvm/definition.rb
@@ -1,7 +1,7 @@
 Veewee::Session.declare(
   cpu_count: "1",
   memory_size: "512",
-  disk_size: "20480",
+  disk_size: "12288",
   disk_format: "VDI",
   hostiocache: "off",
   os_type_id: "Ubuntu_64",


### PR DESCRIPTION
The problem was not that the disk was too small, but that the removal of
the temporary /EMPTY file, which is used to fill the disk with zeros for
optimized storage, was not (always) commited to disk before shutting
down the machine, causing the disk to be completely filled.
