### PR TITLE
[Review] Request from 'greygoo' @ 'SUSE/machinery/review_151124_switch_prophet_test_execution_to_being_matrix_controlled'

### DIFF
--- a/prophet/prophet_integration.rb
+++ b/prophet/prophet_integration.rb
@@ -80,7 +80,7 @@ Prophet.setup do |config|
 
       system(
         "cd ..; (bundle check || sudo bundle install) && rake rpm:build &&" \
-          " rspec spec/integration --tag=ci"
+          "SPEC_OPTS='--tag ~matrix:pending' rake spec:integration:acceptance"
       )
       config.success = ($? == 0)
 


### PR DESCRIPTION
Please review the following changes:
  * f6fa7da Switch prophet test execution from tag based to matrix controlled
  * 648d662 Merge pull request #1694 from SUSE/remove_sles_descriptions
  * d300a8a Merge pull request #1696 from SUSE/review_151124_tag_tests_not_yet_run_via_the_test_matrix_for_easier_exclusion
  * e0dd59f Remove description after inspection integration test
  * f381dbd Make sure zypper is uptodate in machinery 13.1 images
  * 47207f4 Add tags to static tests not being executed via test matrix.
  * d4c6094 Update 13.1 changed-managed-files entry for new image
  * 80705d4 Remove SLES kiwi exports
  * 9ed3c7d Use relative path for export examples integration tests
  * da69623 Remove SLES descriptions