### PR TITLE
[Review] Request from 'greygoo' @ 'SUSE/machinery/review_151123_move_cli_validate_and_upgrade_format_tests_to_test_matrix_'

### DIFF
--- a/spec/definitions/support/integration_tests.yml
+++ b/spec/definitions/support/integration_tests.yml
@@ -1,3 +1,15 @@
+"serve html":
+  supported:
+    "openSUSE_13_2:x86_64":
+      "local":
+    "openSUSE_13_1:x86_64":
+      "local":
+    "leap:x86_64":
+      "local":
+    "Tumbleweed:x86_64":
+      "local":
+    "local":
+      "local": acceptance_test
 CLI:
   supported:
     "openSUSE_13_2:x86_64":
@@ -9,7 +21,7 @@ CLI:
     "Tumbleweed:x86_64":
       "local": full_test
     "local":
-      "local": full_test
+      "local": acceptance_test
 validate:
   supported:
     "openSUSE_13_2:x86_64":

--- a/spec/definitions/support/integration_tests.yml
+++ b/spec/definitions/support/integration_tests.yml
@@ -1,3 +1,39 @@
+CLI:
+  supported:
+    "openSUSE_13_2:x86_64":
+      "local": full_test
+    "openSUSE_13_1:x86_64":
+      "local": full_test
+    "leap:x86_64":
+      "local": full_test
+    "Tumbleweed:x86_64":
+      "local": full_test
+    "local":
+      "local": full_test
+validate:
+  supported:
+    "openSUSE_13_2:x86_64":
+       "local": full_test
+    "openSUSE_13_1:x86_64":
+       "local": full_test
+    "Tumbleweed:x86_64":
+      "local": full_test
+    "leap:x86_64":
+      "local": full_test
+    "local":
+      "local":
+"upgrade format":
+  supported:
+    "openSUSE_13_2:x86_64":
+       "local": full_test
+    "openSUSE_13_1:x86_64":
+       "local": full_test
+    "leap:x86_64":
+      "local": full_test
+    "Tumbleweed:x86_64":
+      "local": full_test
+    "local":
+      "local":
 inspect:
   supported:
     "local":

--- a/spec/integration/integration_spec_helper.rb
+++ b/spec/integration/integration_spec_helper.rb
@@ -123,6 +123,7 @@ def include_examples_for_platform(currently_running_on)
         guests.each do |guest, _test_group|
           include_examples test, "#{boxes[guest]}" if boxes[guest]
           include_examples "#{test} #{servers[guest]}" if servers[guest]
+          include_examples test if guest == "local"
         end
       end
     end

--- a/spec/integration/machinery_local_spec.rb
+++ b/spec/integration/machinery_local_spec.rb
@@ -43,6 +43,5 @@ describe "machinery@local", ci: true do
 
   host = machinery_host(metadata[:description])
 
-  include_examples "serve html"
   include_examples_for_platform(host)
 end

--- a/spec/integration/machinery_local_spec.rb
+++ b/spec/integration/machinery_local_spec.rb
@@ -43,7 +43,6 @@ describe "machinery@local", ci: true do
 
   host = machinery_host(metadata[:description])
 
-  include_examples "CLI"
   include_examples "serve html"
   include_examples_for_platform(host)
 end

--- a/spec/integration/machinery_opensuse13.1_spec.rb
+++ b/spec/integration/machinery_opensuse13.1_spec.rb
@@ -33,8 +33,5 @@ describe "machinery@openSUSE_13_1" do
     @machinery = start_system(box: "machinery_#{host}")
   end
 
-  include_examples "CLI"
-  include_examples "validate"
-  include_examples "upgrade format"
   include_examples_for_platform(host)
 end

--- a/spec/integration/machinery_opensuse13.2_spec.rb
+++ b/spec/integration/machinery_opensuse13.2_spec.rb
@@ -33,8 +33,5 @@ describe "machinery@openSUSE_13_2" do
     @machinery = start_system(box: "machinery_#{host}")
   end
 
-  include_examples "CLI"
-  include_examples "validate"
-  include_examples "upgrade format"
   include_examples_for_platform(host)
 end

--- a/spec/integration/machinery_opensuse_leap_spec.rb
+++ b/spec/integration/machinery_opensuse_leap_spec.rb
@@ -33,9 +33,6 @@ describe "machinery@leap" do
     @machinery = start_system(box: "machinery_#{host}")
   end
 
-  include_examples "CLI"
-  include_examples "validate"
-  include_examples "upgrade format"
   include_examples_for_platform(host)
 
   describe "inspect ubuntu_1404" do

--- a/spec/integration/machinery_opensuse_tumbleweed_spec.rb
+++ b/spec/integration/machinery_opensuse_tumbleweed_spec.rb
@@ -98,9 +98,6 @@ describe "machinery@Tumbleweed" do
     @machinery = start_system(box: "machinery_#{host}")
   end
 
-  include_examples "CLI"
-  include_examples "validate"
-  include_examples "upgrade format"
   include_examples_for_platform(host)
 
   describe "inspect openSUSE Tumbleweed system" do


### PR DESCRIPTION
Please review the following changes:
  * d11b147 Remove hardcoded tests now run via test matrix
  * feb1f57 Add test sections for CLI, validate and upgrade format tests
  * ab656ef Run standalone tests if target system is local in matrix
  * 2f9dc97 Merge pull request #1690 from SUSE/update_test_matrix4
  * 29c6429 Remove call to minimal tests in Rakefile
  * 8168096 Remove openSUSE 13.1 build description
  * a54a352 Use openSUSE leap build description for file access unit tests
  * b8d7d65 Use Jeos descriptions for analyze
  * db72e80 Set a default for Kiwi DHCP option
  * 94fe921 Add jeos and description for opensuse_leap
  * 5ea743a Update external tests to desired state
  * 5fcdc71 Make a deep merge when using multiple test matrix sources
  * d999f14 Merge pull request #1689 from SUSE/review_151123_require_nokogiri_1_6_3_because_of_security_issues
  * 51495fe Require nokogiri 1.6.3 because of security issues
  * 130de0a Merge pull request #1685 from SUSE/review_151123_require_nokogiri_1_6_1_because_of_security_issues_in_1_6_0
  * db436ce Merge pull request #1684 from SUSE/review_151123_fix_ubuntu_vm
  * f3e777b Require nokogiri >= 1.6.1 because of security issues in 1.6.0
  * 74c01e1 Fix disk-full problem in the ubuntu VM
  * b42bd1e Merge pull request #1682 from SUSE/review_151120_fix_disk_size_issue
  * c3cd69b Increase disk size to prevent out-of-disk-space issues