### PR TITLE
[Review] Request from 'greygoo' @ 'SUSE/machinery/review_151124_tag_tests_not_yet_run_via_the_test_matrix_for_easier_exclusion'

### DIFF
--- a/spec/integration/machinery_matcher_spec.rb
+++ b/spec/integration/machinery_matcher_spec.rb
@@ -17,7 +17,7 @@
 
 require_relative "integration_spec_helper"
 
-describe "match_machinery_show_scope matcher" do
+describe "match_machinery_show_scope matcher", matrix: "pending" do
   it "matches correct show output" do
     expected_output = <<-EOT
 # Services [192.168.122.238] (2014-05-02 13:35:46)
@@ -80,7 +80,7 @@ describe "match_machinery_show_scope matcher" do
   end
 end
 
-describe "match_scope matcher" do
+describe "match_scope matcher", matrix: "pending" do
   describe "matches scope as array" do
     it "with equal content" do
       expected_description = create_test_description(json: <<-EOT)
@@ -261,7 +261,7 @@ describe "match_scope matcher" do
   end
 end
 
-describe "include_file_scope matcher" do
+describe "include_file_scope matcher", matrix: "pending" do
   it "matches file scope with included subset of entries" do
     expected_description = create_test_description(json: <<-EOT)
     {

--- a/spec/integration/machinery_opensuse_leap_spec.rb
+++ b/spec/integration/machinery_opensuse_leap_spec.rb
@@ -35,7 +35,7 @@ describe "machinery@leap" do
 
   include_examples_for_platform(host)
 
-  describe "inspect ubuntu_1404" do
+  describe "inspect ubuntu_1404", matrix: "pending" do
     base = "ubuntu_1404"
     username = "root"
     password = "vagrant"

--- a/spec/integration/machinery_opensuse_tumbleweed_spec.rb
+++ b/spec/integration/machinery_opensuse_tumbleweed_spec.rb
@@ -100,7 +100,7 @@ describe "machinery@Tumbleweed" do
 
   include_examples_for_platform(host)
 
-  describe "inspect openSUSE Tumbleweed system" do
+  describe "inspect openSUSE Tumbleweed system", matrix: "pending" do
     before(:all) do
       @subject_system = start_system(
         box: "opensuse_tumbleweed", username: "machinery", password: "linux"


### PR DESCRIPTION
Please review the following changes:
  * 47207f4 Add tags to static tests not being executed via test matrix.
  * 256ebc2 Merge pull request #1695 from SUSE/review_151123_don_t_delete_gemfile_and_gemfile_lock
  * 812d625 Don't delete Gemfile and Gemfile.lock