### PR TITLE
[Review] Request from 'aduffeck' @ 'SUSE/machinery/review_151126_adapt_packages_data_model2'

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -186,7 +186,7 @@ task :upgrade_test_descriptions do
   # we don't want to upgrade format_vX, invalid-json, so we list the ones
   # we want to upgrade here
   descriptions = [
-    "opensuse131-build",
+    "opensuse_leap-build",
     "validation-error"
   ]
 

--- a/html/partials/compare/package_list.html.haml
+++ b/html/partials/compare/package_list.html.haml
@@ -9,7 +9,7 @@
       %th.medium.visible-lg Checksum
       %th.tiny.hidden-lg
   %tbody
-    - list.each do |package|
+    - list.packages.each do |package|
       %tr
         %td= package.name
         %td= package.version

--- a/html/partials/compare/packages.html.haml
+++ b/html/partials/compare/packages.html.haml
@@ -12,10 +12,27 @@
       .col-xs-11
         %h2
           Packages
-          = render_partial "compare/summary",
-            scope: "packages",
-            singular: "package",
-            plural: "packages"
+          .scope-summary
+            - if @diff["packages"].only_in1 && @diff["packages"].only_in1.length > 0
+              %span.summary-part
+                #{@description_a.name}:
+                #{pluralize_scope(@diff["packages"].only_in1, "package", "packages")}
+                (#{@diff["packages"].only_in1.package_system})
+            - if @diff["packages"].only_in2 && @diff["packages"].only_in2.length > 0
+              %span.summary-part
+                #{@description_b.name}:
+                #{pluralize_scope(@diff["packages"].only_in2, "package", "packages")}
+                (#{@diff["packages"].only_in2.package_system})
+            - if @diff["packages"].changed && @diff["packages"].changed.length > 0
+              %span.summary-part
+                %a.show-changed-elements{ href: "#packages_changed" }
+                  changed
+                = ": #{pluralize_scope(@diff["packages"].changed, "package", "packages")}"
+            - if @diff["packages"].common && @diff["packages"].common.length > 0
+              %span.summary-part
+                %a.show-common-elements{ href: "#packages_both" }<
+                  both
+                = ": #{pluralize_scope(@diff["packages"].common, "package", "packages")}"
     .row.scope_content.collapse.in
       .col-md-12
         .row

--- a/html/partials/packages.html.haml
+++ b/html/partials/packages.html.haml
@@ -23,7 +23,7 @@
                   %th.medium Vendor
                   %th Checksum
               %tbody
-                - packages.each do |package|
+                - packages.packages.each do |package|
                   %tr
                     %td= package.name
                     %td= package.version

--- a/html/partials/packages.html.haml
+++ b/html/partials/packages.html.haml
@@ -23,7 +23,7 @@
                   %th.medium Vendor
                   %th Checksum
               %tbody
-                - packages.packages.each do |package|
+                - packages.each do |package|
                   %tr
                     %td= package.name
                     %td= package.version

--- a/lib/array.rb
+++ b/lib/array.rb
@@ -25,7 +25,7 @@ module Machinery
         super
       end
 
-      def has_properties(*keys)
+      def has_attributes(*keys)
         @attribute_keys = keys.map(&:to_s)
       end
 

--- a/lib/autoyast.rb
+++ b/lib/autoyast.rb
@@ -167,7 +167,7 @@ class Autoyast < Exporter
     return if !@system_description.packages
 
     xml.packages("config:type" => "list") do
-      @system_description.packages.packages.each do |package|
+      @system_description.packages.each do |package|
         xml.package package.name
       end
     end

--- a/lib/autoyast.rb
+++ b/lib/autoyast.rb
@@ -167,7 +167,7 @@ class Autoyast < Exporter
     return if !@system_description.packages
 
     xml.packages("config:type" => "list") do
-      @system_description.packages.each do |package|
+      @system_description.packages.packages.each do |package|
         xml.package package.name
       end
     end

--- a/lib/kiwi_config.rb
+++ b/lib/kiwi_config.rb
@@ -247,7 +247,7 @@ EOF
 
     xml.packages(type: "bootstrap") do
       if @system_description.packages
-        @system_description.packages.packages.each do |package|
+        @system_description.packages.each do |package|
           next if filter.include?(package.name)
           xml.package(name: "#{package.name}")
         end

--- a/lib/kiwi_config.rb
+++ b/lib/kiwi_config.rb
@@ -247,7 +247,7 @@ EOF
 
     xml.packages(type: "bootstrap") do
       if @system_description.packages
-        @system_description.packages.each do |package|
+        @system_description.packages.packages.each do |package|
           next if filter.include?(package.name)
           xml.package(name: "#{package.name}")
         end

--- a/lib/object.rb
+++ b/lib/object.rb
@@ -32,7 +32,11 @@ module Machinery
           when ::Array
             Machinery::Array.from_json(value)
           when Hash
-            Machinery::Object.from_json(value)
+            if value.keys.sort == ["_attributes", "_elements"]
+              Machinery::Array.from_json(value)
+            else
+              Machinery::Object.from_json(value)
+            end
           else
             value
           end

--- a/lib/system_description.rb
+++ b/lib/system_description.rb
@@ -26,7 +26,7 @@
 # The sub directories storing the data for specific scopes are handled by the
 # ScopeFileStore class.
 class SystemDescription < Machinery::Object
-  CURRENT_FORMAT_VERSION = 5
+  CURRENT_FORMAT_VERSION = 6
   EXTRACTABLE_SCOPES = [
     "changed_managed_files",
     "config_files",

--- a/plugins/changed_managed_files/schema/system-description-changed-managed-files.schema-v6.json
+++ b/plugins/changed_managed_files/schema/system-description-changed-managed-files.schema-v6.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "type": "object",
+  "required": ["extracted", "files"],
+  "properties": {
+    "extracted": {
+      "type": "boolean"
+    },
+    "files": {
+      "type": "array",
+        "items" : {
+          "type": "object",
+          "required": ["name", "package_name", "package_version"],
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "package_name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "package_version": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "oneOf": [
+            { "$ref": "#/definitions/file_changed" },
+            { "$ref": "#/definitions/file_error" }
+          ]
+        }
+    }
+  },
+  "definitions": {
+    "file_changed": {
+      "required": ["status"],
+      "properties": {
+        "status": {
+          "enum": ["changed"]
+        }
+      },
+      "oneOf": [
+        { "$ref": "#/definitions/file_changed_modified" },
+        { "$ref": "#/definitions/link_changed_modified" },
+        { "$ref": "#/definitions/file_changed_deleted" }
+      ]
+    },
+    "file_changed_modified": {
+      "required": ["changes", "mode", "user", "group", "type"],
+      "properties": {
+        "changes": {
+          "type": "array",
+          "items": {
+            "enum": ["size", "mode", "md5", "device_number", "link_path", "user", "group", "time", "capabilities", "replaced", "other_rpm_changes"]
+          },
+          "minItems": 1
+        },
+        "mode": {
+          "type": "string",
+          "pattern": "^[0-7]{3,4}$"
+        },
+        "user": {
+          "type": "string",
+          "minLength": 1
+        },
+        "group": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "enum": ["file", "dir"]
+        }
+      }
+    },
+    "link_changed_modified": {
+      "required": ["target", "changes", "mode", "user", "group", "type"],
+      "properties": {
+        "changes": {
+          "type": "array",
+          "items": {
+            "enum": ["size", "mode", "md5", "device_number", "link_path", "user", "group", "time", "capabilities", "replaced", "other_rpm_changes"]
+          },
+          "minItems": 1
+        },
+        "mode": {
+          "type": "string",
+          "pattern": "^[0-7]{3,4}$"
+        },
+        "user": {
+          "type": "string",
+          "minLength": 1
+        },
+        "group": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "enum": ["link"]
+        },
+        "target": {
+          "type": "string"
+        }
+      }
+    },
+    "file_changed_deleted": {
+      "required": ["changes"],
+      "properties": {
+        "changes": {
+          "enum": [["deleted"]]
+        }
+      }
+    },
+    "file_error": {
+      "required": ["status", "error_message"],
+      "properties": {
+        "status": {
+          "enum": ["error"]
+        },
+        "error_message": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/plugins/config_files/schema/system-description-config-files.schema-v6.json
+++ b/plugins/config_files/schema/system-description-config-files.schema-v6.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "type": "object",
+  "required": ["extracted", "files"],
+  "properties": {
+    "extracted": {
+      "type": "boolean"
+    },
+    "files": {
+      "type": "array",
+        "items" : {
+          "type": "object",
+          "required": ["name", "package_name", "package_version"],
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "package_name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "package_version": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "oneOf": [
+            { "$ref": "#/definitions/file_changed" },
+            { "$ref": "#/definitions/file_error" }
+          ]
+        }
+    }
+  },
+  "definitions": {
+    "file_changed": {
+      "required": ["status"],
+      "properties": {
+        "status": {
+          "enum": ["changed"]
+        }
+      },
+      "oneOf": [
+        { "$ref": "#/definitions/file_changed_modified" },
+        { "$ref": "#/definitions/link_changed_modified" },
+        { "$ref": "#/definitions/file_changed_deleted" }
+      ]
+    },
+    "file_changed_modified": {
+      "required": ["changes", "mode", "user", "group", "type"],
+      "properties": {
+        "changes": {
+          "type": "array",
+          "items": {
+            "enum": ["size", "mode", "md5", "device_number", "link_path", "user", "group", "time", "capabilities", "replaced", "other_rpm_changes"]
+          },
+          "minItems": 1
+        },
+        "mode": {
+          "type": "string",
+          "pattern": "^[0-7]{3,4}$"
+        },
+        "user": {
+          "type": "string",
+          "minLength": 1
+        },
+        "group": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "enum": ["file", "dir"]
+        }
+      }
+    },
+    "link_changed_modified": {
+      "required": ["target", "changes", "mode", "user", "group", "type"],
+      "properties": {
+        "changes": {
+          "type": "array",
+          "items": {
+            "enum": ["size", "mode", "md5", "device_number", "link_path", "user", "group", "time", "capabilities", "replaced", "other_rpm_changes"]
+          },
+          "minItems": 1
+        },
+        "mode": {
+          "type": "string",
+          "pattern": "^[0-7]{3,4}$"
+        },
+        "user": {
+          "type": "string",
+          "minLength": 1
+        },
+        "group": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "enum": ["link"]
+        },
+        "target": {
+          "type": "string"
+        }
+      }
+    },
+    "file_changed_deleted": {
+      "required": ["changes"],
+      "properties": {
+        "changes": {
+          "enum": [["deleted"]]
+        }
+      }
+    },
+    "file_error": {
+      "required": ["status", "error_message"],
+      "properties": {
+        "status": {
+          "enum": ["error"]
+        },
+        "error_message": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/plugins/environment/schema/system-description-environment.schema-v6.json
+++ b/plugins/environment/schema/system-description-environment.schema-v6.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "type": "object",
+  "required": ["locale"],
+  "properties": {
+    "locale": {
+      "type": "string",
+      "minLength": 1
+    },
+    "system_type": {
+      "type": "string",
+      "enum": ["local", "remote", "docker"]
+    }
+  }
+}
+

--- a/plugins/groups/schema/system-description-groups.schema-v6.json
+++ b/plugins/groups/schema/system-description-groups.schema-v6.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["name", "password", "gid", "users"],
+    "properties": {
+      "name": {
+        "type": "string",
+        "minLength": 1
+      },
+      "password": {
+        "type": "string"
+      },
+      "gid": {
+        "type": ["integer", "null"],
+        "minimum": 0
+      },
+      "users": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}
+

--- a/plugins/os/schema/system-description-os.schema-v6.json
+++ b/plugins/os/schema/system-description-os.schema-v6.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "type": "object",
+  "required": ["name", "version", "architecture"],
+  "properties": {
+    "name": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "version": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "architecture": {
+      "type": ["string", "null"],
+      "minLength": 1
+    }
+  }
+}
+

--- a/plugins/packages/packages_inspector.rb
+++ b/plugins/packages/packages_inspector.rb
@@ -46,10 +46,13 @@ class PackagesInspector < Inspector
       )
     end
 
-    @description.packages = PackagesScope.new(packages.sort_by(&:name))
+    @description.packages = PackagesScope.new(
+      package_system: "rpm",
+      packages: packages.sort_by(&:name)
+    )
   end
 
   def summary
-    "Found #{@description.packages.size} packages."
+    "Found #{@description.packages.length} packages."
   end
 end

--- a/plugins/packages/packages_inspector.rb
+++ b/plugins/packages/packages_inspector.rb
@@ -25,7 +25,7 @@ class PackagesInspector < Inspector
   def inspect(_filter, _options = {})
     @system.check_requirement("rpm", "--version")
 
-    packages = Array.new
+    packages = Machinery::Array.new
     rpm_data = @system.run_command(
       "rpm","-qa","--qf",
       "%{NAME}|%{VERSION}|%{RELEASE}|%{ARCH}|%{VENDOR}|%{SIGMD5}$",
@@ -47,8 +47,8 @@ class PackagesInspector < Inspector
     end
 
     @description.packages = PackagesScope.new(
-      package_system: "rpm",
-      packages: packages.sort_by(&:name)
+      packages.sort_by(&:name),
+      package_system: "rpm"
     )
   end
 

--- a/plugins/packages/packages_model.rb
+++ b/plugins/packages/packages_model.rb
@@ -26,7 +26,7 @@ end
 class PackagesScope < Machinery::Object
   include Machinery::Scope
 
-  has_property :packages,  class: PackageList
+  has_property :packages, class: PackageList
 
   def compare_with(other)
     if self.package_system != other.package_system
@@ -54,6 +54,6 @@ class PackagesScope < Machinery::Object
   private
 
   def package_list_to_scope(packages)
-    self.class.new(package_system: package_system, packages: packages) if !packages.empty?
+    self.class.new(package_system: package_system, packages: packages) unless packages.empty?
   end
 end

--- a/plugins/packages/packages_model.rb
+++ b/plugins/packages/packages_model.rb
@@ -22,6 +22,7 @@ end
 class PackagesScope < Machinery::Array
   include Machinery::Scope
 
+  has_properties :package_system
   has_elements class: Package
 
   def compare_with(other)

--- a/plugins/packages/packages_model.rb
+++ b/plugins/packages/packages_model.rb
@@ -19,22 +19,18 @@
 class Package < Machinery::Object
 end
 
-class PackageList < Machinery::Array
-  has_elements class: Package
-end
-
-class PackagesScope < Machinery::Object
+class PackagesScope < Machinery::Array
   include Machinery::Scope
 
-  has_property :packages, class: PackageList
+  has_elements class: Package
 
   def compare_with(other)
     if self.package_system != other.package_system
       [self, other, nil, nil]
     else
-      only_self = self.packages - other.packages
-      only_other = other.packages - self.packages
-      common = self.packages & other.packages
+      only_self = self - other
+      only_other = other - self
+      common = self & other
       changed = Machinery::Scope.extract_changed_elements(only_self, only_other, :name)
       changed = nil if changed.empty?
 
@@ -47,13 +43,9 @@ class PackagesScope < Machinery::Object
     end
   end
 
-  def length
-    packages.try(:length) || 0
-  end
-
   private
 
   def package_list_to_scope(packages)
-    self.class.new(package_system: package_system, packages: packages) unless packages.empty?
+    self.class.new(packages, package_system: package_system) unless packages.empty?
   end
 end

--- a/plugins/packages/packages_model.rb
+++ b/plugins/packages/packages_model.rb
@@ -22,7 +22,7 @@ end
 class PackagesScope < Machinery::Array
   include Machinery::Scope
 
-  has_properties :package_system
+  has_attributes :package_system
   has_elements class: Package
 
   def compare_with(other)

--- a/plugins/packages/packages_renderer.rb
+++ b/plugins/packages/packages_renderer.rb
@@ -23,12 +23,12 @@ class PackagesRenderer < Renderer
   def content(description)
     return unless description.packages
 
-    if description.packages.packages.empty?
+    if description.packages.empty?
       puts "There are no packages."
     end
 
     list do
-      description.packages.packages.each do |p|
+      description.packages.each do |p|
         item "#{p.name}-#{p.version}-#{p.release}.#{p.arch} (#{p.vendor})"
       end
     end
@@ -38,7 +38,7 @@ class PackagesRenderer < Renderer
   # architecture etc.
   def compare_content_only_in(description)
     list do
-      description.packages.packages.each do |p|
+      description.packages.each do |p|
         item "#{p.name}"
       end
     end

--- a/plugins/packages/packages_renderer.rb
+++ b/plugins/packages/packages_renderer.rb
@@ -23,12 +23,12 @@ class PackagesRenderer < Renderer
   def content(description)
     return unless description.packages
 
-    if description.packages.empty?
+    if description.packages.packages.empty?
       puts "There are no packages."
     end
 
     list do
-      description.packages.each do |p|
+      description.packages.packages.each do |p|
         item "#{p.name}-#{p.version}-#{p.release}.#{p.arch} (#{p.vendor})"
       end
     end
@@ -38,7 +38,7 @@ class PackagesRenderer < Renderer
   # architecture etc.
   def compare_content_only_in(description)
     list do
-      description.packages.each do |p|
+      description.packages.packages.each do |p|
         item "#{p.name}"
       end
     end

--- a/plugins/packages/schema/system-description-packages.schema-v6.json
+++ b/plugins/packages/schema/system-description-packages.schema-v6.json
@@ -2,15 +2,23 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "required": [
-    "package_system",
-    "packages"
+    "_attributes",
+    "_elements"
   ],
   "properties": {
-    "package_system": {
-      "type": "string",
-      "minLength": 1
+    "_attributes": {
+      "type": "object",
+      "required": [
+        "package_system"
+      ],
+      "properties": {
+        "package_system": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
     },
-    "packages": {
+    "_elements": {
       "type": "array",
       "items": {
         "type": "object",

--- a/plugins/packages/schema/system-description-packages.schema-v6.json
+++ b/plugins/packages/schema/system-description-packages.schema-v6.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "package_system",
+    "packages"
+  ],
+  "properties": {
+    "package_system": {
+      "type": "string",
+      "minLength": 1
+    },
+    "packages": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "version",
+          "release",
+          "arch",
+          "vendor",
+          "checksum"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "version": {
+            "type": "string",
+            "minLength": 1
+          },
+          "release": {
+            "type": "string",
+            "minLength": 1
+          },
+          "arch": {
+            "type": "string",
+            "minLength": 1
+          },
+          "vendor": {
+            "type": "string"
+          },
+          "checksum": {
+            "type": "string",
+            "pattern": "^[a-f0-9]+$"
+          }
+        }
+      }
+    }
+  }
+}

--- a/plugins/patterns/schema/system-description-patterns.schema-v6.json
+++ b/plugins/patterns/schema/system-description-patterns.schema-v6.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "type": "array",
+  "items" : {
+    "type" : "object",
+    "required": ["name", "version", "release"],
+    "properties": {
+      "name": {
+        "type": "string",
+        "minLength": 1
+      },
+      "version": {
+        "type": "string",
+        "minLength": 1
+      },
+      "release": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}
+

--- a/plugins/repositories/schema/system-description-repositories.schema-v6.json
+++ b/plugins/repositories/schema/system-description-repositories.schema-v6.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "type": "array",
+  "items" : {
+    "type" : "object",
+    "required": ["alias", "name", "url", "type", "enabled", "gpgcheck", "package_manager"],
+    "properties": {
+      "alias": {
+        "type": "string",
+        "minLength": 1
+      },
+      "name": {
+        "type": "string",
+        "minLength": 1
+      },
+      "type": {
+        "enum": ["yast2", "rpm-md", "plaindir", null]
+      },
+      "url": {
+        "type": "string",
+        "format": "uri",
+        "minLength": 1
+      },
+      "enabled": {
+        "type": "boolean"
+      },
+      "autorefresh": {
+        "type": "boolean"
+      },
+      "gpgcheck": {
+        "type": "boolean"
+      },
+      "priority": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "package_manager": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}
+

--- a/plugins/services/schema/system-description-services.schema-v6.json
+++ b/plugins/services/schema/system-description-services.schema-v6.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "type": "object",
+  "required": ["init_system", "services"],
+  "properties": {
+    "init_system": {
+      "type": "string",
+      "minLength": 1
+    },
+    "services": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "state"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "state": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/plugins/unmanaged_files/schema/system-description-unmanaged-files.schema-v6.json
+++ b/plugins/unmanaged_files/schema/system-description-unmanaged-files.schema-v6.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "type": "object",
+  "required": ["extracted", "files"],
+  "properties": {
+    "extracted": {
+      "type": "boolean"
+    },
+    "files": {
+      "oneOf": [
+        {
+          "type": "array",
+          "maxItems": 0
+        },
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "anyOf": [
+              { "$ref": "#/definitions/file_extracted" },
+              { "$ref": "#/definitions/file_remote_dir" }
+            ]
+          }
+        },
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "anyOf": [
+              { "$ref": "#/definitions/file_not_extracted" },
+              { "$ref": "#/definitions/file_remote_dir" }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "file_common": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "file_not_extracted": {
+      "allOf": [
+        { "$ref": "#/definitions/file_common" },
+        {
+          "required": ["type"],
+          "properties": {
+            "type": {
+              "enum": ["file", "dir", "link", "remote_dir"]
+            }
+          },
+          "not": { "$ref": "#/definitions/file_extracted" }
+        }
+      ]
+    },
+    "file_extracted": {
+      "allOf": [
+        { "$ref": "#/definitions/file_common" },
+        {
+          "required": ["user", "group"],
+          "properties": {
+          "user": {
+          "type": "string",
+          "minLength": 1
+          },
+          "group": {
+          "type": "string",
+          "minLength": 1
+          }
+          },
+          "oneOf": [
+          { "$ref": "#/definitions/file_extracted_file" },
+          { "$ref": "#/definitions/file_extracted_dir" },
+          { "$ref": "#/definitions/file_extracted_link" }
+          ]
+        }
+      ]
+    },
+    "file_extracted_file": {
+      "required": ["type", "size", "mode"],
+      "properties": {
+        "type": {
+          "enum": ["file"]
+        },
+        "size": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "mode": {
+          "type": "string",
+          "pattern": "^[0-7]{3,4}$"
+        }
+      }
+    },
+    "file_extracted_dir": {
+      "required": ["type", "size", "mode", "files"],
+      "properties": {
+        "type": {
+          "enum": ["dir"]
+        },
+        "size": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "mode": {
+          "type": "string",
+          "pattern": "^[0-4]?[0-7]{3}$"
+        },
+        "files": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "file_extracted_link": {
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "enum": ["link"]
+        }
+      }
+    },
+    "file_remote_dir": {
+      "allOf": [
+        { "$ref": "#/definitions/file_common" },
+        {
+          "required": ["type"],
+          "properties": {
+            "type": {
+              "enum": ["remote_dir"]
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/plugins/users/schema/system-description-users.schema-v6.json
+++ b/plugins/users/schema/system-description-users.schema-v6.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["name", "password", "uid", "gid", "comment", "home", "shell"],
+    "properties": {
+      "name": {
+        "type": "string",
+        "minLength": 1
+      },
+      "password": {
+        "type": "string"
+      },
+      "uid": {
+        "type": ["integer", "null"],
+        "minimum": 0
+      },
+      "gid": {
+        "type": ["integer", "null"],
+        "minimum": 0
+      },
+      "comment": {
+        "type": "string"
+      },
+      "home": {
+        "type": "string"
+      },
+      "shell": {
+        "type": "string"
+      },
+      "encrypted_password": {
+        "type": "string"
+      },
+      "last_changed_date": {
+        "type": "integer"
+      },
+      "min_days": {
+        "type": "integer",
+        "minimum": 0
+      },
+      "max_days": {
+        "type": "integer",
+        "minimum": 0
+      },
+      "warn_days": {
+        "type": "integer",
+        "minimum": 0
+      },
+      "disable_days": {
+        "type": "integer",
+        "minimum": 0
+      },
+      "disabled_date": {
+        "type": "integer"
+      }
+    }
+  }
+}
+

--- a/schema/migrations/migrate5to6.rb
+++ b/schema/migrations/migrate5to6.rb
@@ -21,7 +21,7 @@ class Migrate5To6 < Migration
   EOT
 
   def migrate
-    if @hash.has_key?("packages")
+    if @hash.key?("packages")
       @hash["packages"] = {
         "package_system" => "rpm",
         "packages" => @hash["packages"]

--- a/schema/migrations/migrate5to6.rb
+++ b/schema/migrations/migrate5to6.rb
@@ -23,8 +23,10 @@ class Migrate5To6 < Migration
   def migrate
     if @hash.key?("packages")
       @hash["packages"] = {
-        "package_system" => "rpm",
-        "packages" => @hash["packages"]
+        "_attributes" => {
+          "package_system" => "rpm"
+        },
+        "_elements" => @hash["packages"]
       }
     end
 

--- a/schema/migrations/migrate5to6.rb
+++ b/schema/migrations/migrate5to6.rb
@@ -1,0 +1,33 @@
+# Copyright (c) 2013-2014 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
+class Migrate5To6 < Migration
+  desc <<-EOT
+    Schema version 6 adds support for Ubuntu 14.04 systems.
+  EOT
+
+  def migrate
+    if @hash.has_key?("packages")
+      @hash["packages"] = {
+        "package_system" => "rpm",
+        "packages" => @hash["packages"]
+      }
+    end
+
+    @hash
+  end
+end

--- a/schema/system-description-global.schema-v6.json
+++ b/schema/system-description-global.schema-v6.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "type": "object",
+  "required": ["meta"],
+  "properties": {
+    "meta": {
+      "required": ["format_version"],
+      "properties": {
+        "format_version": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "filters": {
+          "type": "object",
+          "required": ["inspect"],
+          "properties": {
+            "inspect": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "additionalProperties": {
+        "type": "object",
+        "required": ["modified", "hostname"],
+        "properties": {
+          "modified": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "hostname": {
+            "type": "string",
+            "format": "hostname"
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/data/descriptions/jeos/opensuse131/manifest.json
+++ b/spec/data/descriptions/jeos/opensuse131/manifest.json
@@ -779,2072 +779,2075 @@
       "gid": 41
     }
   ],
-  "packages": [
-    {
-      "name": "DirectFB",
-      "version": "1.6.3",
-      "release": "4.1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f7ab84032a0b07fe079030b0abb441d3"
-    },
-    {
-      "name": "Mesa",
-      "version": "9.2.3",
-      "release": "61.9.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d3350e07a011f5731cb7a787e0ed11a8"
-    },
-    {
-      "name": "Mesa-libEGL1",
-      "version": "9.2.3",
-      "release": "61.9.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d36cf64cb1860e7130b10ab13de55285"
-    },
-    {
-      "name": "Mesa-libGL1",
-      "version": "9.2.3",
-      "release": "61.9.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ee2ea91c3be8552be55f6a28e60fc3ec"
-    },
-    {
-      "name": "Mesa-libGLESv2-2",
-      "version": "9.2.3",
-      "release": "61.9.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0939ad04af12d3974b5b383a743889e8"
-    },
-    {
-      "name": "Mesa-libglapi0",
-      "version": "9.2.3",
-      "release": "61.9.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6659ebca0af2e8d9baf42f6b768d5273"
-    },
-    {
-      "name": "aaa_base",
-      "version": "13.1",
-      "release": "16.42.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "503e92b38ac00bd311ce7527e907d6d6"
-    },
-    {
-      "name": "adjtimex",
-      "version": "1.29",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6fe8798263f38820e050b3912f41b2a4"
-    },
-    {
-      "name": "bash",
-      "version": "4.2",
-      "release": "68.1.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "533e40ba8a5551204b528c047e45c169"
-    },
-    {
-      "name": "branding-openSUSE",
-      "version": "13.1",
-      "release": "10.4.13",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "c52a3adf23bef50cecf7d265354c78a0"
-    },
-    {
-      "name": "bridge-utils",
-      "version": "1.5",
-      "release": "16.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "322087a0b95cb45a405f7300d3b8a86a"
-    },
-    {
-      "name": "bzip2",
-      "version": "1.0.6",
-      "release": "26.1.21",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ed4d63829fb89c41e6836ee77b8a6a36"
-    },
-    {
-      "name": "coreutils",
-      "version": "8.21",
-      "release": "7.16.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "72ecfca8b13198813ff596769600155d"
-    },
-    {
-      "name": "cpio",
-      "version": "2.11",
-      "release": "25.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "981d0c41ebf01ca7c48d3b9b2a4cc5ff"
-    },
-    {
-      "name": "cracklib",
-      "version": "2.9.0",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ef05b58179386b1ec5ceb75c2b28f3c7"
-    },
-    {
-      "name": "cracklib-dict-full",
-      "version": "2.8.12",
-      "release": "62.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f401ce4c8686f47cf1036302dd38d203"
-    },
-    {
-      "name": "cron",
-      "version": "4.2",
-      "release": "50.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "26a9db1420ea73406246e0a8a420b7e2"
-    },
-    {
-      "name": "cronie",
-      "version": "1.4.8",
-      "release": "50.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "47c2ffa29dc838c13d916045331b8f39"
-    },
-    {
-      "name": "cyrus-sasl",
-      "version": "2.1.25",
-      "release": "28.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "1febe5c5413e4151ba47fefdf622bc5f"
-    },
-    {
-      "name": "dbus-1",
-      "version": "1.7.4",
-      "release": "4.16.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "81a54ec6c964f0ab983fc5368fa3ea03"
-    },
-    {
-      "name": "dbus-1-x11",
-      "version": "1.7.4",
-      "release": "4.16.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "705313fb41bdde2b8c54f45603dcc9d9"
-    },
-    {
-      "name": "device-mapper",
-      "version": "1.02.78",
-      "release": "0.14.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5966592e4352931f7a53bf036e1ee8b9"
-    },
-    {
-      "name": "dhcpcd",
-      "version": "3.2.3",
-      "release": "47.78.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a41747eb196b296f2f8db34401bc0390"
-    },
-    {
-      "name": "diffutils",
-      "version": "3.3",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "908f0790c137980d435a876862bd6cc9"
-    },
-    {
-      "name": "dirmngr",
-      "version": "1.1.0",
-      "release": "18.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6ef4f2839e67d361f8daef05d26dd58e"
-    },
-    {
-      "name": "dmraid",
-      "version": "1.0.0.rc16",
-      "release": "25.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "00f7738e99a14874fcec444ed54a60f9"
-    },
-    {
-      "name": "e2fsprogs",
-      "version": "1.42.8",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c91c5b90bf3fe6fb6d14dca13f9e89f9"
-    },
-    {
-      "name": "elfutils",
-      "version": "0.155",
-      "release": "6.4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6d3e828799be2f3277013aa4e55885c4"
-    },
-    {
-      "name": "expat",
-      "version": "2.1.0",
-      "release": "12.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "268ba7a859ea5aab034ae57ab48ff9d6"
-    },
-    {
-      "name": "file",
-      "version": "5.15",
-      "release": "4.20.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a6f7a3339d9a35f2c3fd59d7579dce20"
-    },
-    {
-      "name": "file-magic",
-      "version": "5.15",
-      "release": "4.20.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a4c8755a5fbff1622ccf8154bcdb0723"
-    },
-    {
-      "name": "filesystem",
-      "version": "13.1",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "35c6b72b11240b2b60ca6aa01261e2f2"
-    },
-    {
-      "name": "fillup",
-      "version": "1.42",
-      "release": "269.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "bf192d483b3b2c69a03e9c270f01705f"
-    },
-    {
-      "name": "findutils",
-      "version": "4.5.12",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4e8bdc044364eade7a2dfc754dd7e172"
-    },
-    {
-      "name": "fontconfig",
-      "version": "2.11.0",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "518c8c930443a2ca35031419288dcd84"
-    },
-    {
-      "name": "gawk",
-      "version": "4.1.0",
-      "release": "2.1.14",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "84980e1ce8eeb88eb28edecfe3fb93da"
-    },
-    {
-      "name": "gettext-runtime",
-      "version": "0.18.3.1",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5fa81a9dd0d81c18db234f79f1824959"
-    },
-    {
-      "name": "gio-branding-openSUSE",
-      "version": "13.1",
-      "release": "2.13.1",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "6f33b8040e1954545050b634b6123716"
-    },
-    {
-      "name": "glib2-tools",
-      "version": "2.38.2",
-      "release": "8.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a2d8a24f6f5005895da45d653bd9e74b"
-    },
-    {
-      "name": "glibc",
-      "version": "2.18",
-      "release": "4.15.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c445d03338a18ed5df13008fcfbc42f7"
-    },
-    {
-      "name": "glibc-32bit",
-      "version": "2.18",
-      "release": "4.15.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "3aa78168eebef10365b78fc061894155"
-    },
-    {
-      "name": "gnu-unifont-bitmap-fonts",
-      "version": "20080123",
-      "release": "82.1.2",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "246ea5728ea7c96ceffcb0d88e8d9198"
-    },
-    {
-      "name": "gpg2",
-      "version": "2.0.22",
-      "release": "8.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6c2bfb0eb55ecd31a0c657323b1e2d80"
-    },
-    {
-      "name": "grep",
-      "version": "2.14",
-      "release": "5.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "9b5eff76470cec4750c13e09b68307b4"
-    },
-    {
-      "name": "grub",
-      "version": "0.97",
-      "release": "194.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "1aa5c0f0a344b2686adab527e966d093"
-    },
-    {
-      "name": "grub2",
-      "version": "2.00",
-      "release": "39.8.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "3a9bc35cf452103ed484e7dad70485be"
-    },
-    {
-      "name": "grub2-i386-pc",
-      "version": "2.00",
-      "release": "39.8.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "95211e0bde6dedb7a32a3bf97a39dab0"
-    },
-    {
-      "name": "gzip",
-      "version": "1.6",
-      "release": "4.2.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "79db5125f8b7ad6837fe453212af5cd3"
-    },
-    {
-      "name": "hwinfo",
-      "version": "20.2",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6a5d3c3fae0661286d845cc05b160ded"
-    },
-    {
-      "name": "info",
-      "version": "4.13a",
-      "release": "36.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ca47c27038491958bce289e5b9217883"
-    },
-    {
-      "name": "insserv-compat",
-      "version": "0.1",
-      "release": "8.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a7bf3cd6f00f08ecac430d01b921e2a2"
-    },
-    {
-      "name": "iproute2",
-      "version": "3.9.0",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "88eaf0491ad1d8a2b46101ba652ae435"
-    },
-    {
-      "name": "iputils",
-      "version": "s20101006",
-      "release": "23.4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f288609e60d206fbf0b58ba17be2e91e"
-    },
-    {
-      "name": "kbd",
-      "version": "1.15.5",
-      "release": "5.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "7efca8396c5f237f3285e9d32976b740"
-    },
-    {
-      "name": "kernel-default",
-      "version": "3.11.10",
-      "release": "21.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "1f02808a7737e2165b6d43dc89925b98"
-    },
-    {
-      "name": "klogd",
-      "version": "1.4.1",
-      "release": "772.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ec248c9cacac4d32879f9c5956aee989"
-    },
-    {
-      "name": "kmod",
-      "version": "14",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "02ac0f892dcf5f1e89c302eb72302864"
-    },
-    {
-      "name": "kpartx",
-      "version": "0.4.9",
-      "release": "11.4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "19518e85b4efa2f214d72f83f6509dce"
-    },
-    {
-      "name": "krb5",
-      "version": "1.11.3",
-      "release": "3.8.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "99c2b99fc2883995ac6d7260be4cf945"
-    },
-    {
-      "name": "libICE6",
-      "version": "1.0.8",
-      "release": "7.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "3e83dca788686f352e2fd5e274fa9924"
-    },
-    {
-      "name": "libLLVM",
-      "version": "3.3",
-      "release": "6.4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "7f33572a255596090c19755445b6d5cd"
-    },
-    {
-      "name": "libSM6",
-      "version": "1.2.2",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "56ffc029177a9d59208a47b543b22f40"
-    },
-    {
-      "name": "libX11-6",
-      "version": "1.6.2",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "55772cdf402ae64da9062c5af6ad23c6"
-    },
-    {
-      "name": "libX11-data",
-      "version": "1.6.2",
-      "release": "2.1.2",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "45c5eb39c862ddcfa74e1ed6a293cff9"
-    },
-    {
-      "name": "libX11-xcb1",
-      "version": "1.6.2",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b2bc2a4765ae26f15f78e9880d998346"
-    },
-    {
-      "name": "libXau6",
-      "version": "1.0.8",
-      "release": "2.2.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "264008603b7067b1374320d913a67b50"
-    },
-    {
-      "name": "libXdamage1",
-      "version": "1.1.4",
-      "release": "6.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d720db9f2c345cfbb6d021ccc6675eaf"
-    },
-    {
-      "name": "libXext6",
-      "version": "1.3.2",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6c1045b4f2b6de12b292918d89b88d91"
-    },
-    {
-      "name": "libXfixes3",
-      "version": "5.0.1",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "2dce65a71fe23c5413a406de9ae9f242"
-    },
-    {
-      "name": "libXft2",
-      "version": "2.3.1",
-      "release": "7.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "390d0a5a5e21e476b0e916fd6aa6858f"
-    },
-    {
-      "name": "libXrender1",
-      "version": "0.9.8",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "9f18b64f2fe146aff06badbd5c95d8ae"
-    },
-    {
-      "name": "libXt6",
-      "version": "1.1.4",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c3ad229d17418d328e4cb36f71e82c8f"
-    },
-    {
-      "name": "libXxf86vm1",
-      "version": "1.1.3",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f0bd67d4c0b7dbd4aa3190383703aad6"
-    },
-    {
-      "name": "libacl1",
-      "version": "2.2.52",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "aa481c6f36a50f65c5e1f49c8e56b6cd"
-    },
-    {
-      "name": "libadns1",
-      "version": "1.4",
-      "release": "100.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "809f26d07084f2efe61a0ba4c4cc9a49"
-    },
-    {
-      "name": "libasm1",
-      "version": "0.155",
-      "release": "6.4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c23167b5cf1585cc3190d7f5eb123b61"
-    },
-    {
-      "name": "libassuan0",
-      "version": "2.1.1",
-      "release": "2.1.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "27baf0c90065f8b789e00ff0c8e58c8a"
-    },
-    {
-      "name": "libattr1",
-      "version": "2.4.47",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "36475f1e0b33db0f6b4ebaec386baced"
-    },
-    {
-      "name": "libaudit1",
-      "version": "2.2.3",
-      "release": "4.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e009d1b6979ac39c0e27618dba5942c3"
-    },
-    {
-      "name": "libaugeas0",
-      "version": "1.0.0",
-      "release": "2.1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "63550fa63afa6e77580a8d6884a6c77f"
-    },
-    {
-      "name": "libblkid1",
-      "version": "2.23.2",
-      "release": "10.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "9c6dd5053f219a078f1401e88199dc26"
-    },
-    {
-      "name": "libbz2-1",
-      "version": "1.0.6",
-      "release": "26.1.21",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "2038cfa741a8ba0e6b56aac63d703f6b"
-    },
-    {
-      "name": "libcairo2",
-      "version": "1.12.16",
-      "release": "3.4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "15a0a4a0db6c856979afb11197b4eeb3"
-    },
-    {
-      "name": "libcap-ng0",
-      "version": "0.7.3",
-      "release": "2.4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ff489e11773fdc71b9d406bde89e1381"
-    },
-    {
-      "name": "libcap2",
-      "version": "2.22",
-      "release": "10.1.24",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0ccfd0e6dbd1b306506e0d16eec00468"
-    },
-    {
-      "name": "libcom_err2",
-      "version": "1.42.8",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5645879cfe6df2124297129ab092f86e"
-    },
-    {
-      "name": "libcrack2",
-      "version": "2.9.0",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "9a4a1661e1e3e830dca5aff5b8d77f53"
-    },
-    {
-      "name": "libcroco-0_6-3",
-      "version": "0.6.8",
-      "release": "5.1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "230c8e1b9663374894179dd7628a66a3"
-    },
-    {
-      "name": "libcryptsetup4",
-      "version": "1.6.2",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e772c215475c2f72ac5116255f2ae94c"
-    },
-    {
-      "name": "libcurl4",
-      "version": "7.32.0",
-      "release": "2.23.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "bb418fe4e5cae3755720778883cc7664"
-    },
-    {
-      "name": "libdb-4_8",
-      "version": "4.8.30",
-      "release": "25.2.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "3baee52f14ee01e68198cb7610c03322"
-    },
-    {
-      "name": "libdbus-1-3",
-      "version": "1.7.4",
-      "release": "4.16.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a0da1a97770ea31c8e0bafec805ed8ee"
-    },
-    {
-      "name": "libdirectfb-1_6-0",
-      "version": "1.6.3",
-      "release": "4.1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ca55121d3a2297e9d8bc10c9738325d4"
-    },
-    {
-      "name": "libdrm2",
-      "version": "2.4.46",
-      "release": "3.2.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "2da207fa912f1349af8fc1d8637a0844"
-    },
-    {
-      "name": "libdrm_intel1",
-      "version": "2.4.46",
-      "release": "3.2.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "62fc0169329cf763af383b0da526e863"
-    },
-    {
-      "name": "libdrm_nouveau2",
-      "version": "2.4.46",
-      "release": "3.2.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a18e9353eb1c317bfccd1ad22abf1566"
-    },
-    {
-      "name": "libdrm_radeon1",
-      "version": "2.4.46",
-      "release": "3.2.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d91061defa2547678b2b0de5c364009f"
-    },
-    {
-      "name": "libdw1",
-      "version": "0.155",
-      "release": "6.4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "73319688553c542d599fec1f47d01289"
-    },
-    {
-      "name": "libedit0",
-      "version": "3.0.snap20110802",
-      "release": "7.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d31500f21b16f4eb3815959ec5a15c0f"
-    },
-    {
-      "name": "libelf0",
-      "version": "0.8.13",
-      "release": "17.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d9155091b404665cb71e36c27bcc69a8"
-    },
-    {
-      "name": "libelf1",
-      "version": "0.155",
-      "release": "6.4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6d10779115f7c30417a4103bd287f7be"
-    },
-    {
-      "name": "libevtlog0",
-      "version": "0.2.12",
-      "release": "12.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4d45600d9adbbf60df46ff5d148e9a70"
-    },
-    {
-      "name": "libexpat1",
-      "version": "2.1.0",
-      "release": "12.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "46c4c86e71dd79326af7a00af5c690f7"
-    },
-    {
-      "name": "libext2fs2",
-      "version": "1.42.8",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "56ec318b2b982c8fc025e77fb3a93f41"
-    },
-    {
-      "name": "libffi4",
-      "version": "4.8.1_20130909",
-      "release": "3.2.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ce39c74566b70e7a46b0751a5b56e4c7"
-    },
-    {
-      "name": "libfreetype6",
-      "version": "2.5.0.1",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "426e5fbb0c86e5f935578b4e92de4339"
-    },
-    {
-      "name": "libfuse2",
-      "version": "2.9.3",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0f615962ec48302125f39fec4dfffea3"
-    },
-    {
-      "name": "libgbm1",
-      "version": "9.2.3",
-      "release": "61.9.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "9eb77854360e5138934337d7d152c694"
-    },
-    {
-      "name": "libgcc_s1",
-      "version": "4.8.1_20130909",
-      "release": "3.2.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6a367abf63e53464569882ffcd698f70"
-    },
-    {
-      "name": "libgcc_s1-32bit",
-      "version": "4.8.1_20130909",
-      "release": "3.2.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c9bac33254154c1566ad5208eff9f7a2"
-    },
-    {
-      "name": "libgcrypt11",
-      "version": "1.5.3",
-      "release": "2.1.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a6dc91cec093e23ceec6fee703e33e95"
-    },
-    {
-      "name": "libgdbm4",
-      "version": "1.10",
-      "release": "7.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4cb8c4186dfc926b4f2873a6442ae05c"
-    },
-    {
-      "name": "libgio-2_0-0",
-      "version": "2.38.2",
-      "release": "8.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a00a5c8c4fbde932e3a18b3ca8e5d5c3"
-    },
-    {
-      "name": "libglib-2_0-0",
-      "version": "2.38.2",
-      "release": "8.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "99270631b20505414d09a6b6b9de0422"
-    },
-    {
-      "name": "libgmodule-2_0-0",
-      "version": "2.38.2",
-      "release": "8.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "3ce5b5de92df7f91a4565e865828bb8e"
-    },
-    {
-      "name": "libgmp10",
-      "version": "5.1.2",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a947a448ea5e2a77d3210e1d1c9dbf37"
-    },
-    {
-      "name": "libgobject-2_0-0",
-      "version": "2.38.2",
-      "release": "8.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "2f47a18777f0ed9adc321c3f9bdff2c5"
-    },
-    {
-      "name": "libgpg-error0",
-      "version": "1.12",
-      "release": "2.1.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "31618d5fcc288f97f408171c9297bb7a"
-    },
-    {
-      "name": "libgraphite2-3",
-      "version": "1.2.0",
-      "release": "6.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "332daef2e774e011c2266602cc01d933"
-    },
-    {
-      "name": "libgthread-2_0-0",
-      "version": "2.38.2",
-      "release": "8.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "cfea336fe24c959b7db5f6a1fe490514"
-    },
-    {
-      "name": "libharfbuzz0",
-      "version": "0.9.21",
-      "release": "1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "346dde85086a523fa901a43432543468"
-    },
-    {
-      "name": "libidn11",
-      "version": "1.25",
-      "release": "7.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "2dadd34019da8fe689769e7737267a24"
-    },
-    {
-      "name": "libjpeg8",
-      "version": "8.0.2",
-      "release": "24.1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "8858cc6b8090c8e2381ed64e658ccc40"
-    },
-    {
-      "name": "libkeyutils1",
-      "version": "1.5.5",
-      "release": "6.1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "858fb7b3e65610a33440274d503be733"
-    },
-    {
-      "name": "libkmod2",
-      "version": "14",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e3e065ec4387217149c55219c7b1afd6"
-    },
-    {
-      "name": "libksba8",
-      "version": "1.3.0",
-      "release": "5.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5f72603086ca945fec2bbc2730e0733e"
-    },
-    {
-      "name": "libldap-2_4-2",
-      "version": "2.4.33",
-      "release": "8.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "9d7a3c403109ae83fb5ef90d16813500"
-    },
-    {
-      "name": "liblua5_1",
-      "version": "5.1.5",
-      "release": "5.2.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a8512013f8c60e92440662d84f06b060"
-    },
-    {
-      "name": "liblzma5",
-      "version": "5.0.5",
-      "release": "2.1.20",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "12c350cecf9beb9c7ce0a0c6cab03db9"
-    },
-    {
-      "name": "liblzo2-2",
-      "version": "2.06",
-      "release": "12.4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "00037888ac7fecc26b1126320cb14d5b"
-    },
-    {
-      "name": "libmagic1",
-      "version": "5.15",
-      "release": "4.20.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "7a87c0b1d8d90136cd6d1fdc04a23bca"
-    },
-    {
-      "name": "libmodman1",
-      "version": "2.0.1",
-      "release": "14.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f777245b0444d15c3d3decdfe6a1353e"
-    },
-    {
-      "name": "libmount1",
-      "version": "2.23.2",
-      "release": "10.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4da095e797ed8c1bf454c06adae31db6"
-    },
-    {
-      "name": "libmozjs-17_0",
-      "version": "17.0",
-      "release": "4.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "2b6c101161d094f53439e710e2674a45"
-    },
-    {
-      "name": "libncurses5",
-      "version": "5.9",
-      "release": "33.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "40748e3e80ecff89afb129ae0eee82cc"
-    },
-    {
-      "name": "libncurses5-32bit",
-      "version": "5.9",
-      "release": "33.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "cdca2990295df2ecc6a3316690e709e7"
-    },
-    {
-      "name": "libncurses6",
-      "version": "5.9",
-      "release": "33.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "33b9de30610593053b0b5849a87ff256"
-    },
-    {
-      "name": "libnet1",
-      "version": "1.1.6",
-      "release": "2.2.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "125baae561665d24a1c3034faabe3996"
-    },
-    {
-      "name": "libopenssl1_0_0",
-      "version": "1.0.1h",
-      "release": "11.48.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d1cbe4dacd6500533d5d40f59cc9d912"
-    },
-    {
-      "name": "libpango-1_0-0",
-      "version": "1.36.1",
-      "release": "4.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e12878a0e5640449f36b67070080a228"
-    },
-    {
-      "name": "libpci3",
-      "version": "3.2.0",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "adda37eb1a9534b302c61f1a4c69c3a3"
-    },
-    {
-      "name": "libpciaccess0",
-      "version": "0.13.2",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ba1b4a06415344d05f2c60a3d838607e"
-    },
-    {
-      "name": "libpcre1",
-      "version": "8.33",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0e425f92d1473b2eee16216ceefc2540"
-    },
-    {
-      "name": "libpixman-1-0",
-      "version": "0.30.2",
-      "release": "2.5.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "87bf57588a4fc9d4e967f66057401d16"
-    },
-    {
-      "name": "libply-boot-client2",
-      "version": "0.8.8_git201309032142",
-      "release": "2.5.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d9639e736c3b4026a9c8d73445860ee0"
-    },
-    {
-      "name": "libply-splash-core2",
-      "version": "0.8.8_git201309032142",
-      "release": "2.5.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "7ddb803703fe3d09446d6cf1b6dbff7b"
-    },
-    {
-      "name": "libply-splash-graphics2",
-      "version": "0.8.8_git201309032142",
-      "release": "2.5.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "300cfe8a83fcbcea07ff48f6f759b3f6"
-    },
-    {
-      "name": "libply2",
-      "version": "0.8.8_git201309032142",
-      "release": "2.5.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b68bf0706b57f6655bd5dbd04d5e104b"
-    },
-    {
-      "name": "libpng16-16",
-      "version": "1.6.6",
-      "release": "12.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "78b3d50bfefda1bad94b24861e0499a3"
-    },
-    {
-      "name": "libpolkit0",
-      "version": "0.112",
-      "release": "2.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "21b6a6b2e7488158ceeead9a34e1ee9d"
-    },
-    {
-      "name": "libpopt0",
-      "version": "1.16",
-      "release": "24.1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0f3c6b975dd8802652d3ca219954ed05"
-    },
-    {
-      "name": "libprocps1",
-      "version": "3.3.8",
-      "release": "5.4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "3491e58c99895c6c0b73a16d41765a4a"
-    },
-    {
-      "name": "libproxy1",
-      "version": "0.4.11",
-      "release": "9.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "cfb3b6740fa83e86ec3cc024661db593"
-    },
-    {
-      "name": "libpth20",
-      "version": "2.0.7",
-      "release": "138.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0172d0b91fc59486c7fedb0e35304f2e"
-    },
-    {
-      "name": "libqrencode3",
-      "version": "3.4.2",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "408c2c66bca2856a0182a32a0b9309da"
-    },
-    {
-      "name": "libreadline6",
-      "version": "6.2",
-      "release": "68.1.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "3e32ca4079cc131cc51d84d521ec6638"
-    },
-    {
-      "name": "libselinux1",
-      "version": "2.1.13",
-      "release": "4.1.21",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "8eb702959d41bc1eb402f1a419f464b7"
-    },
-    {
-      "name": "libsemanage1",
-      "version": "2.1.10",
-      "release": "3.1.20",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "88d84028f1221eb388cfffcd59c7f578"
-    },
-    {
-      "name": "libsepol1",
-      "version": "2.1.9",
-      "release": "5.1.23",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5ab32ec052ee5dbcb1fb4c891991e5cc"
-    },
-    {
-      "name": "libsgutils2-2",
-      "version": "1.36",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d5e5cab2704598e8f594205cb5bd9874"
-    },
-    {
-      "name": "libsolv-tools",
-      "version": "0.4.2",
-      "release": "11.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "828ae058721f75cf8240b988af5728ab"
-    },
-    {
-      "name": "libssh2-1",
-      "version": "1.4.3",
-      "release": "7.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d23a114cbbc1613cda7098c335b0c1dd"
-    },
-    {
-      "name": "libstdc++6",
-      "version": "4.8.1_20130909",
-      "release": "3.2.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "97b33e0029cb4a5c7573d8c045f234db"
-    },
-    {
-      "name": "libstdc++6-32bit",
-      "version": "4.8.1_20130909",
-      "release": "3.2.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b4ec184c5dbf51377066355f3e6d1137"
-    },
-    {
-      "name": "libtirpc1",
-      "version": "0.2.3",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "00a5301be37b29094eca890d5863612d"
-    },
-    {
-      "name": "libts-1_0-0",
-      "version": "1.0",
-      "release": "5.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f2b6fdfece2e79ddadec0f5f8483e083"
-    },
-    {
-      "name": "libudev-mini1",
-      "version": "208",
-      "release": "23.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d6429c4578dc2c099bb9ecece60bae72"
-    },
-    {
-      "name": "libusb-0_1-4",
-      "version": "0.1.13",
-      "release": "27.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c6e02bfa2aec095b34606de1e4713be1"
-    },
-    {
-      "name": "libusb-1_0-0",
-      "version": "1.0.9",
-      "release": "8.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "cb909261aef3b3ced30c81504f74cb5e"
-    },
-    {
-      "name": "libustr-1_0-1",
-      "version": "1.0.4",
-      "release": "29.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "cf086ac2f3e4ea6ae1d9c9fe50f073c8"
-    },
-    {
-      "name": "libutempter0",
-      "version": "1.1.6",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d5c359ce81477afccab1b796ce24e43a"
-    },
-    {
-      "name": "libuuid1",
-      "version": "2.23.2",
-      "release": "10.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "3e34463d1100a619f7ec0b8148b9848f"
-    },
-    {
-      "name": "libvdpau1",
-      "version": "0.6",
-      "release": "3.1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b3ecac5402abe3a8a4935e88d6ebb968"
-    },
-    {
-      "name": "libwayland-client0",
-      "version": "1.2.1",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "7c6f0b1d0064d308131ad91bd12e144c"
-    },
-    {
-      "name": "libwayland-server0",
-      "version": "1.2.1",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d34cdcf483e6f5b260d13973275ee467"
-    },
-    {
-      "name": "libwrap0",
-      "version": "7.6",
-      "release": "881.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "fe377bd99e7d334d9cf79848016f032a"
-    },
-    {
-      "name": "libx86-1",
-      "version": "1.1",
-      "release": "41.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d2b38998dccdf7e221bdec63d78933eb"
-    },
-    {
-      "name": "libx86emu1",
-      "version": "1.1",
-      "release": "20.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "912a60a01b66c8c9d282119be497e270"
-    },
-    {
-      "name": "libxcb-dri2-0",
-      "version": "1.9.1",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "649520326303a5d21a57768a402d4fe4"
-    },
-    {
-      "name": "libxcb-glx0",
-      "version": "1.9.1",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a5f1959e50b120d6b609e6bcda4c3873"
-    },
-    {
-      "name": "libxcb-render0",
-      "version": "1.9.1",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4f197686e4e1bf8a60c0fb360956e079"
-    },
-    {
-      "name": "libxcb-shm0",
-      "version": "1.9.1",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "9a6e1ab0bdee52ee16b9583fadf7e8d6"
-    },
-    {
-      "name": "libxcb-xfixes0",
-      "version": "1.9.1",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6da557e15067061ee5de5f84423d1bad"
-    },
-    {
-      "name": "libxcb1",
-      "version": "1.9.1",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "89d7a9b0a91c234d1df3a683fe9186de"
-    },
-    {
-      "name": "libxml2-2",
-      "version": "2.9.1",
-      "release": "2.12.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "453ae3a9447b84b8d64322f6911254a0"
-    },
-    {
-      "name": "libxtables10",
-      "version": "1.4.19.1",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "785f963cead3b708f5ceb2377fcfb2a4"
-    },
-    {
-      "name": "libz1",
-      "version": "1.2.8",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "2c6323ebf13e698b42fecd70ea601c52"
-    },
-    {
-      "name": "libzio1",
-      "version": "1.00",
-      "release": "8.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e00e07f2c70171d40b4afad9ee731c7d"
-    },
-    {
-      "name": "libzypp",
-      "version": "13.10.2",
-      "release": "19.6",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4f176ae6996a659b459abd00b7405968"
-    },
-    {
-      "name": "logrotate",
-      "version": "3.8.7",
-      "release": "4.8.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "bcfdc3052257777a4f6586afa50d410d"
-    },
-    {
-      "name": "lvm2",
-      "version": "2.02.98",
-      "release": "0.28.18.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6b0b4c3aedeabd583a01eff007b3ef76"
-    },
-    {
-      "name": "mkinitrd",
-      "version": "2.8.1",
-      "release": "5.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ab63ea6f80dbf1309878e1240c3ef692"
-    },
-    {
-      "name": "module-init-tools",
-      "version": "3.15",
-      "release": "11.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "cf47c19d69be792c1b64d78767b213b1"
-    },
-    {
-      "name": "mozilla-nspr",
-      "version": "4.10.6",
-      "release": "12.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d77927f3a2bc2d037c4fdb42217b4c40"
-    },
-    {
-      "name": "ncurses-utils",
-      "version": "5.9",
-      "release": "33.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c895c8627563350384a954bd51e07dbc"
-    },
-    {
-      "name": "net-tools",
-      "version": "1.60",
-      "release": "763.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a096fec9cbf5b4f058e04161660932cf"
-    },
-    {
-      "name": "netcfg",
-      "version": "11.5",
-      "release": "18.1.2",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "b0348797ab50ad507322a0a844dc46f4"
-    },
-    {
-      "name": "openSUSE-build-key",
-      "version": "1.0",
-      "release": "24.4.1",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "22293922b1ec9e499c86ccc994f8e9d7"
-    },
-    {
-      "name": "openSUSE-release",
-      "version": "13.1",
-      "release": "1.10",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c1346b9611b400c2b846c9304c83dda3"
-    },
-    {
-      "name": "openSUSE-release-ftp",
-      "version": "13.1",
-      "release": "1.10",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e90b96f60c978c73e0bb2575ff511c51"
-    },
-    {
-      "name": "openslp",
-      "version": "1.2.0",
-      "release": "202.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "8e939a55456389bfeb670f1d77c7ac3d"
-    },
-    {
-      "name": "openssh",
-      "version": "6.2p2",
-      "release": "3.4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "7c9c818cd3aa7487fe215fa82c3ba79e"
-    },
-    {
-      "name": "openssl",
-      "version": "1.0.1h",
-      "release": "11.48.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "7777920545e792199d03427521040ad5"
-    },
-    {
-      "name": "os-prober",
-      "version": "1.61",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b7d25d6b4f513daa5fca261a6c1e90f9"
-    },
-    {
-      "name": "pam",
-      "version": "1.1.8",
-      "release": "6.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "20662211b201c9e816eff1ceac3ead74"
-    },
-    {
-      "name": "pam-config",
-      "version": "0.86",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "7b0c19ae19a63d125e4ce5034f392c21"
-    },
-    {
-      "name": "pango-tools",
-      "version": "1.36.1",
-      "release": "4.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "9055f8babdc6fb56592931a6837ae69a"
-    },
-    {
-      "name": "patterns-openSUSE-base",
-      "version": "13.1",
-      "release": "13.6.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4b0d596406c411cc27784afb5ded1fd0"
-    },
-    {
-      "name": "perl",
-      "version": "5.18.1",
-      "release": "2.1.11",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "8e2b84ae89fe86c94fd9bb874b32c7bc"
-    },
-    {
-      "name": "perl-Bootloader",
-      "version": "0.711",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c3e5fff04d51da7f39d03113b94da96c"
-    },
-    {
-      "name": "perl-base",
-      "version": "5.18.1",
-      "release": "2.1.11",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "30ba609525fa4599dd9343cba0fce90e"
-    },
-    {
-      "name": "permissions",
-      "version": "2013.08.22.1339",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "bce0da0f540d62d824e562606cf5aea5"
-    },
-    {
-      "name": "pigz",
-      "version": "2.3",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "913fd953da8f90159f0d63182283b9b2"
-    },
-    {
-      "name": "pinentry",
-      "version": "0.8.3",
-      "release": "2.1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0bfe88da0719c9e26862fc51b1905116"
-    },
-    {
-      "name": "pkg-config",
-      "version": "0.28",
-      "release": "4.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c745e0069f89e5fc4c58b83da285ad4a"
-    },
-    {
-      "name": "plymouth",
-      "version": "0.8.8_git201309032142",
-      "release": "2.5.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d6398532c251b29da885a96c3a0ce038"
-    },
-    {
-      "name": "plymouth-branding-openSUSE",
-      "version": "13.1",
-      "release": "10.4.13",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "e88bcce224aa1d3439dd020b2ff32879"
-    },
-    {
-      "name": "plymouth-plugin-label",
-      "version": "0.8.8_git201309032142",
-      "release": "2.5.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "dd868cb02f0c79ea3d47af8c725cdef6"
-    },
-    {
-      "name": "plymouth-plugin-script",
-      "version": "0.8.8_git201309032142",
-      "release": "2.5.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "fd176b49f8dd666a59bffef44d9a5fc5"
-    },
-    {
-      "name": "plymouth-scripts",
-      "version": "0.8.8_git201309032142",
-      "release": "2.5.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a5d19131bd0eb21bd021c57c7475052f"
-    },
-    {
-      "name": "polkit",
-      "version": "0.112",
-      "release": "2.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "41403fe43867063f72681ae8164a3d57"
-    },
-    {
-      "name": "polkit-default-privs",
-      "version": "13.1",
-      "release": "10.2.1",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "9d9d6fa282cda6f79912d9494713c081"
-    },
-    {
-      "name": "procps",
-      "version": "3.3.8",
-      "release": "5.4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0c3f5603c5057d124e90ef7ee72d3f69"
-    },
-    {
-      "name": "rpcbind",
-      "version": "0.2.0_git201103171419",
-      "release": "12.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "25d3938bd3ab1cf13847889b5cb12dff"
-    },
-    {
-      "name": "rpm",
-      "version": "4.11.1",
-      "release": "6.5.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "7dfdd742a9b7d60c75bf4844d294716d"
-    },
-    {
-      "name": "rsync",
-      "version": "3.1.0",
-      "release": "21.8.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "13635fe58b4b2c6a9f76e02a8250d8fb"
-    },
-    {
-      "name": "sed",
-      "version": "4.2.2",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "8a6c03daa0669218cbbc05e258c5ad81"
-    },
-    {
-      "name": "sg3_utils",
-      "version": "1.36",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "bba22b2f04875ccff4e13ba6f8075ea3"
-    },
-    {
-      "name": "shadow",
-      "version": "4.1.5.1",
-      "release": "8.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "cb7e22465082019199af847b8cbe7834"
-    },
-    {
-      "name": "shared-mime-info",
-      "version": "1.1",
-      "release": "2.1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "bf68c9e63bf5e922dfd008f049089e2b"
-    },
-    {
-      "name": "splashy",
-      "version": "0.3.13",
-      "release": "44.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "63a6da3457e7918998f0ff920dfb054b"
-    },
-    {
-      "name": "suse-module-tools",
-      "version": "12.3",
-      "release": "6.1.2",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "9d9e2673781ab036c1b9a4bce6f12f37"
-    },
-    {
-      "name": "suspend",
-      "version": "1.0",
-      "release": "28.1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "26451ace66afc822d02a05bf42b9d754"
-    },
-    {
-      "name": "sysconfig",
-      "version": "0.81.5",
-      "release": "30.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b9b91cd68eacb46e0206fe0f0c6a5942"
-    },
-    {
-      "name": "sysconfig-netconfig",
-      "version": "0.81.5",
-      "release": "30.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b9f3fb0bb05bd06c1fa89e7096a4afd4"
-    },
-    {
-      "name": "sysconfig-network",
-      "version": "0.81.5",
-      "release": "30.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "465047025d6fa03bab9024dd3c8f70a8"
-    },
-    {
-      "name": "sysfsutils",
-      "version": "2.1.0",
-      "release": "150.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "9376708eb251f9ebfbc8cfafcdc30169"
-    },
-    {
-      "name": "syslog-ng",
-      "version": "3.4.7",
-      "release": "2.8.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "92e7fc363269742ad16bacbf00be38d6"
-    },
-    {
-      "name": "syslog-service",
-      "version": "2.0",
-      "release": "772.1.2",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "a9fffdfca30d09868c5665fc38a13f82"
-    },
-    {
-      "name": "systemd",
-      "version": "208",
-      "release": "23.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "2b203bd567b59d3835591a8586b8df32"
-    },
-    {
-      "name": "systemd-presets-branding-openSUSE",
-      "version": "0.3.0",
-      "release": "3.4.1",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "6ef5619371f03c12ea11ffd668067088"
-    },
-    {
-      "name": "systemd-sysvinit",
-      "version": "208",
-      "release": "23.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4206c307df74dde5516a1acbdeb6ee25"
-    },
-    {
-      "name": "sysvinit-tools",
-      "version": "2.88+",
-      "release": "89.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "950eb6c1cd1b191440587a6b5feb9dca"
-    },
-    {
-      "name": "tar",
-      "version": "1.26",
-      "release": "19.4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c98f23f345f27d05108cb1482b43400a"
-    },
-    {
-      "name": "terminfo-base",
-      "version": "5.9",
-      "release": "33.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6419d9cff92c0bb11694b63d9f65c69b"
-    },
-    {
-      "name": "time",
-      "version": "1.7",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "eb72e62ff0e0dfeae621d9dc7ebe9a9c"
-    },
-    {
-      "name": "timezone",
-      "version": "2013h",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "afddca087f38f0f0d47cc3bc37575b4e"
-    },
-    {
-      "name": "tunctl",
-      "version": "1.5",
-      "release": "22.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "3570c4a86602c8f3575a345b7a6553dc"
-    },
-    {
-      "name": "udev-mini",
-      "version": "208",
-      "release": "23.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "8bfcd579f0b8f1bdd903e0947fa3be1c"
-    },
-    {
-      "name": "udevmountd",
-      "version": "0.81.5",
-      "release": "30.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e2f7d6d173a65b36934925b4774cc251"
-    },
-    {
-      "name": "update-alternatives",
-      "version": "1.16.10",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f9d7fb20379a381881ccbba425a22b57"
-    },
-    {
-      "name": "util-linux",
-      "version": "2.23.2",
-      "release": "10.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d79c422626e5fc3abc363994aace3873"
-    },
-    {
-      "name": "vim",
-      "version": "7.4.052",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ad3d655834f823280555d2aba0d43621"
-    },
-    {
-      "name": "vlan",
-      "version": "1.9",
-      "release": "136.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c3832b61a2a30a6d6a760c1513e2ca8f"
-    },
-    {
-      "name": "wallpaper-branding-openSUSE",
-      "version": "13.1",
-      "release": "10.4.13",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "7830ced9c0641c7853d20680e906456e"
-    },
-    {
-      "name": "which",
-      "version": "2.20",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "72fca6588383d5907d5230d025b14c82"
-    },
-    {
-      "name": "xz",
-      "version": "5.0.5",
-      "release": "2.1.20",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "01142bc3c09c23ae7c6b764d1ae51e42"
-    },
-    {
-      "name": "zypper",
-      "version": "1.9.16",
-      "release": "22.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4a87f6b9ceae5d40a411fe52d0f17050"
-    }
-  ],
+  "packages": {
+    "package_system": "rpm",
+    "packages": [
+      {
+        "name": "DirectFB",
+        "version": "1.6.3",
+        "release": "4.1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f7ab84032a0b07fe079030b0abb441d3"
+      },
+      {
+        "name": "Mesa",
+        "version": "9.2.3",
+        "release": "61.9.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d3350e07a011f5731cb7a787e0ed11a8"
+      },
+      {
+        "name": "Mesa-libEGL1",
+        "version": "9.2.3",
+        "release": "61.9.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d36cf64cb1860e7130b10ab13de55285"
+      },
+      {
+        "name": "Mesa-libGL1",
+        "version": "9.2.3",
+        "release": "61.9.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ee2ea91c3be8552be55f6a28e60fc3ec"
+      },
+      {
+        "name": "Mesa-libGLESv2-2",
+        "version": "9.2.3",
+        "release": "61.9.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0939ad04af12d3974b5b383a743889e8"
+      },
+      {
+        "name": "Mesa-libglapi0",
+        "version": "9.2.3",
+        "release": "61.9.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6659ebca0af2e8d9baf42f6b768d5273"
+      },
+      {
+        "name": "aaa_base",
+        "version": "13.1",
+        "release": "16.42.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "503e92b38ac00bd311ce7527e907d6d6"
+      },
+      {
+        "name": "adjtimex",
+        "version": "1.29",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6fe8798263f38820e050b3912f41b2a4"
+      },
+      {
+        "name": "bash",
+        "version": "4.2",
+        "release": "68.1.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "533e40ba8a5551204b528c047e45c169"
+      },
+      {
+        "name": "branding-openSUSE",
+        "version": "13.1",
+        "release": "10.4.13",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "c52a3adf23bef50cecf7d265354c78a0"
+      },
+      {
+        "name": "bridge-utils",
+        "version": "1.5",
+        "release": "16.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "322087a0b95cb45a405f7300d3b8a86a"
+      },
+      {
+        "name": "bzip2",
+        "version": "1.0.6",
+        "release": "26.1.21",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ed4d63829fb89c41e6836ee77b8a6a36"
+      },
+      {
+        "name": "coreutils",
+        "version": "8.21",
+        "release": "7.16.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "72ecfca8b13198813ff596769600155d"
+      },
+      {
+        "name": "cpio",
+        "version": "2.11",
+        "release": "25.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "981d0c41ebf01ca7c48d3b9b2a4cc5ff"
+      },
+      {
+        "name": "cracklib",
+        "version": "2.9.0",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ef05b58179386b1ec5ceb75c2b28f3c7"
+      },
+      {
+        "name": "cracklib-dict-full",
+        "version": "2.8.12",
+        "release": "62.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f401ce4c8686f47cf1036302dd38d203"
+      },
+      {
+        "name": "cron",
+        "version": "4.2",
+        "release": "50.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "26a9db1420ea73406246e0a8a420b7e2"
+      },
+      {
+        "name": "cronie",
+        "version": "1.4.8",
+        "release": "50.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "47c2ffa29dc838c13d916045331b8f39"
+      },
+      {
+        "name": "cyrus-sasl",
+        "version": "2.1.25",
+        "release": "28.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "1febe5c5413e4151ba47fefdf622bc5f"
+      },
+      {
+        "name": "dbus-1",
+        "version": "1.7.4",
+        "release": "4.16.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "81a54ec6c964f0ab983fc5368fa3ea03"
+      },
+      {
+        "name": "dbus-1-x11",
+        "version": "1.7.4",
+        "release": "4.16.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "705313fb41bdde2b8c54f45603dcc9d9"
+      },
+      {
+        "name": "device-mapper",
+        "version": "1.02.78",
+        "release": "0.14.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5966592e4352931f7a53bf036e1ee8b9"
+      },
+      {
+        "name": "dhcpcd",
+        "version": "3.2.3",
+        "release": "47.78.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a41747eb196b296f2f8db34401bc0390"
+      },
+      {
+        "name": "diffutils",
+        "version": "3.3",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "908f0790c137980d435a876862bd6cc9"
+      },
+      {
+        "name": "dirmngr",
+        "version": "1.1.0",
+        "release": "18.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6ef4f2839e67d361f8daef05d26dd58e"
+      },
+      {
+        "name": "dmraid",
+        "version": "1.0.0.rc16",
+        "release": "25.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "00f7738e99a14874fcec444ed54a60f9"
+      },
+      {
+        "name": "e2fsprogs",
+        "version": "1.42.8",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c91c5b90bf3fe6fb6d14dca13f9e89f9"
+      },
+      {
+        "name": "elfutils",
+        "version": "0.155",
+        "release": "6.4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6d3e828799be2f3277013aa4e55885c4"
+      },
+      {
+        "name": "expat",
+        "version": "2.1.0",
+        "release": "12.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "268ba7a859ea5aab034ae57ab48ff9d6"
+      },
+      {
+        "name": "file",
+        "version": "5.15",
+        "release": "4.20.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a6f7a3339d9a35f2c3fd59d7579dce20"
+      },
+      {
+        "name": "file-magic",
+        "version": "5.15",
+        "release": "4.20.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a4c8755a5fbff1622ccf8154bcdb0723"
+      },
+      {
+        "name": "filesystem",
+        "version": "13.1",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "35c6b72b11240b2b60ca6aa01261e2f2"
+      },
+      {
+        "name": "fillup",
+        "version": "1.42",
+        "release": "269.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "bf192d483b3b2c69a03e9c270f01705f"
+      },
+      {
+        "name": "findutils",
+        "version": "4.5.12",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4e8bdc044364eade7a2dfc754dd7e172"
+      },
+      {
+        "name": "fontconfig",
+        "version": "2.11.0",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "518c8c930443a2ca35031419288dcd84"
+      },
+      {
+        "name": "gawk",
+        "version": "4.1.0",
+        "release": "2.1.14",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "84980e1ce8eeb88eb28edecfe3fb93da"
+      },
+      {
+        "name": "gettext-runtime",
+        "version": "0.18.3.1",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5fa81a9dd0d81c18db234f79f1824959"
+      },
+      {
+        "name": "gio-branding-openSUSE",
+        "version": "13.1",
+        "release": "2.13.1",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "6f33b8040e1954545050b634b6123716"
+      },
+      {
+        "name": "glib2-tools",
+        "version": "2.38.2",
+        "release": "8.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a2d8a24f6f5005895da45d653bd9e74b"
+      },
+      {
+        "name": "glibc",
+        "version": "2.18",
+        "release": "4.15.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c445d03338a18ed5df13008fcfbc42f7"
+      },
+      {
+        "name": "glibc-32bit",
+        "version": "2.18",
+        "release": "4.15.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "3aa78168eebef10365b78fc061894155"
+      },
+      {
+        "name": "gnu-unifont-bitmap-fonts",
+        "version": "20080123",
+        "release": "82.1.2",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "246ea5728ea7c96ceffcb0d88e8d9198"
+      },
+      {
+        "name": "gpg2",
+        "version": "2.0.22",
+        "release": "8.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6c2bfb0eb55ecd31a0c657323b1e2d80"
+      },
+      {
+        "name": "grep",
+        "version": "2.14",
+        "release": "5.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "9b5eff76470cec4750c13e09b68307b4"
+      },
+      {
+        "name": "grub",
+        "version": "0.97",
+        "release": "194.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "1aa5c0f0a344b2686adab527e966d093"
+      },
+      {
+        "name": "grub2",
+        "version": "2.00",
+        "release": "39.8.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "3a9bc35cf452103ed484e7dad70485be"
+      },
+      {
+        "name": "grub2-i386-pc",
+        "version": "2.00",
+        "release": "39.8.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "95211e0bde6dedb7a32a3bf97a39dab0"
+      },
+      {
+        "name": "gzip",
+        "version": "1.6",
+        "release": "4.2.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "79db5125f8b7ad6837fe453212af5cd3"
+      },
+      {
+        "name": "hwinfo",
+        "version": "20.2",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6a5d3c3fae0661286d845cc05b160ded"
+      },
+      {
+        "name": "info",
+        "version": "4.13a",
+        "release": "36.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ca47c27038491958bce289e5b9217883"
+      },
+      {
+        "name": "insserv-compat",
+        "version": "0.1",
+        "release": "8.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a7bf3cd6f00f08ecac430d01b921e2a2"
+      },
+      {
+        "name": "iproute2",
+        "version": "3.9.0",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "88eaf0491ad1d8a2b46101ba652ae435"
+      },
+      {
+        "name": "iputils",
+        "version": "s20101006",
+        "release": "23.4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f288609e60d206fbf0b58ba17be2e91e"
+      },
+      {
+        "name": "kbd",
+        "version": "1.15.5",
+        "release": "5.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "7efca8396c5f237f3285e9d32976b740"
+      },
+      {
+        "name": "kernel-default",
+        "version": "3.11.10",
+        "release": "21.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "1f02808a7737e2165b6d43dc89925b98"
+      },
+      {
+        "name": "klogd",
+        "version": "1.4.1",
+        "release": "772.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ec248c9cacac4d32879f9c5956aee989"
+      },
+      {
+        "name": "kmod",
+        "version": "14",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "02ac0f892dcf5f1e89c302eb72302864"
+      },
+      {
+        "name": "kpartx",
+        "version": "0.4.9",
+        "release": "11.4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "19518e85b4efa2f214d72f83f6509dce"
+      },
+      {
+        "name": "krb5",
+        "version": "1.11.3",
+        "release": "3.8.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "99c2b99fc2883995ac6d7260be4cf945"
+      },
+      {
+        "name": "libICE6",
+        "version": "1.0.8",
+        "release": "7.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "3e83dca788686f352e2fd5e274fa9924"
+      },
+      {
+        "name": "libLLVM",
+        "version": "3.3",
+        "release": "6.4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "7f33572a255596090c19755445b6d5cd"
+      },
+      {
+        "name": "libSM6",
+        "version": "1.2.2",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "56ffc029177a9d59208a47b543b22f40"
+      },
+      {
+        "name": "libX11-6",
+        "version": "1.6.2",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "55772cdf402ae64da9062c5af6ad23c6"
+      },
+      {
+        "name": "libX11-data",
+        "version": "1.6.2",
+        "release": "2.1.2",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "45c5eb39c862ddcfa74e1ed6a293cff9"
+      },
+      {
+        "name": "libX11-xcb1",
+        "version": "1.6.2",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b2bc2a4765ae26f15f78e9880d998346"
+      },
+      {
+        "name": "libXau6",
+        "version": "1.0.8",
+        "release": "2.2.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "264008603b7067b1374320d913a67b50"
+      },
+      {
+        "name": "libXdamage1",
+        "version": "1.1.4",
+        "release": "6.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d720db9f2c345cfbb6d021ccc6675eaf"
+      },
+      {
+        "name": "libXext6",
+        "version": "1.3.2",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6c1045b4f2b6de12b292918d89b88d91"
+      },
+      {
+        "name": "libXfixes3",
+        "version": "5.0.1",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "2dce65a71fe23c5413a406de9ae9f242"
+      },
+      {
+        "name": "libXft2",
+        "version": "2.3.1",
+        "release": "7.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "390d0a5a5e21e476b0e916fd6aa6858f"
+      },
+      {
+        "name": "libXrender1",
+        "version": "0.9.8",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "9f18b64f2fe146aff06badbd5c95d8ae"
+      },
+      {
+        "name": "libXt6",
+        "version": "1.1.4",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c3ad229d17418d328e4cb36f71e82c8f"
+      },
+      {
+        "name": "libXxf86vm1",
+        "version": "1.1.3",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f0bd67d4c0b7dbd4aa3190383703aad6"
+      },
+      {
+        "name": "libacl1",
+        "version": "2.2.52",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "aa481c6f36a50f65c5e1f49c8e56b6cd"
+      },
+      {
+        "name": "libadns1",
+        "version": "1.4",
+        "release": "100.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "809f26d07084f2efe61a0ba4c4cc9a49"
+      },
+      {
+        "name": "libasm1",
+        "version": "0.155",
+        "release": "6.4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c23167b5cf1585cc3190d7f5eb123b61"
+      },
+      {
+        "name": "libassuan0",
+        "version": "2.1.1",
+        "release": "2.1.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "27baf0c90065f8b789e00ff0c8e58c8a"
+      },
+      {
+        "name": "libattr1",
+        "version": "2.4.47",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "36475f1e0b33db0f6b4ebaec386baced"
+      },
+      {
+        "name": "libaudit1",
+        "version": "2.2.3",
+        "release": "4.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e009d1b6979ac39c0e27618dba5942c3"
+      },
+      {
+        "name": "libaugeas0",
+        "version": "1.0.0",
+        "release": "2.1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "63550fa63afa6e77580a8d6884a6c77f"
+      },
+      {
+        "name": "libblkid1",
+        "version": "2.23.2",
+        "release": "10.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "9c6dd5053f219a078f1401e88199dc26"
+      },
+      {
+        "name": "libbz2-1",
+        "version": "1.0.6",
+        "release": "26.1.21",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "2038cfa741a8ba0e6b56aac63d703f6b"
+      },
+      {
+        "name": "libcairo2",
+        "version": "1.12.16",
+        "release": "3.4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "15a0a4a0db6c856979afb11197b4eeb3"
+      },
+      {
+        "name": "libcap-ng0",
+        "version": "0.7.3",
+        "release": "2.4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ff489e11773fdc71b9d406bde89e1381"
+      },
+      {
+        "name": "libcap2",
+        "version": "2.22",
+        "release": "10.1.24",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0ccfd0e6dbd1b306506e0d16eec00468"
+      },
+      {
+        "name": "libcom_err2",
+        "version": "1.42.8",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5645879cfe6df2124297129ab092f86e"
+      },
+      {
+        "name": "libcrack2",
+        "version": "2.9.0",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "9a4a1661e1e3e830dca5aff5b8d77f53"
+      },
+      {
+        "name": "libcroco-0_6-3",
+        "version": "0.6.8",
+        "release": "5.1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "230c8e1b9663374894179dd7628a66a3"
+      },
+      {
+        "name": "libcryptsetup4",
+        "version": "1.6.2",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e772c215475c2f72ac5116255f2ae94c"
+      },
+      {
+        "name": "libcurl4",
+        "version": "7.32.0",
+        "release": "2.23.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "bb418fe4e5cae3755720778883cc7664"
+      },
+      {
+        "name": "libdb-4_8",
+        "version": "4.8.30",
+        "release": "25.2.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "3baee52f14ee01e68198cb7610c03322"
+      },
+      {
+        "name": "libdbus-1-3",
+        "version": "1.7.4",
+        "release": "4.16.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a0da1a97770ea31c8e0bafec805ed8ee"
+      },
+      {
+        "name": "libdirectfb-1_6-0",
+        "version": "1.6.3",
+        "release": "4.1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ca55121d3a2297e9d8bc10c9738325d4"
+      },
+      {
+        "name": "libdrm2",
+        "version": "2.4.46",
+        "release": "3.2.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "2da207fa912f1349af8fc1d8637a0844"
+      },
+      {
+        "name": "libdrm_intel1",
+        "version": "2.4.46",
+        "release": "3.2.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "62fc0169329cf763af383b0da526e863"
+      },
+      {
+        "name": "libdrm_nouveau2",
+        "version": "2.4.46",
+        "release": "3.2.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a18e9353eb1c317bfccd1ad22abf1566"
+      },
+      {
+        "name": "libdrm_radeon1",
+        "version": "2.4.46",
+        "release": "3.2.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d91061defa2547678b2b0de5c364009f"
+      },
+      {
+        "name": "libdw1",
+        "version": "0.155",
+        "release": "6.4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "73319688553c542d599fec1f47d01289"
+      },
+      {
+        "name": "libedit0",
+        "version": "3.0.snap20110802",
+        "release": "7.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d31500f21b16f4eb3815959ec5a15c0f"
+      },
+      {
+        "name": "libelf0",
+        "version": "0.8.13",
+        "release": "17.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d9155091b404665cb71e36c27bcc69a8"
+      },
+      {
+        "name": "libelf1",
+        "version": "0.155",
+        "release": "6.4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6d10779115f7c30417a4103bd287f7be"
+      },
+      {
+        "name": "libevtlog0",
+        "version": "0.2.12",
+        "release": "12.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4d45600d9adbbf60df46ff5d148e9a70"
+      },
+      {
+        "name": "libexpat1",
+        "version": "2.1.0",
+        "release": "12.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "46c4c86e71dd79326af7a00af5c690f7"
+      },
+      {
+        "name": "libext2fs2",
+        "version": "1.42.8",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "56ec318b2b982c8fc025e77fb3a93f41"
+      },
+      {
+        "name": "libffi4",
+        "version": "4.8.1_20130909",
+        "release": "3.2.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ce39c74566b70e7a46b0751a5b56e4c7"
+      },
+      {
+        "name": "libfreetype6",
+        "version": "2.5.0.1",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "426e5fbb0c86e5f935578b4e92de4339"
+      },
+      {
+        "name": "libfuse2",
+        "version": "2.9.3",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0f615962ec48302125f39fec4dfffea3"
+      },
+      {
+        "name": "libgbm1",
+        "version": "9.2.3",
+        "release": "61.9.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "9eb77854360e5138934337d7d152c694"
+      },
+      {
+        "name": "libgcc_s1",
+        "version": "4.8.1_20130909",
+        "release": "3.2.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6a367abf63e53464569882ffcd698f70"
+      },
+      {
+        "name": "libgcc_s1-32bit",
+        "version": "4.8.1_20130909",
+        "release": "3.2.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c9bac33254154c1566ad5208eff9f7a2"
+      },
+      {
+        "name": "libgcrypt11",
+        "version": "1.5.3",
+        "release": "2.1.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a6dc91cec093e23ceec6fee703e33e95"
+      },
+      {
+        "name": "libgdbm4",
+        "version": "1.10",
+        "release": "7.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4cb8c4186dfc926b4f2873a6442ae05c"
+      },
+      {
+        "name": "libgio-2_0-0",
+        "version": "2.38.2",
+        "release": "8.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a00a5c8c4fbde932e3a18b3ca8e5d5c3"
+      },
+      {
+        "name": "libglib-2_0-0",
+        "version": "2.38.2",
+        "release": "8.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "99270631b20505414d09a6b6b9de0422"
+      },
+      {
+        "name": "libgmodule-2_0-0",
+        "version": "2.38.2",
+        "release": "8.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "3ce5b5de92df7f91a4565e865828bb8e"
+      },
+      {
+        "name": "libgmp10",
+        "version": "5.1.2",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a947a448ea5e2a77d3210e1d1c9dbf37"
+      },
+      {
+        "name": "libgobject-2_0-0",
+        "version": "2.38.2",
+        "release": "8.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "2f47a18777f0ed9adc321c3f9bdff2c5"
+      },
+      {
+        "name": "libgpg-error0",
+        "version": "1.12",
+        "release": "2.1.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "31618d5fcc288f97f408171c9297bb7a"
+      },
+      {
+        "name": "libgraphite2-3",
+        "version": "1.2.0",
+        "release": "6.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "332daef2e774e011c2266602cc01d933"
+      },
+      {
+        "name": "libgthread-2_0-0",
+        "version": "2.38.2",
+        "release": "8.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "cfea336fe24c959b7db5f6a1fe490514"
+      },
+      {
+        "name": "libharfbuzz0",
+        "version": "0.9.21",
+        "release": "1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "346dde85086a523fa901a43432543468"
+      },
+      {
+        "name": "libidn11",
+        "version": "1.25",
+        "release": "7.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "2dadd34019da8fe689769e7737267a24"
+      },
+      {
+        "name": "libjpeg8",
+        "version": "8.0.2",
+        "release": "24.1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "8858cc6b8090c8e2381ed64e658ccc40"
+      },
+      {
+        "name": "libkeyutils1",
+        "version": "1.5.5",
+        "release": "6.1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "858fb7b3e65610a33440274d503be733"
+      },
+      {
+        "name": "libkmod2",
+        "version": "14",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e3e065ec4387217149c55219c7b1afd6"
+      },
+      {
+        "name": "libksba8",
+        "version": "1.3.0",
+        "release": "5.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5f72603086ca945fec2bbc2730e0733e"
+      },
+      {
+        "name": "libldap-2_4-2",
+        "version": "2.4.33",
+        "release": "8.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "9d7a3c403109ae83fb5ef90d16813500"
+      },
+      {
+        "name": "liblua5_1",
+        "version": "5.1.5",
+        "release": "5.2.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a8512013f8c60e92440662d84f06b060"
+      },
+      {
+        "name": "liblzma5",
+        "version": "5.0.5",
+        "release": "2.1.20",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "12c350cecf9beb9c7ce0a0c6cab03db9"
+      },
+      {
+        "name": "liblzo2-2",
+        "version": "2.06",
+        "release": "12.4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "00037888ac7fecc26b1126320cb14d5b"
+      },
+      {
+        "name": "libmagic1",
+        "version": "5.15",
+        "release": "4.20.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "7a87c0b1d8d90136cd6d1fdc04a23bca"
+      },
+      {
+        "name": "libmodman1",
+        "version": "2.0.1",
+        "release": "14.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f777245b0444d15c3d3decdfe6a1353e"
+      },
+      {
+        "name": "libmount1",
+        "version": "2.23.2",
+        "release": "10.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4da095e797ed8c1bf454c06adae31db6"
+      },
+      {
+        "name": "libmozjs-17_0",
+        "version": "17.0",
+        "release": "4.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "2b6c101161d094f53439e710e2674a45"
+      },
+      {
+        "name": "libncurses5",
+        "version": "5.9",
+        "release": "33.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "40748e3e80ecff89afb129ae0eee82cc"
+      },
+      {
+        "name": "libncurses5-32bit",
+        "version": "5.9",
+        "release": "33.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "cdca2990295df2ecc6a3316690e709e7"
+      },
+      {
+        "name": "libncurses6",
+        "version": "5.9",
+        "release": "33.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "33b9de30610593053b0b5849a87ff256"
+      },
+      {
+        "name": "libnet1",
+        "version": "1.1.6",
+        "release": "2.2.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "125baae561665d24a1c3034faabe3996"
+      },
+      {
+        "name": "libopenssl1_0_0",
+        "version": "1.0.1h",
+        "release": "11.48.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d1cbe4dacd6500533d5d40f59cc9d912"
+      },
+      {
+        "name": "libpango-1_0-0",
+        "version": "1.36.1",
+        "release": "4.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e12878a0e5640449f36b67070080a228"
+      },
+      {
+        "name": "libpci3",
+        "version": "3.2.0",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "adda37eb1a9534b302c61f1a4c69c3a3"
+      },
+      {
+        "name": "libpciaccess0",
+        "version": "0.13.2",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ba1b4a06415344d05f2c60a3d838607e"
+      },
+      {
+        "name": "libpcre1",
+        "version": "8.33",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0e425f92d1473b2eee16216ceefc2540"
+      },
+      {
+        "name": "libpixman-1-0",
+        "version": "0.30.2",
+        "release": "2.5.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "87bf57588a4fc9d4e967f66057401d16"
+      },
+      {
+        "name": "libply-boot-client2",
+        "version": "0.8.8_git201309032142",
+        "release": "2.5.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d9639e736c3b4026a9c8d73445860ee0"
+      },
+      {
+        "name": "libply-splash-core2",
+        "version": "0.8.8_git201309032142",
+        "release": "2.5.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "7ddb803703fe3d09446d6cf1b6dbff7b"
+      },
+      {
+        "name": "libply-splash-graphics2",
+        "version": "0.8.8_git201309032142",
+        "release": "2.5.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "300cfe8a83fcbcea07ff48f6f759b3f6"
+      },
+      {
+        "name": "libply2",
+        "version": "0.8.8_git201309032142",
+        "release": "2.5.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b68bf0706b57f6655bd5dbd04d5e104b"
+      },
+      {
+        "name": "libpng16-16",
+        "version": "1.6.6",
+        "release": "12.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "78b3d50bfefda1bad94b24861e0499a3"
+      },
+      {
+        "name": "libpolkit0",
+        "version": "0.112",
+        "release": "2.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "21b6a6b2e7488158ceeead9a34e1ee9d"
+      },
+      {
+        "name": "libpopt0",
+        "version": "1.16",
+        "release": "24.1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0f3c6b975dd8802652d3ca219954ed05"
+      },
+      {
+        "name": "libprocps1",
+        "version": "3.3.8",
+        "release": "5.4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "3491e58c99895c6c0b73a16d41765a4a"
+      },
+      {
+        "name": "libproxy1",
+        "version": "0.4.11",
+        "release": "9.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "cfb3b6740fa83e86ec3cc024661db593"
+      },
+      {
+        "name": "libpth20",
+        "version": "2.0.7",
+        "release": "138.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0172d0b91fc59486c7fedb0e35304f2e"
+      },
+      {
+        "name": "libqrencode3",
+        "version": "3.4.2",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "408c2c66bca2856a0182a32a0b9309da"
+      },
+      {
+        "name": "libreadline6",
+        "version": "6.2",
+        "release": "68.1.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "3e32ca4079cc131cc51d84d521ec6638"
+      },
+      {
+        "name": "libselinux1",
+        "version": "2.1.13",
+        "release": "4.1.21",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "8eb702959d41bc1eb402f1a419f464b7"
+      },
+      {
+        "name": "libsemanage1",
+        "version": "2.1.10",
+        "release": "3.1.20",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "88d84028f1221eb388cfffcd59c7f578"
+      },
+      {
+        "name": "libsepol1",
+        "version": "2.1.9",
+        "release": "5.1.23",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5ab32ec052ee5dbcb1fb4c891991e5cc"
+      },
+      {
+        "name": "libsgutils2-2",
+        "version": "1.36",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d5e5cab2704598e8f594205cb5bd9874"
+      },
+      {
+        "name": "libsolv-tools",
+        "version": "0.4.2",
+        "release": "11.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "828ae058721f75cf8240b988af5728ab"
+      },
+      {
+        "name": "libssh2-1",
+        "version": "1.4.3",
+        "release": "7.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d23a114cbbc1613cda7098c335b0c1dd"
+      },
+      {
+        "name": "libstdc++6",
+        "version": "4.8.1_20130909",
+        "release": "3.2.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "97b33e0029cb4a5c7573d8c045f234db"
+      },
+      {
+        "name": "libstdc++6-32bit",
+        "version": "4.8.1_20130909",
+        "release": "3.2.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b4ec184c5dbf51377066355f3e6d1137"
+      },
+      {
+        "name": "libtirpc1",
+        "version": "0.2.3",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "00a5301be37b29094eca890d5863612d"
+      },
+      {
+        "name": "libts-1_0-0",
+        "version": "1.0",
+        "release": "5.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f2b6fdfece2e79ddadec0f5f8483e083"
+      },
+      {
+        "name": "libudev-mini1",
+        "version": "208",
+        "release": "23.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d6429c4578dc2c099bb9ecece60bae72"
+      },
+      {
+        "name": "libusb-0_1-4",
+        "version": "0.1.13",
+        "release": "27.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c6e02bfa2aec095b34606de1e4713be1"
+      },
+      {
+        "name": "libusb-1_0-0",
+        "version": "1.0.9",
+        "release": "8.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "cb909261aef3b3ced30c81504f74cb5e"
+      },
+      {
+        "name": "libustr-1_0-1",
+        "version": "1.0.4",
+        "release": "29.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "cf086ac2f3e4ea6ae1d9c9fe50f073c8"
+      },
+      {
+        "name": "libutempter0",
+        "version": "1.1.6",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d5c359ce81477afccab1b796ce24e43a"
+      },
+      {
+        "name": "libuuid1",
+        "version": "2.23.2",
+        "release": "10.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "3e34463d1100a619f7ec0b8148b9848f"
+      },
+      {
+        "name": "libvdpau1",
+        "version": "0.6",
+        "release": "3.1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b3ecac5402abe3a8a4935e88d6ebb968"
+      },
+      {
+        "name": "libwayland-client0",
+        "version": "1.2.1",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "7c6f0b1d0064d308131ad91bd12e144c"
+      },
+      {
+        "name": "libwayland-server0",
+        "version": "1.2.1",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d34cdcf483e6f5b260d13973275ee467"
+      },
+      {
+        "name": "libwrap0",
+        "version": "7.6",
+        "release": "881.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "fe377bd99e7d334d9cf79848016f032a"
+      },
+      {
+        "name": "libx86-1",
+        "version": "1.1",
+        "release": "41.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d2b38998dccdf7e221bdec63d78933eb"
+      },
+      {
+        "name": "libx86emu1",
+        "version": "1.1",
+        "release": "20.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "912a60a01b66c8c9d282119be497e270"
+      },
+      {
+        "name": "libxcb-dri2-0",
+        "version": "1.9.1",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "649520326303a5d21a57768a402d4fe4"
+      },
+      {
+        "name": "libxcb-glx0",
+        "version": "1.9.1",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a5f1959e50b120d6b609e6bcda4c3873"
+      },
+      {
+        "name": "libxcb-render0",
+        "version": "1.9.1",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4f197686e4e1bf8a60c0fb360956e079"
+      },
+      {
+        "name": "libxcb-shm0",
+        "version": "1.9.1",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "9a6e1ab0bdee52ee16b9583fadf7e8d6"
+      },
+      {
+        "name": "libxcb-xfixes0",
+        "version": "1.9.1",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6da557e15067061ee5de5f84423d1bad"
+      },
+      {
+        "name": "libxcb1",
+        "version": "1.9.1",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "89d7a9b0a91c234d1df3a683fe9186de"
+      },
+      {
+        "name": "libxml2-2",
+        "version": "2.9.1",
+        "release": "2.12.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "453ae3a9447b84b8d64322f6911254a0"
+      },
+      {
+        "name": "libxtables10",
+        "version": "1.4.19.1",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "785f963cead3b708f5ceb2377fcfb2a4"
+      },
+      {
+        "name": "libz1",
+        "version": "1.2.8",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "2c6323ebf13e698b42fecd70ea601c52"
+      },
+      {
+        "name": "libzio1",
+        "version": "1.00",
+        "release": "8.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e00e07f2c70171d40b4afad9ee731c7d"
+      },
+      {
+        "name": "libzypp",
+        "version": "13.10.2",
+        "release": "19.6",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4f176ae6996a659b459abd00b7405968"
+      },
+      {
+        "name": "logrotate",
+        "version": "3.8.7",
+        "release": "4.8.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "bcfdc3052257777a4f6586afa50d410d"
+      },
+      {
+        "name": "lvm2",
+        "version": "2.02.98",
+        "release": "0.28.18.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6b0b4c3aedeabd583a01eff007b3ef76"
+      },
+      {
+        "name": "mkinitrd",
+        "version": "2.8.1",
+        "release": "5.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ab63ea6f80dbf1309878e1240c3ef692"
+      },
+      {
+        "name": "module-init-tools",
+        "version": "3.15",
+        "release": "11.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "cf47c19d69be792c1b64d78767b213b1"
+      },
+      {
+        "name": "mozilla-nspr",
+        "version": "4.10.6",
+        "release": "12.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d77927f3a2bc2d037c4fdb42217b4c40"
+      },
+      {
+        "name": "ncurses-utils",
+        "version": "5.9",
+        "release": "33.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c895c8627563350384a954bd51e07dbc"
+      },
+      {
+        "name": "net-tools",
+        "version": "1.60",
+        "release": "763.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a096fec9cbf5b4f058e04161660932cf"
+      },
+      {
+        "name": "netcfg",
+        "version": "11.5",
+        "release": "18.1.2",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "b0348797ab50ad507322a0a844dc46f4"
+      },
+      {
+        "name": "openSUSE-build-key",
+        "version": "1.0",
+        "release": "24.4.1",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "22293922b1ec9e499c86ccc994f8e9d7"
+      },
+      {
+        "name": "openSUSE-release",
+        "version": "13.1",
+        "release": "1.10",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c1346b9611b400c2b846c9304c83dda3"
+      },
+      {
+        "name": "openSUSE-release-ftp",
+        "version": "13.1",
+        "release": "1.10",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e90b96f60c978c73e0bb2575ff511c51"
+      },
+      {
+        "name": "openslp",
+        "version": "1.2.0",
+        "release": "202.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "8e939a55456389bfeb670f1d77c7ac3d"
+      },
+      {
+        "name": "openssh",
+        "version": "6.2p2",
+        "release": "3.4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "7c9c818cd3aa7487fe215fa82c3ba79e"
+      },
+      {
+        "name": "openssl",
+        "version": "1.0.1h",
+        "release": "11.48.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "7777920545e792199d03427521040ad5"
+      },
+      {
+        "name": "os-prober",
+        "version": "1.61",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b7d25d6b4f513daa5fca261a6c1e90f9"
+      },
+      {
+        "name": "pam",
+        "version": "1.1.8",
+        "release": "6.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "20662211b201c9e816eff1ceac3ead74"
+      },
+      {
+        "name": "pam-config",
+        "version": "0.86",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "7b0c19ae19a63d125e4ce5034f392c21"
+      },
+      {
+        "name": "pango-tools",
+        "version": "1.36.1",
+        "release": "4.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "9055f8babdc6fb56592931a6837ae69a"
+      },
+      {
+        "name": "patterns-openSUSE-base",
+        "version": "13.1",
+        "release": "13.6.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4b0d596406c411cc27784afb5ded1fd0"
+      },
+      {
+        "name": "perl",
+        "version": "5.18.1",
+        "release": "2.1.11",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "8e2b84ae89fe86c94fd9bb874b32c7bc"
+      },
+      {
+        "name": "perl-Bootloader",
+        "version": "0.711",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c3e5fff04d51da7f39d03113b94da96c"
+      },
+      {
+        "name": "perl-base",
+        "version": "5.18.1",
+        "release": "2.1.11",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "30ba609525fa4599dd9343cba0fce90e"
+      },
+      {
+        "name": "permissions",
+        "version": "2013.08.22.1339",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "bce0da0f540d62d824e562606cf5aea5"
+      },
+      {
+        "name": "pigz",
+        "version": "2.3",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "913fd953da8f90159f0d63182283b9b2"
+      },
+      {
+        "name": "pinentry",
+        "version": "0.8.3",
+        "release": "2.1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0bfe88da0719c9e26862fc51b1905116"
+      },
+      {
+        "name": "pkg-config",
+        "version": "0.28",
+        "release": "4.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c745e0069f89e5fc4c58b83da285ad4a"
+      },
+      {
+        "name": "plymouth",
+        "version": "0.8.8_git201309032142",
+        "release": "2.5.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d6398532c251b29da885a96c3a0ce038"
+      },
+      {
+        "name": "plymouth-branding-openSUSE",
+        "version": "13.1",
+        "release": "10.4.13",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "e88bcce224aa1d3439dd020b2ff32879"
+      },
+      {
+        "name": "plymouth-plugin-label",
+        "version": "0.8.8_git201309032142",
+        "release": "2.5.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "dd868cb02f0c79ea3d47af8c725cdef6"
+      },
+      {
+        "name": "plymouth-plugin-script",
+        "version": "0.8.8_git201309032142",
+        "release": "2.5.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "fd176b49f8dd666a59bffef44d9a5fc5"
+      },
+      {
+        "name": "plymouth-scripts",
+        "version": "0.8.8_git201309032142",
+        "release": "2.5.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a5d19131bd0eb21bd021c57c7475052f"
+      },
+      {
+        "name": "polkit",
+        "version": "0.112",
+        "release": "2.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "41403fe43867063f72681ae8164a3d57"
+      },
+      {
+        "name": "polkit-default-privs",
+        "version": "13.1",
+        "release": "10.2.1",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "9d9d6fa282cda6f79912d9494713c081"
+      },
+      {
+        "name": "procps",
+        "version": "3.3.8",
+        "release": "5.4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0c3f5603c5057d124e90ef7ee72d3f69"
+      },
+      {
+        "name": "rpcbind",
+        "version": "0.2.0_git201103171419",
+        "release": "12.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "25d3938bd3ab1cf13847889b5cb12dff"
+      },
+      {
+        "name": "rpm",
+        "version": "4.11.1",
+        "release": "6.5.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "7dfdd742a9b7d60c75bf4844d294716d"
+      },
+      {
+        "name": "rsync",
+        "version": "3.1.0",
+        "release": "21.8.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "13635fe58b4b2c6a9f76e02a8250d8fb"
+      },
+      {
+        "name": "sed",
+        "version": "4.2.2",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "8a6c03daa0669218cbbc05e258c5ad81"
+      },
+      {
+        "name": "sg3_utils",
+        "version": "1.36",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "bba22b2f04875ccff4e13ba6f8075ea3"
+      },
+      {
+        "name": "shadow",
+        "version": "4.1.5.1",
+        "release": "8.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "cb7e22465082019199af847b8cbe7834"
+      },
+      {
+        "name": "shared-mime-info",
+        "version": "1.1",
+        "release": "2.1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "bf68c9e63bf5e922dfd008f049089e2b"
+      },
+      {
+        "name": "splashy",
+        "version": "0.3.13",
+        "release": "44.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "63a6da3457e7918998f0ff920dfb054b"
+      },
+      {
+        "name": "suse-module-tools",
+        "version": "12.3",
+        "release": "6.1.2",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "9d9e2673781ab036c1b9a4bce6f12f37"
+      },
+      {
+        "name": "suspend",
+        "version": "1.0",
+        "release": "28.1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "26451ace66afc822d02a05bf42b9d754"
+      },
+      {
+        "name": "sysconfig",
+        "version": "0.81.5",
+        "release": "30.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b9b91cd68eacb46e0206fe0f0c6a5942"
+      },
+      {
+        "name": "sysconfig-netconfig",
+        "version": "0.81.5",
+        "release": "30.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b9f3fb0bb05bd06c1fa89e7096a4afd4"
+      },
+      {
+        "name": "sysconfig-network",
+        "version": "0.81.5",
+        "release": "30.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "465047025d6fa03bab9024dd3c8f70a8"
+      },
+      {
+        "name": "sysfsutils",
+        "version": "2.1.0",
+        "release": "150.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "9376708eb251f9ebfbc8cfafcdc30169"
+      },
+      {
+        "name": "syslog-ng",
+        "version": "3.4.7",
+        "release": "2.8.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "92e7fc363269742ad16bacbf00be38d6"
+      },
+      {
+        "name": "syslog-service",
+        "version": "2.0",
+        "release": "772.1.2",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "a9fffdfca30d09868c5665fc38a13f82"
+      },
+      {
+        "name": "systemd",
+        "version": "208",
+        "release": "23.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "2b203bd567b59d3835591a8586b8df32"
+      },
+      {
+        "name": "systemd-presets-branding-openSUSE",
+        "version": "0.3.0",
+        "release": "3.4.1",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "6ef5619371f03c12ea11ffd668067088"
+      },
+      {
+        "name": "systemd-sysvinit",
+        "version": "208",
+        "release": "23.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4206c307df74dde5516a1acbdeb6ee25"
+      },
+      {
+        "name": "sysvinit-tools",
+        "version": "2.88+",
+        "release": "89.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "950eb6c1cd1b191440587a6b5feb9dca"
+      },
+      {
+        "name": "tar",
+        "version": "1.26",
+        "release": "19.4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c98f23f345f27d05108cb1482b43400a"
+      },
+      {
+        "name": "terminfo-base",
+        "version": "5.9",
+        "release": "33.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6419d9cff92c0bb11694b63d9f65c69b"
+      },
+      {
+        "name": "time",
+        "version": "1.7",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "eb72e62ff0e0dfeae621d9dc7ebe9a9c"
+      },
+      {
+        "name": "timezone",
+        "version": "2013h",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "afddca087f38f0f0d47cc3bc37575b4e"
+      },
+      {
+        "name": "tunctl",
+        "version": "1.5",
+        "release": "22.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "3570c4a86602c8f3575a345b7a6553dc"
+      },
+      {
+        "name": "udev-mini",
+        "version": "208",
+        "release": "23.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "8bfcd579f0b8f1bdd903e0947fa3be1c"
+      },
+      {
+        "name": "udevmountd",
+        "version": "0.81.5",
+        "release": "30.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e2f7d6d173a65b36934925b4774cc251"
+      },
+      {
+        "name": "update-alternatives",
+        "version": "1.16.10",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f9d7fb20379a381881ccbba425a22b57"
+      },
+      {
+        "name": "util-linux",
+        "version": "2.23.2",
+        "release": "10.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d79c422626e5fc3abc363994aace3873"
+      },
+      {
+        "name": "vim",
+        "version": "7.4.052",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ad3d655834f823280555d2aba0d43621"
+      },
+      {
+        "name": "vlan",
+        "version": "1.9",
+        "release": "136.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c3832b61a2a30a6d6a760c1513e2ca8f"
+      },
+      {
+        "name": "wallpaper-branding-openSUSE",
+        "version": "13.1",
+        "release": "10.4.13",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "7830ced9c0641c7853d20680e906456e"
+      },
+      {
+        "name": "which",
+        "version": "2.20",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "72fca6588383d5907d5230d025b14c82"
+      },
+      {
+        "name": "xz",
+        "version": "5.0.5",
+        "release": "2.1.20",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "01142bc3c09c23ae7c6b764d1ae51e42"
+      },
+      {
+        "name": "zypper",
+        "version": "1.9.16",
+        "release": "22.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4a87f6b9ceae5d40a411fe52d0f17050"
+      }
+    ]
+  },
   "unmanaged_files": {
     "extracted": true,
     "files": [
@@ -3111,7 +3114,7 @@
     }
   ],
   "meta": {
-    "format_version": 5,
+    "format_version": 6,
     "os": {
       "modified": "2014-08-14T18:39:10Z",
       "hostname": "192.168.122.164"

--- a/spec/data/descriptions/jeos/opensuse131/manifest.json
+++ b/spec/data/descriptions/jeos/opensuse131/manifest.json
@@ -780,8 +780,10 @@
     }
   ],
   "packages": {
-    "package_system": "rpm",
-    "packages": [
+    "_attributes": {
+      "package_system": "rpm"
+    },
+    "_elements": [
       {
         "name": "DirectFB",
         "version": "1.6.3",

--- a/spec/data/descriptions/jeos/opensuse132/manifest.json
+++ b/spec/data/descriptions/jeos/opensuse132/manifest.json
@@ -5,8 +5,10 @@
     "architecture": "x86_64"
   },
   "packages": {
-    "package_system": "rpm",
-    "packages": [
+    "_attributes": {
+      "package_system": "rpm"
+    },
+    "_elements": [
       {
         "name": "aaa_base",
         "version": "13.2+git20140911.61c1681",

--- a/spec/data/descriptions/jeos/opensuse132/manifest.json
+++ b/spec/data/descriptions/jeos/opensuse132/manifest.json
@@ -4,1776 +4,1779 @@
     "version": "13.2 (Harlequin)",
     "architecture": "x86_64"
   },
-  "packages": [
-    {
-      "name": "aaa_base",
-      "version": "13.2+git20140911.61c1681",
-      "release": "1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "3f25439794c090c3b134fee05cd64d9c"
-    },
-    {
-      "name": "acl",
-      "version": "2.2.52",
-      "release": "5.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "3996a8219a71b66ac385db15f032fd40"
-    },
-    {
-      "name": "adjtimex",
-      "version": "1.29",
-      "release": "6.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "613281c5c6eb28f3c117f430f378a1bc"
-    },
-    {
-      "name": "autofs",
-      "version": "5.1.0",
-      "release": "2.1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "dbd4352c0d2f3ad61ac305f74f490bc5"
-    },
-    {
-      "name": "bash",
-      "version": "4.2",
-      "release": "75.3.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "42ac67b74d5cf14de4107171aeede714"
-    },
-    {
-      "name": "btrfsprogs",
-      "version": "3.16.2",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0d858d931997628135404bc3a871f2e4"
-    },
-    {
-      "name": "bzip2",
-      "version": "1.0.6",
-      "release": "29.2.7",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6eb85b7f5b3a11e650ea6ba9b812865c"
-    },
-    {
-      "name": "ca-certificates",
-      "version": "1_201403302107",
-      "release": "8.1.2",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "21558aa835d2f19c91c9344427ac5ceb"
-    },
-    {
-      "name": "coreutils",
-      "version": "8.23",
-      "release": "2.3.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4020e3a64224a26226ba0fbe4dbac3c7"
-    },
-    {
-      "name": "cpio",
-      "version": "2.11",
-      "release": "29.2.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e3fc6e04fd63e7c8471b9905d0741bdc"
-    },
-    {
-      "name": "cracklib",
-      "version": "2.9.0",
-      "release": "4.1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "94ad849886ece7e88dff463324781560"
-    },
-    {
-      "name": "cracklib-dict-full",
-      "version": "2.8.12",
-      "release": "64.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "22da411129c37b9671dac2d6331cb641"
-    },
-    {
-      "name": "cron",
-      "version": "4.2",
-      "release": "56.3.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c0740ac980e13f46aed1f129a61acdf5"
-    },
-    {
-      "name": "cronie",
-      "version": "1.4.12",
-      "release": "56.3.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "dd72330cbf8e3ad8667fb79f45c5fcfa"
-    },
-    {
-      "name": "dbus-1",
-      "version": "1.8.8",
-      "release": "1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ec88c73d328ede4715b1a94d97ffdd1d"
-    },
-    {
-      "name": "dbus-1-x11",
-      "version": "1.8.8",
-      "release": "1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c39d4704bd06f3eb1d4129108347b153"
-    },
-    {
-      "name": "device-mapper",
-      "version": "1.02.78",
-      "release": "20.2.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4be7055b7fb228c6b2eaecb6c55b868e"
-    },
-    {
-      "name": "dhcpcd",
-      "version": "3.2.3",
-      "release": "47.80.6.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "9e8b05eb4e549d14f6e7ec937b80b76f"
-    },
-    {
-      "name": "diffutils",
-      "version": "3.3",
-      "release": "6.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "bab7055e135b99a645795f1f1e5c46cb"
-    },
-    {
-      "name": "dirmngr",
-      "version": "1.1.1",
-      "release": "2.1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "75b69e98cdc71774556f1bb14c01e32e"
-    },
-    {
-      "name": "dracut",
-      "version": "037",
-      "release": "17.6.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d7a4f1355473f78337f365fbeb35847a"
-    },
-    {
-      "name": "elfutils",
-      "version": "0.158",
-      "release": "4.2.6",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "65560e51f4b71ba6aac63651f890cbf6"
-    },
-    {
-      "name": "expat",
-      "version": "2.1.0",
-      "release": "14.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "83954190ea590078c366e0509836f3aa"
-    },
-    {
-      "name": "file",
-      "version": "5.19",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ffaaa5928b577f6daba198a4bc8e01c5"
-    },
-    {
-      "name": "file-magic",
-      "version": "5.19",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b014dde9d40ace5050dffb9ebcb0b3bf"
-    },
-    {
-      "name": "filesystem",
-      "version": "13.2",
-      "release": "4.3.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c28b82fc840004e237fa44ca29d5c22d"
-    },
-    {
-      "name": "fillup",
-      "version": "1.42",
-      "release": "271.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ff0a91aa1ba4cf2752017088de96e4d9"
-    },
-    {
-      "name": "findutils",
-      "version": "4.5.14",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "91f28c6ca0ff7be36d9281bd283348f5"
-    },
-    {
-      "name": "fipscheck",
-      "version": "1.4.1",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "1d4d08fe657929327cb63fa9f3eaf361"
-    },
-    {
-      "name": "gawk",
-      "version": "4.1.1",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b2f6c49a59a1d6148bf37d39a1aa58d4"
-    },
-    {
-      "name": "gettext-runtime",
-      "version": "0.19.2",
-      "release": "2.1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "1e98e48767205092679f66b63e9bdded"
-    },
-    {
-      "name": "gio-branding-openSUSE",
-      "version": "13.2",
-      "release": "2.1",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "a6d89d35c48d72c0e0b22a8fbaeb9618"
-    },
-    {
-      "name": "glib2-tools",
-      "version": "2.42.0",
-      "release": "2.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b63b0622d4bf614bb35383c103132127"
-    },
-    {
-      "name": "glibc",
-      "version": "2.19",
-      "release": "16.2.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "1382f45425fe3610d1bcccdb9f899c9d"
-    },
-    {
-      "name": "glibc-locale",
-      "version": "2.19",
-      "release": "16.2.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "3daee2f9db6a234b5eb06a0d8b0c4efc"
-    },
-    {
-      "name": "gpg2",
-      "version": "2.0.26",
-      "release": "2.1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b949f9ed59bc2373c6dbee1b2644407f"
-    },
-    {
-      "name": "grep",
-      "version": "2.20",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "619588511d349f1e446b828be93c293f"
-    },
-    {
-      "name": "grub2",
-      "version": "2.02~beta2",
-      "release": "20.5.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f1caa30c58f94887f8e774a0386abd39"
-    },
-    {
-      "name": "grub2-i386-pc",
-      "version": "2.02~beta2",
-      "release": "20.5.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "1821c9a96955b6aedde374023f3b3a46"
-    },
-    {
-      "name": "gzip",
-      "version": "1.6",
-      "release": "8.1.8",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "17015ea14bb071411fa2bc9026bbc7b7"
-    },
-    {
-      "name": "hardlink",
-      "version": "1.0",
-      "release": "7.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f6c49f8584d07151d10de58777cce85f"
-    },
-    {
-      "name": "hwinfo",
-      "version": "21.6",
-      "release": "3.1.8",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "8bc4e8afafadafca385763ff73654835"
-    },
-    {
-      "name": "ifplugd",
-      "version": "0.28",
-      "release": "235.1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "3c20ab621fd14f0bd4c6b04842ee336d"
-    },
-    {
-      "name": "info",
-      "version": "4.13a",
-      "release": "38.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "80c3f6fd7469ca9391f52ddcb64b8d0e"
-    },
-    {
-      "name": "insserv-compat",
-      "version": "0.1",
-      "release": "12.2.2",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "5e439adb4d2c447879db82b381c3271e"
-    },
-    {
-      "name": "iproute2",
-      "version": "3.16",
-      "release": "2.1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "110c7850d2068f5fcb452016129999c4"
-    },
-    {
-      "name": "iputils",
-      "version": "s20121221",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "37ca7a25c0b54ce80fc4534aa972d2e4"
-    },
-    {
-      "name": "kbd",
-      "version": "2.0.2",
-      "release": "2.3.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "8573082d44d80c832f6a9c07689b9b95"
-    },
-    {
-      "name": "kernel-default",
-      "version": "3.16.6",
-      "release": "2.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "2625930b0126279fbb5a15fb5539f854"
-    },
-    {
-      "name": "keyutils",
-      "version": "1.5.9",
-      "release": "3.1.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "95086e498a96096e661087af7735cff2"
-    },
-    {
-      "name": "klogd",
-      "version": "1.4.1",
-      "release": "778.3.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "64d18dffd3a257cacb46f2b912c9a498"
-    },
-    {
-      "name": "kmod",
-      "version": "18",
-      "release": "2.2.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6b4a2c8e2fe0e24baf290494c0d0ef26"
-    },
-    {
-      "name": "kmod-compat",
-      "version": "18",
-      "release": "2.2.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f93067dda30e1d809464cdf94222ec28"
-    },
-    {
-      "name": "krb5",
-      "version": "1.12.2",
-      "release": "3.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "bf4a25deb5049f25a80411e84d07a2f5"
-    },
-    {
-      "name": "libICE6",
-      "version": "1.0.9",
-      "release": "2.1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "63878fb6a1e6319a2baef6a21cced314"
-    },
-    {
-      "name": "libSM6",
-      "version": "1.2.2",
-      "release": "4.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "7f0f5f1968921e1b3305a87f848dbdd9"
-    },
-    {
-      "name": "libX11-6",
-      "version": "1.6.2",
-      "release": "5.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0329c439e9b68195d2a1b4c955a073db"
-    },
-    {
-      "name": "libX11-data",
-      "version": "1.6.2",
-      "release": "5.1.2",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "8d5543e45fcdb1f1fb2dba6cc6d926c4"
-    },
-    {
-      "name": "libXau6",
-      "version": "1.0.8",
-      "release": "5.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "fdc3cb3007f55582707fff2246c020da"
-    },
-    {
-      "name": "libXt6",
-      "version": "1.1.4",
-      "release": "4.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "9cfab41108fa57f1df44f4fb66c35e16"
-    },
-    {
-      "name": "libacl1",
-      "version": "2.2.52",
-      "release": "5.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5e6146a2abbcf108e65f72241f13e9a8"
-    },
-    {
-      "name": "libadns1",
-      "version": "1.4",
-      "release": "102.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6e1f8bc42615fc92ed502e503c6d5f14"
-    },
-    {
-      "name": "libapparmor1",
-      "version": "2.9.0",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "95a17f07730ccf816726a4ff9dafa878"
-    },
-    {
-      "name": "libasm1",
-      "version": "0.158",
-      "release": "4.2.6",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "2399b4e228e1e0ceb8786b4d2d23a547"
-    },
-    {
-      "name": "libassuan0",
-      "version": "2.1.2",
-      "release": "2.1.6",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c5a80a724389fc3f7c8b9793b07220b4"
-    },
-    {
-      "name": "libattr1",
-      "version": "2.4.47",
-      "release": "4.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "270921aa2cdb60b664d80329de62c63b"
-    },
-    {
-      "name": "libaudit1",
-      "version": "2.4",
-      "release": "1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "fff4511dab164905dabef196b189a389"
-    },
-    {
-      "name": "libaugeas0",
-      "version": "1.2.0",
-      "release": "4.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6c4b74d0d6e3f4c5b4cc263d06225e2f"
-    },
-    {
-      "name": "libblkid1",
-      "version": "2.25.1",
-      "release": "2.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "66a5f2f5cd33e35a5382c7085153f043"
-    },
-    {
-      "name": "libbz2-1",
-      "version": "1.0.6",
-      "release": "29.2.7",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "fb2a0b5462229a90a3fb1577c08f8058"
-    },
-    {
-      "name": "libcap-ng0",
-      "version": "0.7.4",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "63189276da879f8b34b62bb1b9558120"
-    },
-    {
-      "name": "libcap2",
-      "version": "2.22",
-      "release": "13.1.8",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "278be95d389517a75cc636f15dce6213"
-    },
-    {
-      "name": "libcom_err2",
-      "version": "1.42.12",
-      "release": "1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f9895068285a9dc9f9ad10d8aab008c4"
-    },
-    {
-      "name": "libcrack2",
-      "version": "2.9.0",
-      "release": "4.1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "feefb57cbcc610bf689cdc22fc00028e"
-    },
-    {
-      "name": "libcroco-0_6-3",
-      "version": "0.6.8",
-      "release": "7.1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a58c1a1343ab210df3c77863a5ac4d9a"
-    },
-    {
-      "name": "libcryptsetup4",
-      "version": "1.6.6",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c09a02f7fda320fdf0bb88e1fabffe8b"
-    },
-    {
-      "name": "libcurl4",
-      "version": "7.38.0",
-      "release": "1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "61877e79cb4f99389030e063d69e759e"
-    },
-    {
-      "name": "libdaemon0",
-      "version": "0.14",
-      "release": "15.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "1bac31d7c38bbc432c1d3e599f872ad3"
-    },
-    {
-      "name": "libdb-4_8",
-      "version": "4.8.30",
-      "release": "29.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a255af744892c98ff643e5488d3048ee"
-    },
-    {
-      "name": "libdbus-1-3",
-      "version": "1.8.8",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e9b74cac2d0e36a50ab5b00d0aa08d91"
-    },
-    {
-      "name": "libdw1",
-      "version": "0.158",
-      "release": "4.2.6",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "797216c20bf951ff63066c7c1a83e9b7"
-    },
-    {
-      "name": "libedit0",
-      "version": "3.1.snap20140620",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "996d0bd86ca9c2f5f27b89c62767433e"
-    },
-    {
-      "name": "libelf0",
-      "version": "0.8.13",
-      "release": "19.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e543b27787b33378dca95209c5299ac4"
-    },
-    {
-      "name": "libelf1",
-      "version": "0.158",
-      "release": "4.2.6",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6e2e31b54c74b75bd3634f98930ef710"
-    },
-    {
-      "name": "libevent-2_0-5",
-      "version": "2.0.21",
-      "release": "4.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "83a0856854aba3da6390e94e1b0fd25b"
-    },
-    {
-      "name": "libexpat1",
-      "version": "2.1.0",
-      "release": "14.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "1a9db1ce6e69fc83c0307648139fbad2"
-    },
-    {
-      "name": "libext2fs2",
-      "version": "1.42.12",
-      "release": "1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6aaf64311c2a5178558d3c10ad2217a2"
-    },
-    {
-      "name": "libffi4",
-      "version": "4.8.3+r212056",
-      "release": "2.2.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0e3711be45118097d308f6a415ca0637"
-    },
-    {
-      "name": "libfipscheck1",
-      "version": "1.4.1",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b6d67ae2095be95a0a9512c2876883b0"
-    },
-    {
-      "name": "libfreetype6",
-      "version": "2.5.3",
-      "release": "2.1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4d60d20e8a58faf52455834b4266c8b4"
-    },
-    {
-      "name": "libfuse2",
-      "version": "2.9.3",
-      "release": "4.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "740010fca429a1f0939e2ed42bc4fc3c"
-    },
-    {
-      "name": "libgcc_s1",
-      "version": "4.8.3+r212056",
-      "release": "2.2.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "476a495eea1836f46694b973814d5200"
-    },
-    {
-      "name": "libgcrypt20",
-      "version": "1.6.1",
-      "release": "8.3.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e0fa834b7898ca0d2ca9b86e7fcbb4fc"
-    },
-    {
-      "name": "libgdbm4",
-      "version": "1.11",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a6747e743d91965b326ab0cd932b3f6e"
-    },
-    {
-      "name": "libgio-2_0-0",
-      "version": "2.42.0",
-      "release": "2.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "33463cda53d8b80e3e3ae87a941ea9ae"
-    },
-    {
-      "name": "libglib-2_0-0",
-      "version": "2.42.0",
-      "release": "2.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5844a980a0c55fd68a2bdb6c46491d6e"
-    },
-    {
-      "name": "libgmodule-2_0-0",
-      "version": "2.42.0",
-      "release": "2.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f38d78870f58351c08f5670cd8a10ac2"
-    },
-    {
-      "name": "libgmp10",
-      "version": "5.1.3",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "555d4cad908564132d5eda2e42856d47"
-    },
-    {
-      "name": "libgobject-2_0-0",
-      "version": "2.42.0",
-      "release": "2.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "aef7e88775b9176bf0d05e649e6c6adb"
-    },
-    {
-      "name": "libgpg-error0",
-      "version": "1.15",
-      "release": "1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "92b7736c7a178624379ebfa137de5557"
-    },
-    {
-      "name": "libidn11",
-      "version": "1.28",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "aa5bac71adacaab81df725c0482ed6f3"
-    },
-    {
-      "name": "libkeyutils1",
-      "version": "1.5.9",
-      "release": "3.1.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "3cc0efa4106c809cb4226e96ea0eff06"
-    },
-    {
-      "name": "libkmod2",
-      "version": "18",
-      "release": "2.2.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "07374a85aa0def60afee137bc48d90a5"
-    },
-    {
-      "name": "libksba8",
-      "version": "1.3.1",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a42aeeca4b429f0355ea76575a5c5f7b"
-    },
-    {
-      "name": "libldap-2_4-2",
-      "version": "2.4.39",
-      "release": "8.3.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5dab80abcafd76efb07758b1d9acd483"
-    },
-    {
-      "name": "liblua5_1",
-      "version": "5.1.5",
-      "release": "10.2.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a5a40e08979100c97b4d4ec036c80ec0"
-    },
-    {
-      "name": "liblzma5",
-      "version": "5.0.7",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "1410bf2a6350a94dd59a93f96ba761b4"
-    },
-    {
-      "name": "liblzo2-2",
-      "version": "2.08",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "1a7122faf72db093a1576081c5fce862"
-    },
-    {
-      "name": "libmagic1",
-      "version": "5.19",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5f72a83aa6037221f014cfe9678545ea"
-    },
-    {
-      "name": "libmodman1",
-      "version": "2.0.1",
-      "release": "16.1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e632832db7c9fcac4151c3015c9058c7"
-    },
-    {
-      "name": "libmount1",
-      "version": "2.25.1",
-      "release": "2.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "575eb67313cffdbbb61345c1bf60dd90"
-    },
-    {
-      "name": "libmozjs-17_0",
-      "version": "17.0",
-      "release": "8.1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "7610109407dc761ad13d0bcbc1173b50"
-    },
-    {
-      "name": "libncurses5",
-      "version": "5.9",
-      "release": "52.2.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ba99ec008c7a708c1e2678eadd52a8c2"
-    },
-    {
-      "name": "libncurses6",
-      "version": "5.9",
-      "release": "52.2.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "2f009711bf3efad974f8dd53fd9e80f4"
-    },
-    {
-      "name": "libnl-config",
-      "version": "3.2.25",
-      "release": "2.1.2",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "64f397841920460b2260c3a3ebb0ae8e"
-    },
-    {
-      "name": "libnl3-200",
-      "version": "3.2.25",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "8d7af7e4bd815c223eca9e3d2c2c3164"
-    },
-    {
-      "name": "libopenssl1_0_0",
-      "version": "1.0.1i",
-      "release": "2.1.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "3f364b6fc25f62bcc04047d49bec16d0"
-    },
-    {
-      "name": "libp11-kit0",
-      "version": "0.20.3",
-      "release": "1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "698e663745445841beaff2550e90e6b0"
-    },
-    {
-      "name": "libparted0",
-      "version": "3.1",
-      "release": "12.3.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "def6c90d61f1447c42c4c66d68ae42dc"
-    },
-    {
-      "name": "libpcre1",
-      "version": "8.35",
-      "release": "3.2.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "cfab86de55ee87b81efabc84112038b4"
-    },
-    {
-      "name": "libpng16-16",
-      "version": "1.6.13",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "2f1e4a42b4023676f249cc0285489edb"
-    },
-    {
-      "name": "libpolkit0",
-      "version": "0.112",
-      "release": "3.1.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "bef78e7c84e57dd6bb6769a9c4cdb3e1"
-    },
-    {
-      "name": "libpopt0",
-      "version": "1.16",
-      "release": "27.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "37746ac41a929646b88184c2a38c9cae"
-    },
-    {
-      "name": "libprocps3",
-      "version": "3.3.9",
-      "release": "3.2.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "273f27a2713d9d243ab555249580c234"
-    },
-    {
-      "name": "libproxy1",
-      "version": "0.4.11",
-      "release": "12.1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c7b5e6076d73fc3f8d5c5c1d34789fa6"
-    },
-    {
-      "name": "libpth20",
-      "version": "2.0.7",
-      "release": "140.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e9774244529d78be3b6acec8ecddb7b6"
-    },
-    {
-      "name": "libqrencode3",
-      "version": "3.4.3",
-      "release": "2.2.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d2c4d9d57c36ab596ec5d5029da9b848"
-    },
-    {
-      "name": "libreadline6",
-      "version": "6.2",
-      "release": "75.3.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "7c9eda8e58bff82aff9813cfdbe9ae4a"
-    },
-    {
-      "name": "libsasl2-3",
-      "version": "2.1.26",
-      "release": "7.2.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4b4dc519bd6b57b73ba86956ad9d0dbf"
-    },
-    {
-      "name": "libseccomp2",
-      "version": "2.1.1",
-      "release": "2.1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "25a254204c005f9f688e0998131b379e"
-    },
-    {
-      "name": "libselinux1",
-      "version": "2.3",
-      "release": "2.2.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "43a9221e97a24225e31ed7f437faac46"
-    },
-    {
-      "name": "libsemanage1",
-      "version": "2.3",
-      "release": "2.1.8",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "7ba176d33da37954eb5d4ea138b3e128"
-    },
-    {
-      "name": "libsepol1",
-      "version": "2.3",
-      "release": "2.1.8",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5561d4478033dff96ace76707090b714"
-    },
-    {
-      "name": "libsgutils2-2",
-      "version": "1.39",
-      "release": "3.2.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c02093a91c28eab8c786917565f58521"
-    },
-    {
-      "name": "libsmartcols1",
-      "version": "2.25.1",
-      "release": "2.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "cf5b365a20f88563a499c58bb82e9ebc"
-    },
-    {
-      "name": "libsolv-tools",
-      "version": "0.6.6",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ff7236d134667b55951a4711ee22aace"
-    },
-    {
-      "name": "libsqlite3-0",
-      "version": "3.8.6",
-      "release": "1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f1c6aa257d5ff89fad0b8f73bdc77f06"
-    },
-    {
-      "name": "libssh2-1",
-      "version": "1.4.3",
-      "release": "9.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d44bf7880ba5d5ad7fedd60c21a95c6b"
-    },
-    {
-      "name": "libstdc++6",
-      "version": "4.8.3+r212056",
-      "release": "2.2.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0ab0f9e0ffefa4bc828ee12422eafb6e"
-    },
-    {
-      "name": "libtasn1",
-      "version": "3.7",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "62efc62e539bcf53c3eccef971779d17"
-    },
-    {
-      "name": "libtasn1-6",
-      "version": "3.7",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6ebe8b3875b2f2a4b8af5e7e32e17db7"
-    },
-    {
-      "name": "libtirpc1",
-      "version": "0.2.3",
-      "release": "6.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "71dd8cd87594a66075de88e356ffcfc8"
-    },
-    {
-      "name": "libudev1",
-      "version": "210",
-      "release": "25.5.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f8fce88590f1d92115c82fec159bd447"
-    },
-    {
-      "name": "libusb-0_1-4",
-      "version": "0.1.13",
-      "release": "30.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d4a0714d44eb7a771c23ee15eb60b944"
-    },
-    {
-      "name": "libusb-1_0-0",
-      "version": "1.0.19",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c9e840752179a386e0d5154ec1d821d5"
-    },
-    {
-      "name": "libustr-1_0-1",
-      "version": "1.0.4",
-      "release": "33.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "8edd6ad8cdf4a2e24d6da3b2fb0b409d"
-    },
-    {
-      "name": "libutempter0",
-      "version": "1.1.6",
-      "release": "5.2.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f35ec8b020a6ad454c798f4dd5c92fc2"
-    },
-    {
-      "name": "libuuid1",
-      "version": "2.25.1",
-      "release": "2.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "acd0cc861c76941118ebecaac4cffc87"
-    },
-    {
-      "name": "libwicked-0-6",
-      "version": "0.6.12",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "37f4aa3837404bcbe6dbfc4ed55308b7"
-    },
-    {
-      "name": "libwrap0",
-      "version": "7.6",
-      "release": "884.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4611d9f0662b53f842921201a91a7a47"
-    },
-    {
-      "name": "libx86emu1",
-      "version": "1.1",
-      "release": "22.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "51e3740248ed8d604b88e4ffd5b8c9d4"
-    },
-    {
-      "name": "libxcb1",
-      "version": "1.11",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "3377cd90b17ff84dba259ab1f6059ac3"
-    },
-    {
-      "name": "libxml2-2",
-      "version": "2.9.1",
-      "release": "7.2.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "79b41b9de27872effb36f3f51b72e2aa"
-    },
-    {
-      "name": "libxtables10",
-      "version": "1.4.21",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "dc0fb3050f832160539f613d30975f59"
-    },
-    {
-      "name": "libz1",
-      "version": "1.2.8",
-      "release": "5.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "283ad3ad9a05bde5a011b03dcb7cc96e"
-    },
-    {
-      "name": "libzio1",
-      "version": "1.00",
-      "release": "10.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4e3b81e0a57ce47bdb227a9ec1e5d1f2"
-    },
-    {
-      "name": "libzypp",
-      "version": "14.29.4",
-      "release": "2.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "02c6c3b9256b6719a9186a4f3bcf3b3c"
-    },
-    {
-      "name": "lvm2",
-      "version": "2.02.98",
-      "release": "43.2.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "3ea23edb94caeec7ca09621dcf7ef2a0"
-    },
-    {
-      "name": "mozilla-nspr",
-      "version": "4.10.7",
-      "release": "1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "930510631313c90757a166c56aae7bff"
-    },
-    {
-      "name": "mtools",
-      "version": "4.0.18",
-      "release": "5.1.11",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d043f8a4f420778a78c36efb1dc5d800"
-    },
-    {
-      "name": "ncurses-utils",
-      "version": "5.9",
-      "release": "52.2.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "dbd37ccdb12b0af628412aa4e3e42635"
-    },
-    {
-      "name": "net-tools",
-      "version": "1.60",
-      "release": "765.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "29065114db69ca919f5ef00990ecedd0"
-    },
-    {
-      "name": "netcfg",
-      "version": "11.5",
-      "release": "24.2.1",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "bba16328246aed8d662da60d1736b2e1"
-    },
-    {
-      "name": "nfs-client",
-      "version": "1.3.0",
-      "release": "4.2.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d0e95673098410ca8005c37d76262a34"
-    },
-    {
-      "name": "nfs-kernel-server",
-      "version": "1.3.0",
-      "release": "4.2.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "44de05b846043b3ab18e3ffbe59fd803"
-    },
-    {
-      "name": "nfsidmap",
-      "version": "0.25",
-      "release": "6.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a3b61517f95b8f4eadec54a91ec42048"
-    },
-    {
-      "name": "openSUSE-build-key",
-      "version": "1.0",
-      "release": "27.2.1",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "4ae5d20ba926bf8634ebba11094bceb9"
-    },
-    {
-      "name": "openSUSE-release",
-      "version": "13.2",
-      "release": "1.28",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e8cc82f2cbb6d7eccd7ca39732191552"
-    },
-    {
-      "name": "openSUSE-release-ftp",
-      "version": "13.2",
-      "release": "1.28",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ffe04e3f1d60ddcd108fbcb801b930ef"
-    },
-    {
-      "name": "openslp",
-      "version": "2.0.0",
-      "release": "3.2.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "3096c08d7612097804ed5418fe484673"
-    },
-    {
-      "name": "openssh",
-      "version": "6.6p1",
-      "release": "5.1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "fd68e38b0d22367f156ae08f7170385d"
-    },
-    {
-      "name": "openssl",
-      "version": "1.0.1i",
-      "release": "2.1.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f68e40b0b14864284f698c38c53b6c3b"
-    },
-    {
-      "name": "os-prober",
-      "version": "1.61",
-      "release": "12.2.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "60b15752bd635ee6e23be3c4930c3755"
-    },
-    {
-      "name": "p11-kit",
-      "version": "0.20.3",
-      "release": "1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a75fcc11aeadf50ef0a55da8b9ecb5cc"
-    },
-    {
-      "name": "p11-kit-tools",
-      "version": "0.20.3",
-      "release": "1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "9d4db412f67768efd5d37dbe6b2a139d"
-    },
-    {
-      "name": "pam",
-      "version": "1.1.8",
-      "release": "11.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "eb892a5f72b04db153c9b5cfc6051aed"
-    },
-    {
-      "name": "pam-config",
-      "version": "0.88",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "22ac9165cbebf0000b619a839ac6c30d"
-    },
-    {
-      "name": "parted",
-      "version": "3.1",
-      "release": "12.3.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "58e66da4f439af380641bcd2107848ec"
-    },
-    {
-      "name": "patterns-openSUSE-base",
-      "version": "20141007",
-      "release": "2.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "7719998d62810eb6f63c5a459be9cb7f"
-    },
-    {
-      "name": "perl",
-      "version": "5.20.1",
-      "release": "1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5ac140025d8d0ec4a7167c2c0dbd36d3"
-    },
-    {
-      "name": "perl-Bootloader",
-      "version": "0.826",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5138540cbfc9323a4475dcf0ec5107e4"
-    },
-    {
-      "name": "perl-base",
-      "version": "5.20.1",
-      "release": "1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5348bf9921dcf9cd07337a73f36a5d9a"
-    },
-    {
-      "name": "permissions",
-      "version": "2014.08.26.1452",
-      "release": "1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b6c367aa496bc45db497822b51cd5450"
-    },
-    {
-      "name": "pigz",
-      "version": "2.3",
-      "release": "4.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "72bc53c3d8b49fc11007be3911b1ac64"
-    },
-    {
-      "name": "pinentry",
-      "version": "0.8.4",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "2f7ea27d7985f872027c23d07f8ddc2a"
-    },
-    {
-      "name": "pkg-config",
-      "version": "0.28",
-      "release": "7.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f897b7e053e28858f1c84dd760940fbf"
-    },
-    {
-      "name": "polkit",
-      "version": "0.112",
-      "release": "3.1.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "edaf377b75f29ec364263521ee738fbf"
-    },
-    {
-      "name": "polkit-default-privs",
-      "version": "13.2",
-      "release": "7.2.1",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "116d2975cae310bcbf7adceaa81810e6"
-    },
-    {
-      "name": "procps",
-      "version": "3.3.9",
-      "release": "3.2.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "757e5288ee736d0ab735e76f9e8f6532"
-    },
-    {
-      "name": "rpcbind",
-      "version": "0.2.1_rc4",
-      "release": "8.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "1733281484bf6db82a012722c875a238"
-    },
-    {
-      "name": "rpm",
-      "version": "4.11.3",
-      "release": "1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c8f5ffd54d3c76b701e1c9e51cee9eeb"
-    },
-    {
-      "name": "rsync",
-      "version": "3.1.1",
-      "release": "2.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "35637cc42784fecbc83774e3535709e8"
-    },
-    {
-      "name": "sed",
-      "version": "4.2.2",
-      "release": "5.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0799460f34184eefe17aeb25e9b18abb"
-    },
-    {
-      "name": "sg3_utils",
-      "version": "1.39",
-      "release": "3.2.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "594d21f992810bacacd8e016779bd8b7"
-    },
-    {
-      "name": "shadow",
-      "version": "4.1.5.1",
-      "release": "13.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f44a8a9b571eed938fdc41bc979267a4"
-    },
-    {
-      "name": "shared-mime-info",
-      "version": "1.3",
-      "release": "2.1.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a67bc0adb4013ae40c5f15faf58c9e23"
-    },
-    {
-      "name": "squashfs",
-      "version": "4.3",
-      "release": "3.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d664246e6b37f7c704c5449366aa8506"
-    },
-    {
-      "name": "sudo",
-      "version": "1.8.10p3",
-      "release": "2.1.6",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "827b681c561b432a50c3522c655d5c37"
-    },
-    {
-      "name": "suse-module-tools",
-      "version": "12.3",
-      "release": "14.2.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "071be5894fff2c474ff77639651104de"
-    },
-    {
-      "name": "sysconfig",
-      "version": "0.83.7",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4145aa426c447a35ebaea53eb9eed193"
-    },
-    {
-      "name": "sysconfig-netconfig",
-      "version": "0.83.7",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "bb8d662269f2363605d06daad66b54c2"
-    },
-    {
-      "name": "syslinux",
-      "version": "4.04",
-      "release": "33.1.7",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ec2ad73b5631806e0cad06ab16a33f90"
-    },
-    {
-      "name": "systemd",
-      "version": "210",
-      "release": "25.5.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f32ef6f4f21f2ce8326b703f3b92b783"
-    },
-    {
-      "name": "systemd-presets-branding-openSUSE",
-      "version": "0.3.0",
-      "release": "12.1.2",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "09d0b3521086bfe892dcf8bf39ef1e8b"
-    },
-    {
-      "name": "systemd-sysvinit",
-      "version": "210",
-      "release": "25.5.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "96eeba29342ea95e893ff192e3bdcd76"
-    },
-    {
-      "name": "sysvinit-tools",
-      "version": "2.88+",
-      "release": "96.2.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "282c6602009db7ca60dc6a0bc4dd80f3"
-    },
-    {
-      "name": "tar",
-      "version": "1.28",
-      "release": "2.2.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c7a26eda52067a3da487dc9ffc09b056"
-    },
-    {
-      "name": "terminfo-base",
-      "version": "5.9",
-      "release": "52.2.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4c87f521aa2da791c0e6570330716718"
-    },
-    {
-      "name": "test-data-files",
-      "version": "1.0",
-      "release": "1",
-      "arch": "noarch",
-      "vendor": "(none)",
-      "checksum": "e356aa610edf853009e640e9d6bee813"
-    },
-    {
-      "name": "time",
-      "version": "1.7",
-      "release": "7.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "bc8a15b938feff434ff8213225628439"
-    },
-    {
-      "name": "udev",
-      "version": "210",
-      "release": "25.5.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0337655918c07be034ceacd9ab9f46f7"
-    },
-    {
-      "name": "update-alternatives",
-      "version": "1.16.10",
-      "release": "8.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "29af590d48e6877531eae1c9794fc2b2"
-    },
-    {
-      "name": "util-linux",
-      "version": "2.25.1",
-      "release": "2.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "259ad9ea72b2d96f27a231774633ac1b"
-    },
-    {
-      "name": "util-linux-systemd",
-      "version": "2.25.1",
-      "release": "2.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0be1fbe4702738a85bed862a45b156a5"
-    },
-    {
-      "name": "vim",
-      "version": "7.4.461.hg.6253",
-      "release": "1.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d8d3d922d9349a6d5c745681618597f0"
-    },
-    {
-      "name": "wallpaper-branding-openSUSE",
-      "version": "13.2",
-      "release": "3.6.1",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "ec2d79df332261d9168202fc38bcaf2e"
-    },
-    {
-      "name": "which",
-      "version": "2.20",
-      "release": "4.1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "362e35d4d5b61f9f2daddb1a296da790"
-    },
-    {
-      "name": "wicked",
-      "version": "0.6.12",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0c9b4f0cf4d87e25f1ce7af475b43f6b"
-    },
-    {
-      "name": "wicked-service",
-      "version": "0.6.12",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "1d1668bf348ff4a8ba63a984f466c8fc"
-    },
-    {
-      "name": "xz",
-      "version": "5.0.7",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "eb8962316fb5be90be3cefd39b9b5899"
-    },
-    {
-      "name": "zypper",
-      "version": "1.11.14",
-      "release": "2.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d5796d9d26d8bf62532549e7d6eff0bc"
-    }
-  ],
+  "packages": {
+    "package_system": "rpm",
+    "packages": [
+      {
+        "name": "aaa_base",
+        "version": "13.2+git20140911.61c1681",
+        "release": "1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "3f25439794c090c3b134fee05cd64d9c"
+      },
+      {
+        "name": "acl",
+        "version": "2.2.52",
+        "release": "5.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "3996a8219a71b66ac385db15f032fd40"
+      },
+      {
+        "name": "adjtimex",
+        "version": "1.29",
+        "release": "6.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "613281c5c6eb28f3c117f430f378a1bc"
+      },
+      {
+        "name": "autofs",
+        "version": "5.1.0",
+        "release": "2.1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "dbd4352c0d2f3ad61ac305f74f490bc5"
+      },
+      {
+        "name": "bash",
+        "version": "4.2",
+        "release": "75.3.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "42ac67b74d5cf14de4107171aeede714"
+      },
+      {
+        "name": "btrfsprogs",
+        "version": "3.16.2",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0d858d931997628135404bc3a871f2e4"
+      },
+      {
+        "name": "bzip2",
+        "version": "1.0.6",
+        "release": "29.2.7",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6eb85b7f5b3a11e650ea6ba9b812865c"
+      },
+      {
+        "name": "ca-certificates",
+        "version": "1_201403302107",
+        "release": "8.1.2",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "21558aa835d2f19c91c9344427ac5ceb"
+      },
+      {
+        "name": "coreutils",
+        "version": "8.23",
+        "release": "2.3.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4020e3a64224a26226ba0fbe4dbac3c7"
+      },
+      {
+        "name": "cpio",
+        "version": "2.11",
+        "release": "29.2.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e3fc6e04fd63e7c8471b9905d0741bdc"
+      },
+      {
+        "name": "cracklib",
+        "version": "2.9.0",
+        "release": "4.1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "94ad849886ece7e88dff463324781560"
+      },
+      {
+        "name": "cracklib-dict-full",
+        "version": "2.8.12",
+        "release": "64.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "22da411129c37b9671dac2d6331cb641"
+      },
+      {
+        "name": "cron",
+        "version": "4.2",
+        "release": "56.3.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c0740ac980e13f46aed1f129a61acdf5"
+      },
+      {
+        "name": "cronie",
+        "version": "1.4.12",
+        "release": "56.3.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "dd72330cbf8e3ad8667fb79f45c5fcfa"
+      },
+      {
+        "name": "dbus-1",
+        "version": "1.8.8",
+        "release": "1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ec88c73d328ede4715b1a94d97ffdd1d"
+      },
+      {
+        "name": "dbus-1-x11",
+        "version": "1.8.8",
+        "release": "1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c39d4704bd06f3eb1d4129108347b153"
+      },
+      {
+        "name": "device-mapper",
+        "version": "1.02.78",
+        "release": "20.2.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4be7055b7fb228c6b2eaecb6c55b868e"
+      },
+      {
+        "name": "dhcpcd",
+        "version": "3.2.3",
+        "release": "47.80.6.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "9e8b05eb4e549d14f6e7ec937b80b76f"
+      },
+      {
+        "name": "diffutils",
+        "version": "3.3",
+        "release": "6.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "bab7055e135b99a645795f1f1e5c46cb"
+      },
+      {
+        "name": "dirmngr",
+        "version": "1.1.1",
+        "release": "2.1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "75b69e98cdc71774556f1bb14c01e32e"
+      },
+      {
+        "name": "dracut",
+        "version": "037",
+        "release": "17.6.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d7a4f1355473f78337f365fbeb35847a"
+      },
+      {
+        "name": "elfutils",
+        "version": "0.158",
+        "release": "4.2.6",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "65560e51f4b71ba6aac63651f890cbf6"
+      },
+      {
+        "name": "expat",
+        "version": "2.1.0",
+        "release": "14.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "83954190ea590078c366e0509836f3aa"
+      },
+      {
+        "name": "file",
+        "version": "5.19",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ffaaa5928b577f6daba198a4bc8e01c5"
+      },
+      {
+        "name": "file-magic",
+        "version": "5.19",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b014dde9d40ace5050dffb9ebcb0b3bf"
+      },
+      {
+        "name": "filesystem",
+        "version": "13.2",
+        "release": "4.3.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c28b82fc840004e237fa44ca29d5c22d"
+      },
+      {
+        "name": "fillup",
+        "version": "1.42",
+        "release": "271.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ff0a91aa1ba4cf2752017088de96e4d9"
+      },
+      {
+        "name": "findutils",
+        "version": "4.5.14",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "91f28c6ca0ff7be36d9281bd283348f5"
+      },
+      {
+        "name": "fipscheck",
+        "version": "1.4.1",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "1d4d08fe657929327cb63fa9f3eaf361"
+      },
+      {
+        "name": "gawk",
+        "version": "4.1.1",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b2f6c49a59a1d6148bf37d39a1aa58d4"
+      },
+      {
+        "name": "gettext-runtime",
+        "version": "0.19.2",
+        "release": "2.1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "1e98e48767205092679f66b63e9bdded"
+      },
+      {
+        "name": "gio-branding-openSUSE",
+        "version": "13.2",
+        "release": "2.1",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "a6d89d35c48d72c0e0b22a8fbaeb9618"
+      },
+      {
+        "name": "glib2-tools",
+        "version": "2.42.0",
+        "release": "2.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b63b0622d4bf614bb35383c103132127"
+      },
+      {
+        "name": "glibc",
+        "version": "2.19",
+        "release": "16.2.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "1382f45425fe3610d1bcccdb9f899c9d"
+      },
+      {
+        "name": "glibc-locale",
+        "version": "2.19",
+        "release": "16.2.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "3daee2f9db6a234b5eb06a0d8b0c4efc"
+      },
+      {
+        "name": "gpg2",
+        "version": "2.0.26",
+        "release": "2.1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b949f9ed59bc2373c6dbee1b2644407f"
+      },
+      {
+        "name": "grep",
+        "version": "2.20",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "619588511d349f1e446b828be93c293f"
+      },
+      {
+        "name": "grub2",
+        "version": "2.02~beta2",
+        "release": "20.5.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f1caa30c58f94887f8e774a0386abd39"
+      },
+      {
+        "name": "grub2-i386-pc",
+        "version": "2.02~beta2",
+        "release": "20.5.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "1821c9a96955b6aedde374023f3b3a46"
+      },
+      {
+        "name": "gzip",
+        "version": "1.6",
+        "release": "8.1.8",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "17015ea14bb071411fa2bc9026bbc7b7"
+      },
+      {
+        "name": "hardlink",
+        "version": "1.0",
+        "release": "7.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f6c49f8584d07151d10de58777cce85f"
+      },
+      {
+        "name": "hwinfo",
+        "version": "21.6",
+        "release": "3.1.8",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "8bc4e8afafadafca385763ff73654835"
+      },
+      {
+        "name": "ifplugd",
+        "version": "0.28",
+        "release": "235.1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "3c20ab621fd14f0bd4c6b04842ee336d"
+      },
+      {
+        "name": "info",
+        "version": "4.13a",
+        "release": "38.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "80c3f6fd7469ca9391f52ddcb64b8d0e"
+      },
+      {
+        "name": "insserv-compat",
+        "version": "0.1",
+        "release": "12.2.2",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "5e439adb4d2c447879db82b381c3271e"
+      },
+      {
+        "name": "iproute2",
+        "version": "3.16",
+        "release": "2.1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "110c7850d2068f5fcb452016129999c4"
+      },
+      {
+        "name": "iputils",
+        "version": "s20121221",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "37ca7a25c0b54ce80fc4534aa972d2e4"
+      },
+      {
+        "name": "kbd",
+        "version": "2.0.2",
+        "release": "2.3.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "8573082d44d80c832f6a9c07689b9b95"
+      },
+      {
+        "name": "kernel-default",
+        "version": "3.16.6",
+        "release": "2.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "2625930b0126279fbb5a15fb5539f854"
+      },
+      {
+        "name": "keyutils",
+        "version": "1.5.9",
+        "release": "3.1.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "95086e498a96096e661087af7735cff2"
+      },
+      {
+        "name": "klogd",
+        "version": "1.4.1",
+        "release": "778.3.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "64d18dffd3a257cacb46f2b912c9a498"
+      },
+      {
+        "name": "kmod",
+        "version": "18",
+        "release": "2.2.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6b4a2c8e2fe0e24baf290494c0d0ef26"
+      },
+      {
+        "name": "kmod-compat",
+        "version": "18",
+        "release": "2.2.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f93067dda30e1d809464cdf94222ec28"
+      },
+      {
+        "name": "krb5",
+        "version": "1.12.2",
+        "release": "3.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "bf4a25deb5049f25a80411e84d07a2f5"
+      },
+      {
+        "name": "libICE6",
+        "version": "1.0.9",
+        "release": "2.1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "63878fb6a1e6319a2baef6a21cced314"
+      },
+      {
+        "name": "libSM6",
+        "version": "1.2.2",
+        "release": "4.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "7f0f5f1968921e1b3305a87f848dbdd9"
+      },
+      {
+        "name": "libX11-6",
+        "version": "1.6.2",
+        "release": "5.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0329c439e9b68195d2a1b4c955a073db"
+      },
+      {
+        "name": "libX11-data",
+        "version": "1.6.2",
+        "release": "5.1.2",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "8d5543e45fcdb1f1fb2dba6cc6d926c4"
+      },
+      {
+        "name": "libXau6",
+        "version": "1.0.8",
+        "release": "5.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "fdc3cb3007f55582707fff2246c020da"
+      },
+      {
+        "name": "libXt6",
+        "version": "1.1.4",
+        "release": "4.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "9cfab41108fa57f1df44f4fb66c35e16"
+      },
+      {
+        "name": "libacl1",
+        "version": "2.2.52",
+        "release": "5.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5e6146a2abbcf108e65f72241f13e9a8"
+      },
+      {
+        "name": "libadns1",
+        "version": "1.4",
+        "release": "102.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6e1f8bc42615fc92ed502e503c6d5f14"
+      },
+      {
+        "name": "libapparmor1",
+        "version": "2.9.0",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "95a17f07730ccf816726a4ff9dafa878"
+      },
+      {
+        "name": "libasm1",
+        "version": "0.158",
+        "release": "4.2.6",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "2399b4e228e1e0ceb8786b4d2d23a547"
+      },
+      {
+        "name": "libassuan0",
+        "version": "2.1.2",
+        "release": "2.1.6",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c5a80a724389fc3f7c8b9793b07220b4"
+      },
+      {
+        "name": "libattr1",
+        "version": "2.4.47",
+        "release": "4.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "270921aa2cdb60b664d80329de62c63b"
+      },
+      {
+        "name": "libaudit1",
+        "version": "2.4",
+        "release": "1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "fff4511dab164905dabef196b189a389"
+      },
+      {
+        "name": "libaugeas0",
+        "version": "1.2.0",
+        "release": "4.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6c4b74d0d6e3f4c5b4cc263d06225e2f"
+      },
+      {
+        "name": "libblkid1",
+        "version": "2.25.1",
+        "release": "2.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "66a5f2f5cd33e35a5382c7085153f043"
+      },
+      {
+        "name": "libbz2-1",
+        "version": "1.0.6",
+        "release": "29.2.7",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "fb2a0b5462229a90a3fb1577c08f8058"
+      },
+      {
+        "name": "libcap-ng0",
+        "version": "0.7.4",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "63189276da879f8b34b62bb1b9558120"
+      },
+      {
+        "name": "libcap2",
+        "version": "2.22",
+        "release": "13.1.8",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "278be95d389517a75cc636f15dce6213"
+      },
+      {
+        "name": "libcom_err2",
+        "version": "1.42.12",
+        "release": "1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f9895068285a9dc9f9ad10d8aab008c4"
+      },
+      {
+        "name": "libcrack2",
+        "version": "2.9.0",
+        "release": "4.1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "feefb57cbcc610bf689cdc22fc00028e"
+      },
+      {
+        "name": "libcroco-0_6-3",
+        "version": "0.6.8",
+        "release": "7.1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a58c1a1343ab210df3c77863a5ac4d9a"
+      },
+      {
+        "name": "libcryptsetup4",
+        "version": "1.6.6",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c09a02f7fda320fdf0bb88e1fabffe8b"
+      },
+      {
+        "name": "libcurl4",
+        "version": "7.38.0",
+        "release": "1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "61877e79cb4f99389030e063d69e759e"
+      },
+      {
+        "name": "libdaemon0",
+        "version": "0.14",
+        "release": "15.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "1bac31d7c38bbc432c1d3e599f872ad3"
+      },
+      {
+        "name": "libdb-4_8",
+        "version": "4.8.30",
+        "release": "29.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a255af744892c98ff643e5488d3048ee"
+      },
+      {
+        "name": "libdbus-1-3",
+        "version": "1.8.8",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e9b74cac2d0e36a50ab5b00d0aa08d91"
+      },
+      {
+        "name": "libdw1",
+        "version": "0.158",
+        "release": "4.2.6",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "797216c20bf951ff63066c7c1a83e9b7"
+      },
+      {
+        "name": "libedit0",
+        "version": "3.1.snap20140620",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "996d0bd86ca9c2f5f27b89c62767433e"
+      },
+      {
+        "name": "libelf0",
+        "version": "0.8.13",
+        "release": "19.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e543b27787b33378dca95209c5299ac4"
+      },
+      {
+        "name": "libelf1",
+        "version": "0.158",
+        "release": "4.2.6",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6e2e31b54c74b75bd3634f98930ef710"
+      },
+      {
+        "name": "libevent-2_0-5",
+        "version": "2.0.21",
+        "release": "4.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "83a0856854aba3da6390e94e1b0fd25b"
+      },
+      {
+        "name": "libexpat1",
+        "version": "2.1.0",
+        "release": "14.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "1a9db1ce6e69fc83c0307648139fbad2"
+      },
+      {
+        "name": "libext2fs2",
+        "version": "1.42.12",
+        "release": "1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6aaf64311c2a5178558d3c10ad2217a2"
+      },
+      {
+        "name": "libffi4",
+        "version": "4.8.3+r212056",
+        "release": "2.2.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0e3711be45118097d308f6a415ca0637"
+      },
+      {
+        "name": "libfipscheck1",
+        "version": "1.4.1",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b6d67ae2095be95a0a9512c2876883b0"
+      },
+      {
+        "name": "libfreetype6",
+        "version": "2.5.3",
+        "release": "2.1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4d60d20e8a58faf52455834b4266c8b4"
+      },
+      {
+        "name": "libfuse2",
+        "version": "2.9.3",
+        "release": "4.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "740010fca429a1f0939e2ed42bc4fc3c"
+      },
+      {
+        "name": "libgcc_s1",
+        "version": "4.8.3+r212056",
+        "release": "2.2.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "476a495eea1836f46694b973814d5200"
+      },
+      {
+        "name": "libgcrypt20",
+        "version": "1.6.1",
+        "release": "8.3.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e0fa834b7898ca0d2ca9b86e7fcbb4fc"
+      },
+      {
+        "name": "libgdbm4",
+        "version": "1.11",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a6747e743d91965b326ab0cd932b3f6e"
+      },
+      {
+        "name": "libgio-2_0-0",
+        "version": "2.42.0",
+        "release": "2.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "33463cda53d8b80e3e3ae87a941ea9ae"
+      },
+      {
+        "name": "libglib-2_0-0",
+        "version": "2.42.0",
+        "release": "2.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5844a980a0c55fd68a2bdb6c46491d6e"
+      },
+      {
+        "name": "libgmodule-2_0-0",
+        "version": "2.42.0",
+        "release": "2.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f38d78870f58351c08f5670cd8a10ac2"
+      },
+      {
+        "name": "libgmp10",
+        "version": "5.1.3",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "555d4cad908564132d5eda2e42856d47"
+      },
+      {
+        "name": "libgobject-2_0-0",
+        "version": "2.42.0",
+        "release": "2.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "aef7e88775b9176bf0d05e649e6c6adb"
+      },
+      {
+        "name": "libgpg-error0",
+        "version": "1.15",
+        "release": "1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "92b7736c7a178624379ebfa137de5557"
+      },
+      {
+        "name": "libidn11",
+        "version": "1.28",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "aa5bac71adacaab81df725c0482ed6f3"
+      },
+      {
+        "name": "libkeyutils1",
+        "version": "1.5.9",
+        "release": "3.1.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "3cc0efa4106c809cb4226e96ea0eff06"
+      },
+      {
+        "name": "libkmod2",
+        "version": "18",
+        "release": "2.2.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "07374a85aa0def60afee137bc48d90a5"
+      },
+      {
+        "name": "libksba8",
+        "version": "1.3.1",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a42aeeca4b429f0355ea76575a5c5f7b"
+      },
+      {
+        "name": "libldap-2_4-2",
+        "version": "2.4.39",
+        "release": "8.3.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5dab80abcafd76efb07758b1d9acd483"
+      },
+      {
+        "name": "liblua5_1",
+        "version": "5.1.5",
+        "release": "10.2.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a5a40e08979100c97b4d4ec036c80ec0"
+      },
+      {
+        "name": "liblzma5",
+        "version": "5.0.7",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "1410bf2a6350a94dd59a93f96ba761b4"
+      },
+      {
+        "name": "liblzo2-2",
+        "version": "2.08",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "1a7122faf72db093a1576081c5fce862"
+      },
+      {
+        "name": "libmagic1",
+        "version": "5.19",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5f72a83aa6037221f014cfe9678545ea"
+      },
+      {
+        "name": "libmodman1",
+        "version": "2.0.1",
+        "release": "16.1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e632832db7c9fcac4151c3015c9058c7"
+      },
+      {
+        "name": "libmount1",
+        "version": "2.25.1",
+        "release": "2.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "575eb67313cffdbbb61345c1bf60dd90"
+      },
+      {
+        "name": "libmozjs-17_0",
+        "version": "17.0",
+        "release": "8.1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "7610109407dc761ad13d0bcbc1173b50"
+      },
+      {
+        "name": "libncurses5",
+        "version": "5.9",
+        "release": "52.2.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ba99ec008c7a708c1e2678eadd52a8c2"
+      },
+      {
+        "name": "libncurses6",
+        "version": "5.9",
+        "release": "52.2.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "2f009711bf3efad974f8dd53fd9e80f4"
+      },
+      {
+        "name": "libnl-config",
+        "version": "3.2.25",
+        "release": "2.1.2",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "64f397841920460b2260c3a3ebb0ae8e"
+      },
+      {
+        "name": "libnl3-200",
+        "version": "3.2.25",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "8d7af7e4bd815c223eca9e3d2c2c3164"
+      },
+      {
+        "name": "libopenssl1_0_0",
+        "version": "1.0.1i",
+        "release": "2.1.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "3f364b6fc25f62bcc04047d49bec16d0"
+      },
+      {
+        "name": "libp11-kit0",
+        "version": "0.20.3",
+        "release": "1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "698e663745445841beaff2550e90e6b0"
+      },
+      {
+        "name": "libparted0",
+        "version": "3.1",
+        "release": "12.3.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "def6c90d61f1447c42c4c66d68ae42dc"
+      },
+      {
+        "name": "libpcre1",
+        "version": "8.35",
+        "release": "3.2.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "cfab86de55ee87b81efabc84112038b4"
+      },
+      {
+        "name": "libpng16-16",
+        "version": "1.6.13",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "2f1e4a42b4023676f249cc0285489edb"
+      },
+      {
+        "name": "libpolkit0",
+        "version": "0.112",
+        "release": "3.1.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "bef78e7c84e57dd6bb6769a9c4cdb3e1"
+      },
+      {
+        "name": "libpopt0",
+        "version": "1.16",
+        "release": "27.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "37746ac41a929646b88184c2a38c9cae"
+      },
+      {
+        "name": "libprocps3",
+        "version": "3.3.9",
+        "release": "3.2.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "273f27a2713d9d243ab555249580c234"
+      },
+      {
+        "name": "libproxy1",
+        "version": "0.4.11",
+        "release": "12.1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c7b5e6076d73fc3f8d5c5c1d34789fa6"
+      },
+      {
+        "name": "libpth20",
+        "version": "2.0.7",
+        "release": "140.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e9774244529d78be3b6acec8ecddb7b6"
+      },
+      {
+        "name": "libqrencode3",
+        "version": "3.4.3",
+        "release": "2.2.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d2c4d9d57c36ab596ec5d5029da9b848"
+      },
+      {
+        "name": "libreadline6",
+        "version": "6.2",
+        "release": "75.3.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "7c9eda8e58bff82aff9813cfdbe9ae4a"
+      },
+      {
+        "name": "libsasl2-3",
+        "version": "2.1.26",
+        "release": "7.2.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4b4dc519bd6b57b73ba86956ad9d0dbf"
+      },
+      {
+        "name": "libseccomp2",
+        "version": "2.1.1",
+        "release": "2.1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "25a254204c005f9f688e0998131b379e"
+      },
+      {
+        "name": "libselinux1",
+        "version": "2.3",
+        "release": "2.2.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "43a9221e97a24225e31ed7f437faac46"
+      },
+      {
+        "name": "libsemanage1",
+        "version": "2.3",
+        "release": "2.1.8",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "7ba176d33da37954eb5d4ea138b3e128"
+      },
+      {
+        "name": "libsepol1",
+        "version": "2.3",
+        "release": "2.1.8",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5561d4478033dff96ace76707090b714"
+      },
+      {
+        "name": "libsgutils2-2",
+        "version": "1.39",
+        "release": "3.2.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c02093a91c28eab8c786917565f58521"
+      },
+      {
+        "name": "libsmartcols1",
+        "version": "2.25.1",
+        "release": "2.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "cf5b365a20f88563a499c58bb82e9ebc"
+      },
+      {
+        "name": "libsolv-tools",
+        "version": "0.6.6",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ff7236d134667b55951a4711ee22aace"
+      },
+      {
+        "name": "libsqlite3-0",
+        "version": "3.8.6",
+        "release": "1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f1c6aa257d5ff89fad0b8f73bdc77f06"
+      },
+      {
+        "name": "libssh2-1",
+        "version": "1.4.3",
+        "release": "9.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d44bf7880ba5d5ad7fedd60c21a95c6b"
+      },
+      {
+        "name": "libstdc++6",
+        "version": "4.8.3+r212056",
+        "release": "2.2.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0ab0f9e0ffefa4bc828ee12422eafb6e"
+      },
+      {
+        "name": "libtasn1",
+        "version": "3.7",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "62efc62e539bcf53c3eccef971779d17"
+      },
+      {
+        "name": "libtasn1-6",
+        "version": "3.7",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6ebe8b3875b2f2a4b8af5e7e32e17db7"
+      },
+      {
+        "name": "libtirpc1",
+        "version": "0.2.3",
+        "release": "6.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "71dd8cd87594a66075de88e356ffcfc8"
+      },
+      {
+        "name": "libudev1",
+        "version": "210",
+        "release": "25.5.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f8fce88590f1d92115c82fec159bd447"
+      },
+      {
+        "name": "libusb-0_1-4",
+        "version": "0.1.13",
+        "release": "30.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d4a0714d44eb7a771c23ee15eb60b944"
+      },
+      {
+        "name": "libusb-1_0-0",
+        "version": "1.0.19",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c9e840752179a386e0d5154ec1d821d5"
+      },
+      {
+        "name": "libustr-1_0-1",
+        "version": "1.0.4",
+        "release": "33.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "8edd6ad8cdf4a2e24d6da3b2fb0b409d"
+      },
+      {
+        "name": "libutempter0",
+        "version": "1.1.6",
+        "release": "5.2.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f35ec8b020a6ad454c798f4dd5c92fc2"
+      },
+      {
+        "name": "libuuid1",
+        "version": "2.25.1",
+        "release": "2.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "acd0cc861c76941118ebecaac4cffc87"
+      },
+      {
+        "name": "libwicked-0-6",
+        "version": "0.6.12",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "37f4aa3837404bcbe6dbfc4ed55308b7"
+      },
+      {
+        "name": "libwrap0",
+        "version": "7.6",
+        "release": "884.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4611d9f0662b53f842921201a91a7a47"
+      },
+      {
+        "name": "libx86emu1",
+        "version": "1.1",
+        "release": "22.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "51e3740248ed8d604b88e4ffd5b8c9d4"
+      },
+      {
+        "name": "libxcb1",
+        "version": "1.11",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "3377cd90b17ff84dba259ab1f6059ac3"
+      },
+      {
+        "name": "libxml2-2",
+        "version": "2.9.1",
+        "release": "7.2.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "79b41b9de27872effb36f3f51b72e2aa"
+      },
+      {
+        "name": "libxtables10",
+        "version": "1.4.21",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "dc0fb3050f832160539f613d30975f59"
+      },
+      {
+        "name": "libz1",
+        "version": "1.2.8",
+        "release": "5.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "283ad3ad9a05bde5a011b03dcb7cc96e"
+      },
+      {
+        "name": "libzio1",
+        "version": "1.00",
+        "release": "10.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4e3b81e0a57ce47bdb227a9ec1e5d1f2"
+      },
+      {
+        "name": "libzypp",
+        "version": "14.29.4",
+        "release": "2.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "02c6c3b9256b6719a9186a4f3bcf3b3c"
+      },
+      {
+        "name": "lvm2",
+        "version": "2.02.98",
+        "release": "43.2.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "3ea23edb94caeec7ca09621dcf7ef2a0"
+      },
+      {
+        "name": "mozilla-nspr",
+        "version": "4.10.7",
+        "release": "1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "930510631313c90757a166c56aae7bff"
+      },
+      {
+        "name": "mtools",
+        "version": "4.0.18",
+        "release": "5.1.11",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d043f8a4f420778a78c36efb1dc5d800"
+      },
+      {
+        "name": "ncurses-utils",
+        "version": "5.9",
+        "release": "52.2.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "dbd37ccdb12b0af628412aa4e3e42635"
+      },
+      {
+        "name": "net-tools",
+        "version": "1.60",
+        "release": "765.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "29065114db69ca919f5ef00990ecedd0"
+      },
+      {
+        "name": "netcfg",
+        "version": "11.5",
+        "release": "24.2.1",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "bba16328246aed8d662da60d1736b2e1"
+      },
+      {
+        "name": "nfs-client",
+        "version": "1.3.0",
+        "release": "4.2.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d0e95673098410ca8005c37d76262a34"
+      },
+      {
+        "name": "nfs-kernel-server",
+        "version": "1.3.0",
+        "release": "4.2.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "44de05b846043b3ab18e3ffbe59fd803"
+      },
+      {
+        "name": "nfsidmap",
+        "version": "0.25",
+        "release": "6.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a3b61517f95b8f4eadec54a91ec42048"
+      },
+      {
+        "name": "openSUSE-build-key",
+        "version": "1.0",
+        "release": "27.2.1",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "4ae5d20ba926bf8634ebba11094bceb9"
+      },
+      {
+        "name": "openSUSE-release",
+        "version": "13.2",
+        "release": "1.28",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e8cc82f2cbb6d7eccd7ca39732191552"
+      },
+      {
+        "name": "openSUSE-release-ftp",
+        "version": "13.2",
+        "release": "1.28",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ffe04e3f1d60ddcd108fbcb801b930ef"
+      },
+      {
+        "name": "openslp",
+        "version": "2.0.0",
+        "release": "3.2.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "3096c08d7612097804ed5418fe484673"
+      },
+      {
+        "name": "openssh",
+        "version": "6.6p1",
+        "release": "5.1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "fd68e38b0d22367f156ae08f7170385d"
+      },
+      {
+        "name": "openssl",
+        "version": "1.0.1i",
+        "release": "2.1.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f68e40b0b14864284f698c38c53b6c3b"
+      },
+      {
+        "name": "os-prober",
+        "version": "1.61",
+        "release": "12.2.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "60b15752bd635ee6e23be3c4930c3755"
+      },
+      {
+        "name": "p11-kit",
+        "version": "0.20.3",
+        "release": "1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a75fcc11aeadf50ef0a55da8b9ecb5cc"
+      },
+      {
+        "name": "p11-kit-tools",
+        "version": "0.20.3",
+        "release": "1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "9d4db412f67768efd5d37dbe6b2a139d"
+      },
+      {
+        "name": "pam",
+        "version": "1.1.8",
+        "release": "11.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "eb892a5f72b04db153c9b5cfc6051aed"
+      },
+      {
+        "name": "pam-config",
+        "version": "0.88",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "22ac9165cbebf0000b619a839ac6c30d"
+      },
+      {
+        "name": "parted",
+        "version": "3.1",
+        "release": "12.3.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "58e66da4f439af380641bcd2107848ec"
+      },
+      {
+        "name": "patterns-openSUSE-base",
+        "version": "20141007",
+        "release": "2.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "7719998d62810eb6f63c5a459be9cb7f"
+      },
+      {
+        "name": "perl",
+        "version": "5.20.1",
+        "release": "1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5ac140025d8d0ec4a7167c2c0dbd36d3"
+      },
+      {
+        "name": "perl-Bootloader",
+        "version": "0.826",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5138540cbfc9323a4475dcf0ec5107e4"
+      },
+      {
+        "name": "perl-base",
+        "version": "5.20.1",
+        "release": "1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5348bf9921dcf9cd07337a73f36a5d9a"
+      },
+      {
+        "name": "permissions",
+        "version": "2014.08.26.1452",
+        "release": "1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b6c367aa496bc45db497822b51cd5450"
+      },
+      {
+        "name": "pigz",
+        "version": "2.3",
+        "release": "4.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "72bc53c3d8b49fc11007be3911b1ac64"
+      },
+      {
+        "name": "pinentry",
+        "version": "0.8.4",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "2f7ea27d7985f872027c23d07f8ddc2a"
+      },
+      {
+        "name": "pkg-config",
+        "version": "0.28",
+        "release": "7.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f897b7e053e28858f1c84dd760940fbf"
+      },
+      {
+        "name": "polkit",
+        "version": "0.112",
+        "release": "3.1.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "edaf377b75f29ec364263521ee738fbf"
+      },
+      {
+        "name": "polkit-default-privs",
+        "version": "13.2",
+        "release": "7.2.1",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "116d2975cae310bcbf7adceaa81810e6"
+      },
+      {
+        "name": "procps",
+        "version": "3.3.9",
+        "release": "3.2.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "757e5288ee736d0ab735e76f9e8f6532"
+      },
+      {
+        "name": "rpcbind",
+        "version": "0.2.1_rc4",
+        "release": "8.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "1733281484bf6db82a012722c875a238"
+      },
+      {
+        "name": "rpm",
+        "version": "4.11.3",
+        "release": "1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c8f5ffd54d3c76b701e1c9e51cee9eeb"
+      },
+      {
+        "name": "rsync",
+        "version": "3.1.1",
+        "release": "2.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "35637cc42784fecbc83774e3535709e8"
+      },
+      {
+        "name": "sed",
+        "version": "4.2.2",
+        "release": "5.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0799460f34184eefe17aeb25e9b18abb"
+      },
+      {
+        "name": "sg3_utils",
+        "version": "1.39",
+        "release": "3.2.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "594d21f992810bacacd8e016779bd8b7"
+      },
+      {
+        "name": "shadow",
+        "version": "4.1.5.1",
+        "release": "13.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f44a8a9b571eed938fdc41bc979267a4"
+      },
+      {
+        "name": "shared-mime-info",
+        "version": "1.3",
+        "release": "2.1.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a67bc0adb4013ae40c5f15faf58c9e23"
+      },
+      {
+        "name": "squashfs",
+        "version": "4.3",
+        "release": "3.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d664246e6b37f7c704c5449366aa8506"
+      },
+      {
+        "name": "sudo",
+        "version": "1.8.10p3",
+        "release": "2.1.6",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "827b681c561b432a50c3522c655d5c37"
+      },
+      {
+        "name": "suse-module-tools",
+        "version": "12.3",
+        "release": "14.2.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "071be5894fff2c474ff77639651104de"
+      },
+      {
+        "name": "sysconfig",
+        "version": "0.83.7",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4145aa426c447a35ebaea53eb9eed193"
+      },
+      {
+        "name": "sysconfig-netconfig",
+        "version": "0.83.7",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "bb8d662269f2363605d06daad66b54c2"
+      },
+      {
+        "name": "syslinux",
+        "version": "4.04",
+        "release": "33.1.7",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ec2ad73b5631806e0cad06ab16a33f90"
+      },
+      {
+        "name": "systemd",
+        "version": "210",
+        "release": "25.5.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f32ef6f4f21f2ce8326b703f3b92b783"
+      },
+      {
+        "name": "systemd-presets-branding-openSUSE",
+        "version": "0.3.0",
+        "release": "12.1.2",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "09d0b3521086bfe892dcf8bf39ef1e8b"
+      },
+      {
+        "name": "systemd-sysvinit",
+        "version": "210",
+        "release": "25.5.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "96eeba29342ea95e893ff192e3bdcd76"
+      },
+      {
+        "name": "sysvinit-tools",
+        "version": "2.88+",
+        "release": "96.2.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "282c6602009db7ca60dc6a0bc4dd80f3"
+      },
+      {
+        "name": "tar",
+        "version": "1.28",
+        "release": "2.2.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c7a26eda52067a3da487dc9ffc09b056"
+      },
+      {
+        "name": "terminfo-base",
+        "version": "5.9",
+        "release": "52.2.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4c87f521aa2da791c0e6570330716718"
+      },
+      {
+        "name": "test-data-files",
+        "version": "1.0",
+        "release": "1",
+        "arch": "noarch",
+        "vendor": "(none)",
+        "checksum": "e356aa610edf853009e640e9d6bee813"
+      },
+      {
+        "name": "time",
+        "version": "1.7",
+        "release": "7.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "bc8a15b938feff434ff8213225628439"
+      },
+      {
+        "name": "udev",
+        "version": "210",
+        "release": "25.5.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0337655918c07be034ceacd9ab9f46f7"
+      },
+      {
+        "name": "update-alternatives",
+        "version": "1.16.10",
+        "release": "8.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "29af590d48e6877531eae1c9794fc2b2"
+      },
+      {
+        "name": "util-linux",
+        "version": "2.25.1",
+        "release": "2.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "259ad9ea72b2d96f27a231774633ac1b"
+      },
+      {
+        "name": "util-linux-systemd",
+        "version": "2.25.1",
+        "release": "2.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0be1fbe4702738a85bed862a45b156a5"
+      },
+      {
+        "name": "vim",
+        "version": "7.4.461.hg.6253",
+        "release": "1.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d8d3d922d9349a6d5c745681618597f0"
+      },
+      {
+        "name": "wallpaper-branding-openSUSE",
+        "version": "13.2",
+        "release": "3.6.1",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "ec2d79df332261d9168202fc38bcaf2e"
+      },
+      {
+        "name": "which",
+        "version": "2.20",
+        "release": "4.1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "362e35d4d5b61f9f2daddb1a296da790"
+      },
+      {
+        "name": "wicked",
+        "version": "0.6.12",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0c9b4f0cf4d87e25f1ce7af475b43f6b"
+      },
+      {
+        "name": "wicked-service",
+        "version": "0.6.12",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "1d1668bf348ff4a8ba63a984f466c8fc"
+      },
+      {
+        "name": "xz",
+        "version": "5.0.7",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "eb8962316fb5be90be3cefd39b9b5899"
+      },
+      {
+        "name": "zypper",
+        "version": "1.11.14",
+        "release": "2.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d5796d9d26d8bf62532549e7d6eff0bc"
+      }
+    ]
+  },
   "patterns": [
     {
       "name": "base",
@@ -2907,7 +2910,7 @@
     ]
   },
   "meta": {
-    "format_version": 5,
+    "format_version": 6,
     "os": {
       "modified": "2015-06-23T11:55:38Z",
       "hostname": "192.168.121.70"

--- a/spec/data/descriptions/jeos/opensuse_leap/manifest.json
+++ b/spec/data/descriptions/jeos/opensuse_leap/manifest.json
@@ -8,1752 +8,1755 @@
     "version": "42.1",
     "architecture": "x86_64"
   },
-  "packages": [
-    {
-      "name": "aaa_base",
-      "version": "13.2+git20140911.61c1681",
-      "release": "4.6",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "081158cbce7420230e5debfc93e489f0"
-    },
-    {
-      "name": "acl",
-      "version": "2.2.52",
-      "release": "6.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "766d1f6f9b2523ce864bde867e81557e"
-    },
-    {
-      "name": "autofs",
-      "version": "5.0.9",
-      "release": "4.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "7bc71d01fff912393048d72034e2de73"
-    },
-    {
-      "name": "bash",
-      "version": "4.2",
-      "release": "76.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "561f9d9e35793b8420bf38be8b3ee922"
-    },
-    {
-      "name": "btrfsprogs",
-      "version": "4.1.2",
-      "release": "8.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6c402497faf63d4e3bc42bc0c8933594"
-    },
-    {
-      "name": "bzip2",
-      "version": "1.0.6",
-      "release": "30.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ecb5db1d84561924017cf4db72b85fdd"
-    },
-    {
-      "name": "ca-certificates",
-      "version": "1_201403302107",
-      "release": "9.1",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "be1740cc1c20a08890800ca732872940"
-    },
-    {
-      "name": "coreutils",
-      "version": "8.22",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "3d02b57038ef0896d85da7c0801b1d5c"
-    },
-    {
-      "name": "cpio",
-      "version": "2.11",
-      "release": "30.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c39a9599f1b3f3124585a515b9522e51"
-    },
-    {
-      "name": "cracklib",
-      "version": "2.9.0",
-      "release": "5.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "42f358e756e107022e64636f7a1e3dae"
-    },
-    {
-      "name": "cracklib-dict-full",
-      "version": "2.8.12",
-      "release": "65.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "89f5ef288f7dcab86dc64b82588fc44d"
-    },
-    {
-      "name": "cron",
-      "version": "4.2",
-      "release": "57.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "9e04e3296fb2590d44b66cea2b2205dc"
-    },
-    {
-      "name": "cronie",
-      "version": "1.4.11",
-      "release": "57.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "52ed6912e670f4d4756f90f81d72f75b"
-    },
-    {
-      "name": "dbus-1",
-      "version": "1.8.16",
-      "release": "5.9",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6a03c4e5ce455f6824eb77cd2b069195"
-    },
-    {
-      "name": "dbus-1-x11",
-      "version": "1.8.16",
-      "release": "5.9",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4f16d7a5d39286f2053ceb62f43a4a4d"
-    },
-    {
-      "name": "device-mapper",
-      "version": "1.02.97",
-      "release": "62.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "388ac9d2a7e3200fefb1f0bd1baae2ff"
-    },
-    {
-      "name": "diffutils",
-      "version": "3.3",
-      "release": "7.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "21b94c7e0c99652ac9b1190e9ad4185f"
-    },
-    {
-      "name": "dirmngr",
-      "version": "1.1.1",
-      "release": "5.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b9474382c5a1a32cb4b80c8c11ad974a"
-    },
-    {
-      "name": "dmraid",
-      "version": "1.0.0.rc16",
-      "release": "37.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e73db7b22432baeae182c43e23695394"
-    },
-    {
-      "name": "dracut",
-      "version": "037",
-      "release": "66.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0754343c0f264e86d4f64542e9f400df"
-    },
-    {
-      "name": "elfutils",
-      "version": "0.158",
-      "release": "9.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0c98f93f724cd9193a4cfc677e84dee5"
-    },
-    {
-      "name": "expat",
-      "version": "2.1.0",
-      "release": "15.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f0eb5eb42ea515b2aa5bafea21fc3145"
-    },
-    {
-      "name": "file",
-      "version": "5.19",
-      "release": "5.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "477b6d9501345b433afdf6176c4a15b5"
-    },
-    {
-      "name": "file-magic",
-      "version": "5.19",
-      "release": "5.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4505cf10caf6196235ce22bb2a537ecc"
-    },
-    {
-      "name": "filesystem",
-      "version": "13.1",
-      "release": "5.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d67112cffc0a9fb857a865b3712cf31e"
-    },
-    {
-      "name": "fillup",
-      "version": "1.42",
-      "release": "272.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "00e96a60de4fbc763504a34c5ef89d67"
-    },
-    {
-      "name": "findutils",
-      "version": "4.5.12",
-      "release": "3.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "9ed445ac242d021d78bde3d85916b4e9"
-    },
-    {
-      "name": "fipscheck",
-      "version": "1.2.0",
-      "release": "7.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "576b4b85fb2d98190c933c258fc02006"
-    },
-    {
-      "name": "gawk",
-      "version": "4.1.3",
-      "release": "4.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "2ba134744092902e47fa35b6e1d57184"
-    },
-    {
-      "name": "gettext-runtime",
-      "version": "0.19.2",
-      "release": "3.6",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f3047a9549c5de7e740e3eb8cee9198d"
-    },
-    {
-      "name": "gio-branding-openSUSE",
-      "version": "42.1",
-      "release": "2.1",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "b32c86666c2c9762a6fcf2e437794522"
-    },
-    {
-      "name": "glib2-tools",
-      "version": "2.44.1",
-      "release": "2.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d45f109a13f163dcd7402583ca6a8461"
-    },
-    {
-      "name": "glibc",
-      "version": "2.19",
-      "release": "17.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0c43af7fce881df707d8f8fdba431028"
-    },
-    {
-      "name": "glibc-locale",
-      "version": "2.19",
-      "release": "17.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "275cef46e18ae2f9f3ab86b7f45c6a12"
-    },
-    {
-      "name": "gpg2",
-      "version": "2.0.24",
-      "release": "3.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4d584a80bb8e61c3186832468e0f433d"
-    },
-    {
-      "name": "grep",
-      "version": "2.16",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0261d7c67ef4ef1b3ee2886f9d221a7d"
-    },
-    {
-      "name": "grub2",
-      "version": "2.02~beta2",
-      "release": "68.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d97a40a45fe97a05623192d1aba31979"
-    },
-    {
-      "name": "grub2-i386-pc",
-      "version": "2.02~beta2",
-      "release": "68.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "460b36f7bd90ee29357293d67ea0a8f8"
-    },
-    {
-      "name": "gzip",
-      "version": "1.6",
-      "release": "9.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "8805cc4b5481248c76fbf73b25d0967c"
-    },
-    {
-      "name": "hardlink",
-      "version": "1.0",
-      "release": "8.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6949f7db310547a5a7b5f3876c211544"
-    },
-    {
-      "name": "hwinfo",
-      "version": "21.23",
-      "release": "1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "1148f436ee53a5c8d425b0b91c2d3eaa"
-    },
-    {
-      "name": "ifplugd",
-      "version": "0.28",
-      "release": "236.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b29aaa55b0cd4443969eab33c0a7a9b6"
-    },
-    {
-      "name": "info",
-      "version": "4.13a",
-      "release": "39.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4106a30405ac8522219eda9b45021f13"
-    },
-    {
-      "name": "insserv-compat",
-      "version": "0.1",
-      "release": "13.4",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "16224bf774a3714d55be6355dd4ea528"
-    },
-    {
-      "name": "iproute2",
-      "version": "4.2",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d0fdaecdd4c27a83ca14f250993c8c30"
-    },
-    {
-      "name": "iputils",
-      "version": "s20121221",
-      "release": "3.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b8a76296b8d39aa9340dfb9677f33800"
-    },
-    {
-      "name": "kbd",
-      "version": "1.15.5",
-      "release": "6.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "38bb82ee41f8cfdac42098970bab7fc3"
-    },
-    {
-      "name": "kernel-default",
-      "version": "4.1.12",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c9d0cbe850fe6b6c30110c398e5cf5de"
-    },
-    {
-      "name": "keyutils",
-      "version": "1.5.9",
-      "release": "4.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "746c5a4a2b7380a61d1f46d194601bfb"
-    },
-    {
-      "name": "klogd",
-      "version": "1.4.1",
-      "release": "779.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6c0ebedc416ab10be2cc9ebbf4a4afbc"
-    },
-    {
-      "name": "kmod",
-      "version": "17",
-      "release": "3.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "bf83b106d2e969e1f67059e40285670f"
-    },
-    {
-      "name": "kmod-compat",
-      "version": "17",
-      "release": "3.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6e4c906c5a8aa763abe7807faef9656f"
-    },
-    {
-      "name": "kpartx",
-      "version": "0.5.0",
-      "release": "48.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b1b43779794a5a20df4daea8f8ef2eaa"
-    },
-    {
-      "name": "krb5",
-      "version": "1.12.1",
-      "release": "19.9",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "bdab6842125d0170f176e5293fc7bc57"
-    },
-    {
-      "name": "libX11-6",
-      "version": "1.6.3",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d81e5d726512266dad5bd41a3ee673ff"
-    },
-    {
-      "name": "libX11-data",
-      "version": "1.6.3",
-      "release": "1.1",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "84a346123235e8fffed79b1d16e4d202"
-    },
-    {
-      "name": "libXau6",
-      "version": "1.0.8",
-      "release": "6.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "fc6392b8bfb72b5a5ef8fb6f3103b113"
-    },
-    {
-      "name": "libacl1",
-      "version": "2.2.52",
-      "release": "6.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "99c7abed9b2f6ed6171c583a0656544f"
-    },
-    {
-      "name": "libadns1",
-      "version": "1.4",
-      "release": "103.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "71e817de14d7efc51084fea99c4c83ec"
-    },
-    {
-      "name": "libaio1",
-      "version": "0.3.109",
-      "release": "19.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "385acc095a701bdd1fdc81d136f64ade"
-    },
-    {
-      "name": "libapparmor1",
-      "version": "2.10",
-      "release": "3.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "57c78c11189b3c0118b76732dae8c038"
-    },
-    {
-      "name": "libasm1",
-      "version": "0.158",
-      "release": "9.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "595c731f1ca8cfd566c79c865ad5c934"
-    },
-    {
-      "name": "libassuan0",
-      "version": "2.1.1",
-      "release": "3.6",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "13119dd654a231d1ef393575698daf43"
-    },
-    {
-      "name": "libattr1",
-      "version": "2.4.47",
-      "release": "5.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5ecf26b664bf5e39c044d7dc55613503"
-    },
-    {
-      "name": "libaudit1",
-      "version": "2.3.6",
-      "release": "3.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ae9a9128aef35481887aaf7f4fdb7395"
-    },
-    {
-      "name": "libaugeas0",
-      "version": "1.2.0",
-      "release": "6.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "978d76d447de6877eee5fb35ba470e08"
-    },
-    {
-      "name": "libblkid1",
-      "version": "2.25",
-      "release": "7.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "24976d4ae7ae4378664cb1e008374370"
-    },
-    {
-      "name": "libbz2-1",
-      "version": "1.0.6",
-      "release": "30.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "7fdc7c1ddd6f315d72bf27989e27d65f"
-    },
-    {
-      "name": "libcap-ng0",
-      "version": "0.7.3",
-      "release": "3.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5ad0f4c8860079f035adca5117faed16"
-    },
-    {
-      "name": "libcap2",
-      "version": "2.22",
-      "release": "14.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "474398c10aeb7a0427f6d46d55db7c8d"
-    },
-    {
-      "name": "libcom_err2",
-      "version": "1.42.11",
-      "release": "10.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "968bc37bcfde17cd1a67a0c14f741959"
-    },
-    {
-      "name": "libcrack2",
-      "version": "2.9.0",
-      "release": "5.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ed710df3d688ddfaee6b8f16f0fab94a"
-    },
-    {
-      "name": "libcroco-0_6-3",
-      "version": "0.6.8",
-      "release": "8.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4c6816f85d96c95e75ead6fa1b5e1a93"
-    },
-    {
-      "name": "libcryptsetup4",
-      "version": "1.6.4",
-      "release": "3.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "cf52d77b951c552ee1e9d49b5653957b"
-    },
-    {
-      "name": "libcurl4",
-      "version": "7.37.0",
-      "release": "5.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "9b275f787e46ba192a4b419d8dafcc59"
-    },
-    {
-      "name": "libdaemon0",
-      "version": "0.14",
-      "release": "16.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "98c1da92d5765c028ec377869948d963"
-    },
-    {
-      "name": "libdb-4_8",
-      "version": "4.8.30",
-      "release": "30.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "9048c99c58b699941ebbb5379e22800e"
-    },
-    {
-      "name": "libdbus-1-3",
-      "version": "1.8.16",
-      "release": "5.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b33f7d7cf3bb4b0dd67864c82c9c7d89"
-    },
-    {
-      "name": "libdw1",
-      "version": "0.158",
-      "release": "9.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "63c5fa258664ab3f4aa4e946e7c09415"
-    },
-    {
-      "name": "libedit0",
-      "version": "3.1.snap20140620",
-      "release": "3.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "3b3f2fbf583d24bf8084deffe4a1c6c4"
-    },
-    {
-      "name": "libelf0",
-      "version": "0.8.13",
-      "release": "20.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "067caff382236fe4116f092b466fa4b0"
-    },
-    {
-      "name": "libelf1",
-      "version": "0.158",
-      "release": "9.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "9fbf4e75e7ce3fa57a7c05ce94cdd131"
-    },
-    {
-      "name": "libevent-2_0-5",
-      "version": "2.0.21",
-      "release": "5.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6af8fdf972d32d65c9344432f63f3810"
-    },
-    {
-      "name": "libexpat1",
-      "version": "2.1.0",
-      "release": "15.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d817724be54a59c550770448be55e850"
-    },
-    {
-      "name": "libext2fs2",
-      "version": "1.42.11",
-      "release": "10.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0f06977a3e9111fc65c435eacbd70401"
-    },
-    {
-      "name": "libffi4",
-      "version": "5.2.1+r226025",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5d80ff50e7a524845a6d9a040bf8d847"
-    },
-    {
-      "name": "libfipscheck1",
-      "version": "1.2.0",
-      "release": "7.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ae58f0bbe2cf9014f9c2bdd70b826e8c"
-    },
-    {
-      "name": "libfreetype6",
-      "version": "2.5.5",
-      "release": "8.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b71acf65d24b66a023350974c3283a57"
-    },
-    {
-      "name": "libfuse2",
-      "version": "2.9.3",
-      "release": "8.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c1f672440dc6ba4f9b70faaf2f179bcc"
-    },
-    {
-      "name": "libgcc_s1",
-      "version": "5.2.1+r226025",
-      "release": "4.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "62c714318520d5f9470255ea7e014b7f"
-    },
-    {
-      "name": "libgcrypt20",
-      "version": "1.6.1",
-      "release": "18.7",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "2a969479224d8c343043e895157f5a39"
-    },
-    {
-      "name": "libgdbm4",
-      "version": "1.10",
-      "release": "3.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "7a6a9015c0888529a5d219ef622c1c3d"
-    },
-    {
-      "name": "libgio-2_0-0",
-      "version": "2.44.1",
-      "release": "2.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e1be5315ad7bf5eb37f62bcc3fb3a374"
-    },
-    {
-      "name": "libglib-2_0-0",
-      "version": "2.44.1",
-      "release": "2.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5675fc8cd8df92a1b14a142ae386d647"
-    },
-    {
-      "name": "libgmodule-2_0-0",
-      "version": "2.44.1",
-      "release": "2.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "673f815ca542e7c68ddf2077a3bd23e6"
-    },
-    {
-      "name": "libgmp10",
-      "version": "5.1.3",
-      "release": "4.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a0e62fa96082c4b2795d039c04bd59c7"
-    },
-    {
-      "name": "libgobject-2_0-0",
-      "version": "2.44.1",
-      "release": "2.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5b43dc73af4181a66be2aee91d61132a"
-    },
-    {
-      "name": "libgpg-error0",
-      "version": "1.13",
-      "release": "3.6",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "8c53b983461b2b5b176a5c38197fff27"
-    },
-    {
-      "name": "libidn11",
-      "version": "1.28",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ec33361965f206dba5375f5ee6684847"
-    },
-    {
-      "name": "libkeyutils1",
-      "version": "1.5.9",
-      "release": "4.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0d17a38828ebd5b477c47682ef7ace5f"
-    },
-    {
-      "name": "libkmod2",
-      "version": "17",
-      "release": "3.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a3ea927784b790bdc72b1924bfaccbc3"
-    },
-    {
-      "name": "libksba8",
-      "version": "1.3.0",
-      "release": "2.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "3d3443b50ac034e1415f00bf95753889"
-    },
-    {
-      "name": "libldap-2_4-2",
-      "version": "2.4.41",
-      "release": "9.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4aa486177ff244a96c3d114a91472406"
-    },
-    {
-      "name": "liblua5_1",
-      "version": "5.1.5",
-      "release": "11.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "3d70c542cf88d65ae03ba9c440a31c20"
-    },
-    {
-      "name": "liblzma5",
-      "version": "5.0.5",
-      "release": "3.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a7549cb7b79d2e598414ec11291dc3b3"
-    },
-    {
-      "name": "liblzo2-2",
-      "version": "2.08",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c1c980b7163b805cf53c76e0df1dd5c8"
-    },
-    {
-      "name": "libmagic1",
-      "version": "5.19",
-      "release": "5.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "35f913015516d358f919a9bf2a151c60"
-    },
-    {
-      "name": "libmnl0",
-      "version": "1.0.3",
-      "release": "11.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e9eedd7d320fe800ecfb3eb6755aac5d"
-    },
-    {
-      "name": "libmodman1",
-      "version": "2.0.1",
-      "release": "17.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "09ee09a7401aee9cb708f633667419cf"
-    },
-    {
-      "name": "libmount1",
-      "version": "2.25",
-      "release": "7.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d89d7ef9180cbf0b6652cc55ec25816b"
-    },
-    {
-      "name": "libmozjs-17_0",
-      "version": "17.0",
-      "release": "9.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5948f68685d467b399160953e14cd657"
-    },
-    {
-      "name": "libncurses5",
-      "version": "5.9",
-      "release": "53.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "bd073814979cf7ec44be4e0e6709b4e0"
-    },
-    {
-      "name": "libncurses6",
-      "version": "5.9",
-      "release": "53.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "59fd948b23f023d6d58a6996d1165e96"
-    },
-    {
-      "name": "libnl-config",
-      "version": "3.2.23",
-      "release": "3.2",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "716e44608b489a0f5d7dad76a4c3f4fc"
-    },
-    {
-      "name": "libnl3-200",
-      "version": "3.2.23",
-      "release": "3.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a37fda4081aa7167a1e720c46dd77cfb"
-    },
-    {
-      "name": "libopenssl1_0_0",
-      "version": "1.0.1i",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4c3448b2c5e136182c85ccb50bcf7f87"
-    },
-    {
-      "name": "libp11-kit0",
-      "version": "0.20.3",
-      "release": "7.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b31820a5ab481c71c27011300b97c342"
-    },
-    {
-      "name": "libparted0",
-      "version": "3.1",
-      "release": "17.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d6a086e3519db99b49e610a1d2988540"
-    },
-    {
-      "name": "libpcre1",
-      "version": "8.33",
-      "release": "3.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "395ad9aedce1ab1cdae65e15f9fdac27"
-    },
-    {
-      "name": "libpng16-16",
-      "version": "1.6.8",
-      "release": "2.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0ec7a9ef42c556b44b5675cd8b5a1fd7"
-    },
-    {
-      "name": "libpolkit0",
-      "version": "0.112",
-      "release": "4.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ffbedfb22a932d9713fe5886ffc456ec"
-    },
-    {
-      "name": "libpopt0",
-      "version": "1.16",
-      "release": "28.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a83dc8dcd88541920e3f605ee9a35f10"
-    },
-    {
-      "name": "libprocps3",
-      "version": "3.3.9",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "1eb77bbae72f9f827666451eca1d8451"
-    },
-    {
-      "name": "libproxy1",
-      "version": "0.4.11",
-      "release": "13.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "bc349abdb2da93030c9d7fb883e5230b"
-    },
-    {
-      "name": "libpth20",
-      "version": "2.0.7",
-      "release": "141.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f46f7a186081948253d3d9d5b0dea85a"
-    },
-    {
-      "name": "libqrencode3",
-      "version": "3.4.3",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "933ff2856ce1043768f777f6beedea58"
-    },
-    {
-      "name": "libreadline6",
-      "version": "6.2",
-      "release": "76.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "1362ad02cc6eb801668e2e8b0ce22d8c"
-    },
-    {
-      "name": "libreiserfscore0",
-      "version": "3.6.24",
-      "release": "7.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "eae1c65bc257b18bc12976a13c51a28c"
-    },
-    {
-      "name": "libsasl2-3",
-      "version": "2.1.26",
-      "release": "8.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "603031f8e40da1ad042cef4cf290f809"
-    },
-    {
-      "name": "libseccomp2",
-      "version": "2.1.1",
-      "release": "3.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "30b388d17a2b2e44cb4b1e1a3aded378"
-    },
-    {
-      "name": "libselinux1",
-      "version": "2.3",
-      "release": "3.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5704953fa5cc9534f0130186b5eed86c"
-    },
-    {
-      "name": "libsemanage1",
-      "version": "2.3",
-      "release": "3.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "966de4475e7ef999a6dcc2167628e96a"
-    },
-    {
-      "name": "libsepol1",
-      "version": "2.3",
-      "release": "3.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "25a44cb17af04ed900838524458fabea"
-    },
-    {
-      "name": "libsgutils2-2",
-      "version": "1.41",
-      "release": "6.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e33ceadb5471bda94a0447871988886a"
-    },
-    {
-      "name": "libsmartcols1",
-      "version": "2.25",
-      "release": "7.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "598157b2169ea2e4d5664c621c1b459e"
-    },
-    {
-      "name": "libsolv-tools",
-      "version": "0.6.14",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5e496bfdc84c4b6b9076528d01ffa837"
-    },
-    {
-      "name": "libsqlite3-0",
-      "version": "3.8.10.2",
-      "release": "5.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4011163d31a62520d53b98a417d2ae78"
-    },
-    {
-      "name": "libssh2-1",
-      "version": "1.4.3",
-      "release": "10.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6f909139497c6170b307bd3dfba62aea"
-    },
-    {
-      "name": "libstdc++6",
-      "version": "5.2.1+r226025",
-      "release": "4.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "dd6917616d8419dac960316b4d1b5dd0"
-    },
-    {
-      "name": "libtasn1",
-      "version": "3.7",
-      "release": "10.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "8d4ba27025e4e3697378f3a4ac1fdeb2"
-    },
-    {
-      "name": "libtasn1-6",
-      "version": "3.7",
-      "release": "10.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "1987356b9f5cd5b4e748c353a3452a15"
-    },
-    {
-      "name": "libtirpc1",
-      "version": "0.2.3",
-      "release": "7.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "87af35eb8c5b377e943af42a500665ac"
-    },
-    {
-      "name": "libudev1",
-      "version": "210",
-      "release": "84.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "21294775d0f7c459442da007e602fc46"
-    },
-    {
-      "name": "libusb-0_1-4",
-      "version": "0.1.13",
-      "release": "31.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e0c33d8f1b2124ac4cd406ca02fa26fc"
-    },
-    {
-      "name": "libusb-1_0-0",
-      "version": "1.0.20",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "fe534a1b8543d13afa6ace2ac9ac9fc0"
-    },
-    {
-      "name": "libustr-1_0-1",
-      "version": "1.0.4",
-      "release": "34.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5867189d1be04094b6803055d76fa9ed"
-    },
-    {
-      "name": "libutempter0",
-      "version": "1.1.6",
-      "release": "6.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "725851a15ad68060a1879bc52bc038bd"
-    },
-    {
-      "name": "libuuid1",
-      "version": "2.25",
-      "release": "7.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "763bf8fb1585c384577b3519bd971fd8"
-    },
-    {
-      "name": "libwicked-0-6",
-      "version": "0.6.27",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f063b6ba778b43ba581f683c72bc0a39"
-    },
-    {
-      "name": "libwrap0",
-      "version": "7.6",
-      "release": "885.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4d030beb9444548a64b968cbedbd503a"
-    },
-    {
-      "name": "libx86emu1",
-      "version": "1.5",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4f5294a5f06ceae33e6dcf4553af8c16"
-    },
-    {
-      "name": "libxcb1",
-      "version": "1.11.1",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "68594c8b6d82583fb9b18183b27ed2ed"
-    },
-    {
-      "name": "libxml2-2",
-      "version": "2.9.1",
-      "release": "8.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "dca88cfe4ddad156a8b3ec63340a5d79"
-    },
-    {
-      "name": "libxtables10",
-      "version": "1.4.21",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6686e7170269c59e4241e96f71482bec"
-    },
-    {
-      "name": "libz1",
-      "version": "1.2.8",
-      "release": "6.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "2b0e8459c17ff7c18d7fa603e46d8af8"
-    },
-    {
-      "name": "libzio1",
-      "version": "1.00",
-      "release": "11.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d3bed4bab54ef017f6ec2f7eab2a2eab"
-    },
-    {
-      "name": "libzypp",
-      "version": "15.19.5",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e24a7299bcf72ecfe1b53d1f079b1b22"
-    },
-    {
-      "name": "lvm2",
-      "version": "2.02.120",
-      "release": "62.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "07c47e34c1f7450dd883f713f98dfba3"
-    },
-    {
-      "name": "mozilla-nspr",
-      "version": "4.10.8",
-      "release": "2.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d60f71e6c41b0f8427fbf6f05a7ff859"
-    },
-    {
-      "name": "ncurses-utils",
-      "version": "5.9",
-      "release": "53.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "be7ec4b37a45f3d6203f34be710028d7"
-    },
-    {
-      "name": "netcfg",
-      "version": "11.5",
-      "release": "26.1",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "bd43ad2811d57ebfa714ad917585176c"
-    },
-    {
-      "name": "nfs-client",
-      "version": "1.3.0",
-      "release": "9.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "27c3111ec42452de1c096a8b5cd8406b"
-    },
-    {
-      "name": "nfs-kernel-server",
-      "version": "1.3.0",
-      "release": "9.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ce51e81bb9bfcbc36a25bf7a6dbedb8d"
-    },
-    {
-      "name": "nfsidmap",
-      "version": "0.25",
-      "release": "7.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e136fa60a9f8a17c1a65bce79399f8eb"
-    },
-    {
-      "name": "openSUSE-build-key",
-      "version": "1.0",
-      "release": "32.2",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "e9b1b6a0acab733785c1917a614bec4c"
-    },
-    {
-      "name": "openSUSE-release",
-      "version": "42.1",
-      "release": "1.46",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "cf9d4736a3f57d1ba2737acce151de88"
-    },
-    {
-      "name": "openSUSE-release-ftp",
-      "version": "42.1",
-      "release": "1.46",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f59b8c889e3be76d2e5cd48386bd769d"
-    },
-    {
-      "name": "openslp",
-      "version": "2.0.0",
-      "release": "8.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "41ac615914d0d4963d1fa7142f5397ac"
-    },
-    {
-      "name": "openssh",
-      "version": "6.6p1",
-      "release": "6.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "77bd1c768d5e18514346e0ce1919ebf8"
-    },
-    {
-      "name": "openssl",
-      "version": "1.0.1i",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c3ae00e7c026622b581cb7c787e862b2"
-    },
-    {
-      "name": "os-prober",
-      "version": "1.61",
-      "release": "13.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "2a5914bf642f1c3dd58b04dbf2f224ff"
-    },
-    {
-      "name": "p11-kit",
-      "version": "0.20.3",
-      "release": "7.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "1a4fbf51e1e7f2ea702b56ac0a5f8629"
-    },
-    {
-      "name": "p11-kit-tools",
-      "version": "0.20.3",
-      "release": "7.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "76e1262aa55518dd9c9aad01d000ea9d"
-    },
-    {
-      "name": "pam",
-      "version": "1.1.8",
-      "release": "12.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "89fb119bc96c58eb8ae36bbfb7c7a9ac"
-    },
-    {
-      "name": "pam-config",
-      "version": "0.88",
-      "release": "3.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4ac861a96312be035c91508616440e42"
-    },
-    {
-      "name": "parted",
-      "version": "3.1",
-      "release": "17.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "78ce8ad64acf97448971662040c08bbe"
-    },
-    {
-      "name": "patterns-openSUSE-base",
-      "version": "20150918",
-      "release": "10.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "535a49dfcc33dc71e5c449a670f5bf0c"
-    },
-    {
-      "name": "perl",
-      "version": "5.18.2",
-      "release": "3.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "fec639f37724b6db5d19ec0e75079874"
-    },
-    {
-      "name": "perl-Bootloader",
-      "version": "0.844",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "8d1f9810985464b3455c08f429c6b1a0"
-    },
-    {
-      "name": "perl-base",
-      "version": "5.18.2",
-      "release": "3.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "70ede2005fd4aea48172f92a53d340c8"
-    },
-    {
-      "name": "permissions",
-      "version": "2014.08.26.1452",
-      "release": "3.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c0dcb6d707f29d97922b2554ab9094c9"
-    },
-    {
-      "name": "pigz",
-      "version": "2.3",
-      "release": "5.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d71f853f036d3f067084141821f4a724"
-    },
-    {
-      "name": "pinentry",
-      "version": "0.8.3",
-      "release": "3.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4515aba86a21e012b38f235f1e58216e"
-    },
-    {
-      "name": "pkg-config",
-      "version": "0.28",
-      "release": "8.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0c6e3c89832083f13c3ac8d9eedaec43"
-    },
-    {
-      "name": "polkit",
-      "version": "0.112",
-      "release": "4.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c698acc85baf46a9d53660e712c1d139"
-    },
-    {
-      "name": "polkit-default-privs",
-      "version": "13.2",
-      "release": "8.1",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "7e72805bfa7be325ad3ff2598dcaa0fa"
-    },
-    {
-      "name": "procps",
-      "version": "3.3.9",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "1099d51ad98a72c950bb7a2e265d8ab2"
-    },
-    {
-      "name": "rpcbind",
-      "version": "0.2.1_rc4",
-      "release": "9.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "7fdb3e2ab5f5626a5ecac1007d69a886"
-    },
-    {
-      "name": "rpm",
-      "version": "4.11.2",
-      "release": "6.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c1165f89362d61a7cd5ce3c4c57c0db2"
-    },
-    {
-      "name": "rsync",
-      "version": "3.1.0",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6e6589c90f073872ca934b5780599a5a"
-    },
-    {
-      "name": "sed",
-      "version": "4.2.2",
-      "release": "6.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d591d4a09e1c8801df91e6fafc6775bd"
-    },
-    {
-      "name": "sg3_utils",
-      "version": "1.41",
-      "release": "6.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d99c08b0c56c5e7c62de3cb39de45468"
-    },
-    {
-      "name": "shadow",
-      "version": "4.1.5.1",
-      "release": "14.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e675bf8b52ada6b99d1d2782c4907740"
-    },
-    {
-      "name": "shared-mime-info",
-      "version": "1.2",
-      "release": "3.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "feff5c41f619f236e2b722c192d2464a"
-    },
-    {
-      "name": "squashfs",
-      "version": "4.3",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "576c75d423e50ebcd6affbd806ef8d06"
-    },
-    {
-      "name": "sudo",
-      "version": "1.8.10p3",
-      "release": "3.8",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "cbad9e70c306d1bde094a0c7b47fc705"
-    },
-    {
-      "name": "suse-module-tools",
-      "version": "12.3",
-      "release": "16.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "74ec43dcfd6f8d0cf2d538b073a4a017"
-    },
-    {
-      "name": "sysconfig",
-      "version": "0.83.8",
-      "release": "5.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "539d89d9bcb2f2a0cb7e39e2b85a66f3"
-    },
-    {
-      "name": "sysconfig-netconfig",
-      "version": "0.83.8",
-      "release": "5.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a61fe5590444b230c1c9aff63e108fb1"
-    },
-    {
-      "name": "syslinux",
-      "version": "4.04",
-      "release": "34.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c94acd46c7dc72a21380e0f634afbf01"
-    },
-    {
-      "name": "systemd",
-      "version": "210",
-      "release": "84.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "8406d85954619896606bc5cfa867f942"
-    },
-    {
-      "name": "systemd-presets-branding-openSUSE",
-      "version": "0.3.0",
-      "release": "23.2",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "e6b50b275e529bbeaa09b917eac30a12"
-    },
-    {
-      "name": "systemd-sysvinit",
-      "version": "210",
-      "release": "84.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "2caa2bae61cbae5627162f8eb505cc0e"
-    },
-    {
-      "name": "sysvinit-tools",
-      "version": "2.88+",
-      "release": "97.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "af5d2e1a6a5992d29d124d3b1a89d0da"
-    },
-    {
-      "name": "tar",
-      "version": "1.27.1",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "84c421ba47651f0a38f9cb32fa603b2d"
-    },
-    {
-      "name": "terminfo-base",
-      "version": "5.9",
-      "release": "53.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "cb09a6420e75ebaf4b814caf6b7c600d"
-    },
-    {
-      "name": "time",
-      "version": "1.7",
-      "release": "8.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "97e358055cbc505d87f8afbc4442a5de"
-    },
-    {
-      "name": "udev",
-      "version": "210",
-      "release": "84.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5bb2181e5953920e9f8824835620a2b4"
-    },
-    {
-      "name": "update-alternatives",
-      "version": "1.16.10",
-      "release": "9.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "2583a577d67e2c8ec2fa9fc84b5dc809"
-    },
-    {
-      "name": "util-linux",
-      "version": "2.25",
-      "release": "7.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "fc4f36ccf6e1b915862791d91b00b8bb"
-    },
-    {
-      "name": "util-linux-systemd",
-      "version": "2.25",
-      "release": "7.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f87f35b663f13a8cefccf876105a128a"
-    },
-    {
-      "name": "vim",
-      "version": "7.4.326",
-      "release": "3.10",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c62ce9aab34a37677d88017ecd99d958"
-    },
-    {
-      "name": "wallpaper-branding-openSUSE",
-      "version": "42.1",
-      "release": "6.2",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "28ee7958284becfb2df2edb45b2388a8"
-    },
-    {
-      "name": "which",
-      "version": "2.20",
-      "release": "5.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "8a8770b618f1eaed28bc8a96f50b0ed1"
-    },
-    {
-      "name": "wicked",
-      "version": "0.6.27",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "13156ac1272e726120f533e0f61fbd0c"
-    },
-    {
-      "name": "wicked-service",
-      "version": "0.6.27",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "32d7ac64ca424ed626de3e867f7c145a"
-    },
-    {
-      "name": "xz",
-      "version": "5.0.5",
-      "release": "3.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e168e3853561ae5bc9daafe90dac210b"
-    },
-    {
-      "name": "zypper",
-      "version": "1.12.23",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "8d772eca4a59f14171e715237caee9a1"
-    }
-  ],
+  "packages": {
+    "package_system": "rpm",
+    "packages": [
+      {
+        "name": "aaa_base",
+        "version": "13.2+git20140911.61c1681",
+        "release": "4.6",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "081158cbce7420230e5debfc93e489f0"
+      },
+      {
+        "name": "acl",
+        "version": "2.2.52",
+        "release": "6.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "766d1f6f9b2523ce864bde867e81557e"
+      },
+      {
+        "name": "autofs",
+        "version": "5.0.9",
+        "release": "4.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "7bc71d01fff912393048d72034e2de73"
+      },
+      {
+        "name": "bash",
+        "version": "4.2",
+        "release": "76.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "561f9d9e35793b8420bf38be8b3ee922"
+      },
+      {
+        "name": "btrfsprogs",
+        "version": "4.1.2",
+        "release": "8.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6c402497faf63d4e3bc42bc0c8933594"
+      },
+      {
+        "name": "bzip2",
+        "version": "1.0.6",
+        "release": "30.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ecb5db1d84561924017cf4db72b85fdd"
+      },
+      {
+        "name": "ca-certificates",
+        "version": "1_201403302107",
+        "release": "9.1",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "be1740cc1c20a08890800ca732872940"
+      },
+      {
+        "name": "coreutils",
+        "version": "8.22",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "3d02b57038ef0896d85da7c0801b1d5c"
+      },
+      {
+        "name": "cpio",
+        "version": "2.11",
+        "release": "30.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c39a9599f1b3f3124585a515b9522e51"
+      },
+      {
+        "name": "cracklib",
+        "version": "2.9.0",
+        "release": "5.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "42f358e756e107022e64636f7a1e3dae"
+      },
+      {
+        "name": "cracklib-dict-full",
+        "version": "2.8.12",
+        "release": "65.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "89f5ef288f7dcab86dc64b82588fc44d"
+      },
+      {
+        "name": "cron",
+        "version": "4.2",
+        "release": "57.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "9e04e3296fb2590d44b66cea2b2205dc"
+      },
+      {
+        "name": "cronie",
+        "version": "1.4.11",
+        "release": "57.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "52ed6912e670f4d4756f90f81d72f75b"
+      },
+      {
+        "name": "dbus-1",
+        "version": "1.8.16",
+        "release": "5.9",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6a03c4e5ce455f6824eb77cd2b069195"
+      },
+      {
+        "name": "dbus-1-x11",
+        "version": "1.8.16",
+        "release": "5.9",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4f16d7a5d39286f2053ceb62f43a4a4d"
+      },
+      {
+        "name": "device-mapper",
+        "version": "1.02.97",
+        "release": "62.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "388ac9d2a7e3200fefb1f0bd1baae2ff"
+      },
+      {
+        "name": "diffutils",
+        "version": "3.3",
+        "release": "7.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "21b94c7e0c99652ac9b1190e9ad4185f"
+      },
+      {
+        "name": "dirmngr",
+        "version": "1.1.1",
+        "release": "5.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b9474382c5a1a32cb4b80c8c11ad974a"
+      },
+      {
+        "name": "dmraid",
+        "version": "1.0.0.rc16",
+        "release": "37.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e73db7b22432baeae182c43e23695394"
+      },
+      {
+        "name": "dracut",
+        "version": "037",
+        "release": "66.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0754343c0f264e86d4f64542e9f400df"
+      },
+      {
+        "name": "elfutils",
+        "version": "0.158",
+        "release": "9.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0c98f93f724cd9193a4cfc677e84dee5"
+      },
+      {
+        "name": "expat",
+        "version": "2.1.0",
+        "release": "15.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f0eb5eb42ea515b2aa5bafea21fc3145"
+      },
+      {
+        "name": "file",
+        "version": "5.19",
+        "release": "5.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "477b6d9501345b433afdf6176c4a15b5"
+      },
+      {
+        "name": "file-magic",
+        "version": "5.19",
+        "release": "5.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4505cf10caf6196235ce22bb2a537ecc"
+      },
+      {
+        "name": "filesystem",
+        "version": "13.1",
+        "release": "5.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d67112cffc0a9fb857a865b3712cf31e"
+      },
+      {
+        "name": "fillup",
+        "version": "1.42",
+        "release": "272.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "00e96a60de4fbc763504a34c5ef89d67"
+      },
+      {
+        "name": "findutils",
+        "version": "4.5.12",
+        "release": "3.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "9ed445ac242d021d78bde3d85916b4e9"
+      },
+      {
+        "name": "fipscheck",
+        "version": "1.2.0",
+        "release": "7.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "576b4b85fb2d98190c933c258fc02006"
+      },
+      {
+        "name": "gawk",
+        "version": "4.1.3",
+        "release": "4.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "2ba134744092902e47fa35b6e1d57184"
+      },
+      {
+        "name": "gettext-runtime",
+        "version": "0.19.2",
+        "release": "3.6",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f3047a9549c5de7e740e3eb8cee9198d"
+      },
+      {
+        "name": "gio-branding-openSUSE",
+        "version": "42.1",
+        "release": "2.1",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "b32c86666c2c9762a6fcf2e437794522"
+      },
+      {
+        "name": "glib2-tools",
+        "version": "2.44.1",
+        "release": "2.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d45f109a13f163dcd7402583ca6a8461"
+      },
+      {
+        "name": "glibc",
+        "version": "2.19",
+        "release": "17.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0c43af7fce881df707d8f8fdba431028"
+      },
+      {
+        "name": "glibc-locale",
+        "version": "2.19",
+        "release": "17.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "275cef46e18ae2f9f3ab86b7f45c6a12"
+      },
+      {
+        "name": "gpg2",
+        "version": "2.0.24",
+        "release": "3.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4d584a80bb8e61c3186832468e0f433d"
+      },
+      {
+        "name": "grep",
+        "version": "2.16",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0261d7c67ef4ef1b3ee2886f9d221a7d"
+      },
+      {
+        "name": "grub2",
+        "version": "2.02~beta2",
+        "release": "68.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d97a40a45fe97a05623192d1aba31979"
+      },
+      {
+        "name": "grub2-i386-pc",
+        "version": "2.02~beta2",
+        "release": "68.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "460b36f7bd90ee29357293d67ea0a8f8"
+      },
+      {
+        "name": "gzip",
+        "version": "1.6",
+        "release": "9.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "8805cc4b5481248c76fbf73b25d0967c"
+      },
+      {
+        "name": "hardlink",
+        "version": "1.0",
+        "release": "8.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6949f7db310547a5a7b5f3876c211544"
+      },
+      {
+        "name": "hwinfo",
+        "version": "21.23",
+        "release": "1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "1148f436ee53a5c8d425b0b91c2d3eaa"
+      },
+      {
+        "name": "ifplugd",
+        "version": "0.28",
+        "release": "236.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b29aaa55b0cd4443969eab33c0a7a9b6"
+      },
+      {
+        "name": "info",
+        "version": "4.13a",
+        "release": "39.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4106a30405ac8522219eda9b45021f13"
+      },
+      {
+        "name": "insserv-compat",
+        "version": "0.1",
+        "release": "13.4",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "16224bf774a3714d55be6355dd4ea528"
+      },
+      {
+        "name": "iproute2",
+        "version": "4.2",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d0fdaecdd4c27a83ca14f250993c8c30"
+      },
+      {
+        "name": "iputils",
+        "version": "s20121221",
+        "release": "3.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b8a76296b8d39aa9340dfb9677f33800"
+      },
+      {
+        "name": "kbd",
+        "version": "1.15.5",
+        "release": "6.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "38bb82ee41f8cfdac42098970bab7fc3"
+      },
+      {
+        "name": "kernel-default",
+        "version": "4.1.12",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c9d0cbe850fe6b6c30110c398e5cf5de"
+      },
+      {
+        "name": "keyutils",
+        "version": "1.5.9",
+        "release": "4.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "746c5a4a2b7380a61d1f46d194601bfb"
+      },
+      {
+        "name": "klogd",
+        "version": "1.4.1",
+        "release": "779.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6c0ebedc416ab10be2cc9ebbf4a4afbc"
+      },
+      {
+        "name": "kmod",
+        "version": "17",
+        "release": "3.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "bf83b106d2e969e1f67059e40285670f"
+      },
+      {
+        "name": "kmod-compat",
+        "version": "17",
+        "release": "3.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6e4c906c5a8aa763abe7807faef9656f"
+      },
+      {
+        "name": "kpartx",
+        "version": "0.5.0",
+        "release": "48.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b1b43779794a5a20df4daea8f8ef2eaa"
+      },
+      {
+        "name": "krb5",
+        "version": "1.12.1",
+        "release": "19.9",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "bdab6842125d0170f176e5293fc7bc57"
+      },
+      {
+        "name": "libX11-6",
+        "version": "1.6.3",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d81e5d726512266dad5bd41a3ee673ff"
+      },
+      {
+        "name": "libX11-data",
+        "version": "1.6.3",
+        "release": "1.1",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "84a346123235e8fffed79b1d16e4d202"
+      },
+      {
+        "name": "libXau6",
+        "version": "1.0.8",
+        "release": "6.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "fc6392b8bfb72b5a5ef8fb6f3103b113"
+      },
+      {
+        "name": "libacl1",
+        "version": "2.2.52",
+        "release": "6.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "99c7abed9b2f6ed6171c583a0656544f"
+      },
+      {
+        "name": "libadns1",
+        "version": "1.4",
+        "release": "103.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "71e817de14d7efc51084fea99c4c83ec"
+      },
+      {
+        "name": "libaio1",
+        "version": "0.3.109",
+        "release": "19.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "385acc095a701bdd1fdc81d136f64ade"
+      },
+      {
+        "name": "libapparmor1",
+        "version": "2.10",
+        "release": "3.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "57c78c11189b3c0118b76732dae8c038"
+      },
+      {
+        "name": "libasm1",
+        "version": "0.158",
+        "release": "9.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "595c731f1ca8cfd566c79c865ad5c934"
+      },
+      {
+        "name": "libassuan0",
+        "version": "2.1.1",
+        "release": "3.6",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "13119dd654a231d1ef393575698daf43"
+      },
+      {
+        "name": "libattr1",
+        "version": "2.4.47",
+        "release": "5.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5ecf26b664bf5e39c044d7dc55613503"
+      },
+      {
+        "name": "libaudit1",
+        "version": "2.3.6",
+        "release": "3.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ae9a9128aef35481887aaf7f4fdb7395"
+      },
+      {
+        "name": "libaugeas0",
+        "version": "1.2.0",
+        "release": "6.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "978d76d447de6877eee5fb35ba470e08"
+      },
+      {
+        "name": "libblkid1",
+        "version": "2.25",
+        "release": "7.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "24976d4ae7ae4378664cb1e008374370"
+      },
+      {
+        "name": "libbz2-1",
+        "version": "1.0.6",
+        "release": "30.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "7fdc7c1ddd6f315d72bf27989e27d65f"
+      },
+      {
+        "name": "libcap-ng0",
+        "version": "0.7.3",
+        "release": "3.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5ad0f4c8860079f035adca5117faed16"
+      },
+      {
+        "name": "libcap2",
+        "version": "2.22",
+        "release": "14.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "474398c10aeb7a0427f6d46d55db7c8d"
+      },
+      {
+        "name": "libcom_err2",
+        "version": "1.42.11",
+        "release": "10.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "968bc37bcfde17cd1a67a0c14f741959"
+      },
+      {
+        "name": "libcrack2",
+        "version": "2.9.0",
+        "release": "5.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ed710df3d688ddfaee6b8f16f0fab94a"
+      },
+      {
+        "name": "libcroco-0_6-3",
+        "version": "0.6.8",
+        "release": "8.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4c6816f85d96c95e75ead6fa1b5e1a93"
+      },
+      {
+        "name": "libcryptsetup4",
+        "version": "1.6.4",
+        "release": "3.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "cf52d77b951c552ee1e9d49b5653957b"
+      },
+      {
+        "name": "libcurl4",
+        "version": "7.37.0",
+        "release": "5.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "9b275f787e46ba192a4b419d8dafcc59"
+      },
+      {
+        "name": "libdaemon0",
+        "version": "0.14",
+        "release": "16.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "98c1da92d5765c028ec377869948d963"
+      },
+      {
+        "name": "libdb-4_8",
+        "version": "4.8.30",
+        "release": "30.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "9048c99c58b699941ebbb5379e22800e"
+      },
+      {
+        "name": "libdbus-1-3",
+        "version": "1.8.16",
+        "release": "5.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b33f7d7cf3bb4b0dd67864c82c9c7d89"
+      },
+      {
+        "name": "libdw1",
+        "version": "0.158",
+        "release": "9.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "63c5fa258664ab3f4aa4e946e7c09415"
+      },
+      {
+        "name": "libedit0",
+        "version": "3.1.snap20140620",
+        "release": "3.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "3b3f2fbf583d24bf8084deffe4a1c6c4"
+      },
+      {
+        "name": "libelf0",
+        "version": "0.8.13",
+        "release": "20.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "067caff382236fe4116f092b466fa4b0"
+      },
+      {
+        "name": "libelf1",
+        "version": "0.158",
+        "release": "9.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "9fbf4e75e7ce3fa57a7c05ce94cdd131"
+      },
+      {
+        "name": "libevent-2_0-5",
+        "version": "2.0.21",
+        "release": "5.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6af8fdf972d32d65c9344432f63f3810"
+      },
+      {
+        "name": "libexpat1",
+        "version": "2.1.0",
+        "release": "15.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d817724be54a59c550770448be55e850"
+      },
+      {
+        "name": "libext2fs2",
+        "version": "1.42.11",
+        "release": "10.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0f06977a3e9111fc65c435eacbd70401"
+      },
+      {
+        "name": "libffi4",
+        "version": "5.2.1+r226025",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5d80ff50e7a524845a6d9a040bf8d847"
+      },
+      {
+        "name": "libfipscheck1",
+        "version": "1.2.0",
+        "release": "7.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ae58f0bbe2cf9014f9c2bdd70b826e8c"
+      },
+      {
+        "name": "libfreetype6",
+        "version": "2.5.5",
+        "release": "8.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b71acf65d24b66a023350974c3283a57"
+      },
+      {
+        "name": "libfuse2",
+        "version": "2.9.3",
+        "release": "8.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c1f672440dc6ba4f9b70faaf2f179bcc"
+      },
+      {
+        "name": "libgcc_s1",
+        "version": "5.2.1+r226025",
+        "release": "4.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "62c714318520d5f9470255ea7e014b7f"
+      },
+      {
+        "name": "libgcrypt20",
+        "version": "1.6.1",
+        "release": "18.7",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "2a969479224d8c343043e895157f5a39"
+      },
+      {
+        "name": "libgdbm4",
+        "version": "1.10",
+        "release": "3.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "7a6a9015c0888529a5d219ef622c1c3d"
+      },
+      {
+        "name": "libgio-2_0-0",
+        "version": "2.44.1",
+        "release": "2.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e1be5315ad7bf5eb37f62bcc3fb3a374"
+      },
+      {
+        "name": "libglib-2_0-0",
+        "version": "2.44.1",
+        "release": "2.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5675fc8cd8df92a1b14a142ae386d647"
+      },
+      {
+        "name": "libgmodule-2_0-0",
+        "version": "2.44.1",
+        "release": "2.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "673f815ca542e7c68ddf2077a3bd23e6"
+      },
+      {
+        "name": "libgmp10",
+        "version": "5.1.3",
+        "release": "4.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a0e62fa96082c4b2795d039c04bd59c7"
+      },
+      {
+        "name": "libgobject-2_0-0",
+        "version": "2.44.1",
+        "release": "2.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5b43dc73af4181a66be2aee91d61132a"
+      },
+      {
+        "name": "libgpg-error0",
+        "version": "1.13",
+        "release": "3.6",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "8c53b983461b2b5b176a5c38197fff27"
+      },
+      {
+        "name": "libidn11",
+        "version": "1.28",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ec33361965f206dba5375f5ee6684847"
+      },
+      {
+        "name": "libkeyutils1",
+        "version": "1.5.9",
+        "release": "4.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0d17a38828ebd5b477c47682ef7ace5f"
+      },
+      {
+        "name": "libkmod2",
+        "version": "17",
+        "release": "3.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a3ea927784b790bdc72b1924bfaccbc3"
+      },
+      {
+        "name": "libksba8",
+        "version": "1.3.0",
+        "release": "2.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "3d3443b50ac034e1415f00bf95753889"
+      },
+      {
+        "name": "libldap-2_4-2",
+        "version": "2.4.41",
+        "release": "9.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4aa486177ff244a96c3d114a91472406"
+      },
+      {
+        "name": "liblua5_1",
+        "version": "5.1.5",
+        "release": "11.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "3d70c542cf88d65ae03ba9c440a31c20"
+      },
+      {
+        "name": "liblzma5",
+        "version": "5.0.5",
+        "release": "3.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a7549cb7b79d2e598414ec11291dc3b3"
+      },
+      {
+        "name": "liblzo2-2",
+        "version": "2.08",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c1c980b7163b805cf53c76e0df1dd5c8"
+      },
+      {
+        "name": "libmagic1",
+        "version": "5.19",
+        "release": "5.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "35f913015516d358f919a9bf2a151c60"
+      },
+      {
+        "name": "libmnl0",
+        "version": "1.0.3",
+        "release": "11.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e9eedd7d320fe800ecfb3eb6755aac5d"
+      },
+      {
+        "name": "libmodman1",
+        "version": "2.0.1",
+        "release": "17.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "09ee09a7401aee9cb708f633667419cf"
+      },
+      {
+        "name": "libmount1",
+        "version": "2.25",
+        "release": "7.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d89d7ef9180cbf0b6652cc55ec25816b"
+      },
+      {
+        "name": "libmozjs-17_0",
+        "version": "17.0",
+        "release": "9.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5948f68685d467b399160953e14cd657"
+      },
+      {
+        "name": "libncurses5",
+        "version": "5.9",
+        "release": "53.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "bd073814979cf7ec44be4e0e6709b4e0"
+      },
+      {
+        "name": "libncurses6",
+        "version": "5.9",
+        "release": "53.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "59fd948b23f023d6d58a6996d1165e96"
+      },
+      {
+        "name": "libnl-config",
+        "version": "3.2.23",
+        "release": "3.2",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "716e44608b489a0f5d7dad76a4c3f4fc"
+      },
+      {
+        "name": "libnl3-200",
+        "version": "3.2.23",
+        "release": "3.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a37fda4081aa7167a1e720c46dd77cfb"
+      },
+      {
+        "name": "libopenssl1_0_0",
+        "version": "1.0.1i",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4c3448b2c5e136182c85ccb50bcf7f87"
+      },
+      {
+        "name": "libp11-kit0",
+        "version": "0.20.3",
+        "release": "7.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b31820a5ab481c71c27011300b97c342"
+      },
+      {
+        "name": "libparted0",
+        "version": "3.1",
+        "release": "17.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d6a086e3519db99b49e610a1d2988540"
+      },
+      {
+        "name": "libpcre1",
+        "version": "8.33",
+        "release": "3.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "395ad9aedce1ab1cdae65e15f9fdac27"
+      },
+      {
+        "name": "libpng16-16",
+        "version": "1.6.8",
+        "release": "2.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0ec7a9ef42c556b44b5675cd8b5a1fd7"
+      },
+      {
+        "name": "libpolkit0",
+        "version": "0.112",
+        "release": "4.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ffbedfb22a932d9713fe5886ffc456ec"
+      },
+      {
+        "name": "libpopt0",
+        "version": "1.16",
+        "release": "28.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a83dc8dcd88541920e3f605ee9a35f10"
+      },
+      {
+        "name": "libprocps3",
+        "version": "3.3.9",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "1eb77bbae72f9f827666451eca1d8451"
+      },
+      {
+        "name": "libproxy1",
+        "version": "0.4.11",
+        "release": "13.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "bc349abdb2da93030c9d7fb883e5230b"
+      },
+      {
+        "name": "libpth20",
+        "version": "2.0.7",
+        "release": "141.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f46f7a186081948253d3d9d5b0dea85a"
+      },
+      {
+        "name": "libqrencode3",
+        "version": "3.4.3",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "933ff2856ce1043768f777f6beedea58"
+      },
+      {
+        "name": "libreadline6",
+        "version": "6.2",
+        "release": "76.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "1362ad02cc6eb801668e2e8b0ce22d8c"
+      },
+      {
+        "name": "libreiserfscore0",
+        "version": "3.6.24",
+        "release": "7.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "eae1c65bc257b18bc12976a13c51a28c"
+      },
+      {
+        "name": "libsasl2-3",
+        "version": "2.1.26",
+        "release": "8.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "603031f8e40da1ad042cef4cf290f809"
+      },
+      {
+        "name": "libseccomp2",
+        "version": "2.1.1",
+        "release": "3.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "30b388d17a2b2e44cb4b1e1a3aded378"
+      },
+      {
+        "name": "libselinux1",
+        "version": "2.3",
+        "release": "3.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5704953fa5cc9534f0130186b5eed86c"
+      },
+      {
+        "name": "libsemanage1",
+        "version": "2.3",
+        "release": "3.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "966de4475e7ef999a6dcc2167628e96a"
+      },
+      {
+        "name": "libsepol1",
+        "version": "2.3",
+        "release": "3.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "25a44cb17af04ed900838524458fabea"
+      },
+      {
+        "name": "libsgutils2-2",
+        "version": "1.41",
+        "release": "6.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e33ceadb5471bda94a0447871988886a"
+      },
+      {
+        "name": "libsmartcols1",
+        "version": "2.25",
+        "release": "7.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "598157b2169ea2e4d5664c621c1b459e"
+      },
+      {
+        "name": "libsolv-tools",
+        "version": "0.6.14",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5e496bfdc84c4b6b9076528d01ffa837"
+      },
+      {
+        "name": "libsqlite3-0",
+        "version": "3.8.10.2",
+        "release": "5.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4011163d31a62520d53b98a417d2ae78"
+      },
+      {
+        "name": "libssh2-1",
+        "version": "1.4.3",
+        "release": "10.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6f909139497c6170b307bd3dfba62aea"
+      },
+      {
+        "name": "libstdc++6",
+        "version": "5.2.1+r226025",
+        "release": "4.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "dd6917616d8419dac960316b4d1b5dd0"
+      },
+      {
+        "name": "libtasn1",
+        "version": "3.7",
+        "release": "10.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "8d4ba27025e4e3697378f3a4ac1fdeb2"
+      },
+      {
+        "name": "libtasn1-6",
+        "version": "3.7",
+        "release": "10.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "1987356b9f5cd5b4e748c353a3452a15"
+      },
+      {
+        "name": "libtirpc1",
+        "version": "0.2.3",
+        "release": "7.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "87af35eb8c5b377e943af42a500665ac"
+      },
+      {
+        "name": "libudev1",
+        "version": "210",
+        "release": "84.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "21294775d0f7c459442da007e602fc46"
+      },
+      {
+        "name": "libusb-0_1-4",
+        "version": "0.1.13",
+        "release": "31.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e0c33d8f1b2124ac4cd406ca02fa26fc"
+      },
+      {
+        "name": "libusb-1_0-0",
+        "version": "1.0.20",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "fe534a1b8543d13afa6ace2ac9ac9fc0"
+      },
+      {
+        "name": "libustr-1_0-1",
+        "version": "1.0.4",
+        "release": "34.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5867189d1be04094b6803055d76fa9ed"
+      },
+      {
+        "name": "libutempter0",
+        "version": "1.1.6",
+        "release": "6.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "725851a15ad68060a1879bc52bc038bd"
+      },
+      {
+        "name": "libuuid1",
+        "version": "2.25",
+        "release": "7.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "763bf8fb1585c384577b3519bd971fd8"
+      },
+      {
+        "name": "libwicked-0-6",
+        "version": "0.6.27",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f063b6ba778b43ba581f683c72bc0a39"
+      },
+      {
+        "name": "libwrap0",
+        "version": "7.6",
+        "release": "885.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4d030beb9444548a64b968cbedbd503a"
+      },
+      {
+        "name": "libx86emu1",
+        "version": "1.5",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4f5294a5f06ceae33e6dcf4553af8c16"
+      },
+      {
+        "name": "libxcb1",
+        "version": "1.11.1",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "68594c8b6d82583fb9b18183b27ed2ed"
+      },
+      {
+        "name": "libxml2-2",
+        "version": "2.9.1",
+        "release": "8.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "dca88cfe4ddad156a8b3ec63340a5d79"
+      },
+      {
+        "name": "libxtables10",
+        "version": "1.4.21",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6686e7170269c59e4241e96f71482bec"
+      },
+      {
+        "name": "libz1",
+        "version": "1.2.8",
+        "release": "6.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "2b0e8459c17ff7c18d7fa603e46d8af8"
+      },
+      {
+        "name": "libzio1",
+        "version": "1.00",
+        "release": "11.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d3bed4bab54ef017f6ec2f7eab2a2eab"
+      },
+      {
+        "name": "libzypp",
+        "version": "15.19.5",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e24a7299bcf72ecfe1b53d1f079b1b22"
+      },
+      {
+        "name": "lvm2",
+        "version": "2.02.120",
+        "release": "62.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "07c47e34c1f7450dd883f713f98dfba3"
+      },
+      {
+        "name": "mozilla-nspr",
+        "version": "4.10.8",
+        "release": "2.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d60f71e6c41b0f8427fbf6f05a7ff859"
+      },
+      {
+        "name": "ncurses-utils",
+        "version": "5.9",
+        "release": "53.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "be7ec4b37a45f3d6203f34be710028d7"
+      },
+      {
+        "name": "netcfg",
+        "version": "11.5",
+        "release": "26.1",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "bd43ad2811d57ebfa714ad917585176c"
+      },
+      {
+        "name": "nfs-client",
+        "version": "1.3.0",
+        "release": "9.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "27c3111ec42452de1c096a8b5cd8406b"
+      },
+      {
+        "name": "nfs-kernel-server",
+        "version": "1.3.0",
+        "release": "9.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ce51e81bb9bfcbc36a25bf7a6dbedb8d"
+      },
+      {
+        "name": "nfsidmap",
+        "version": "0.25",
+        "release": "7.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e136fa60a9f8a17c1a65bce79399f8eb"
+      },
+      {
+        "name": "openSUSE-build-key",
+        "version": "1.0",
+        "release": "32.2",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "e9b1b6a0acab733785c1917a614bec4c"
+      },
+      {
+        "name": "openSUSE-release",
+        "version": "42.1",
+        "release": "1.46",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "cf9d4736a3f57d1ba2737acce151de88"
+      },
+      {
+        "name": "openSUSE-release-ftp",
+        "version": "42.1",
+        "release": "1.46",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f59b8c889e3be76d2e5cd48386bd769d"
+      },
+      {
+        "name": "openslp",
+        "version": "2.0.0",
+        "release": "8.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "41ac615914d0d4963d1fa7142f5397ac"
+      },
+      {
+        "name": "openssh",
+        "version": "6.6p1",
+        "release": "6.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "77bd1c768d5e18514346e0ce1919ebf8"
+      },
+      {
+        "name": "openssl",
+        "version": "1.0.1i",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c3ae00e7c026622b581cb7c787e862b2"
+      },
+      {
+        "name": "os-prober",
+        "version": "1.61",
+        "release": "13.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "2a5914bf642f1c3dd58b04dbf2f224ff"
+      },
+      {
+        "name": "p11-kit",
+        "version": "0.20.3",
+        "release": "7.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "1a4fbf51e1e7f2ea702b56ac0a5f8629"
+      },
+      {
+        "name": "p11-kit-tools",
+        "version": "0.20.3",
+        "release": "7.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "76e1262aa55518dd9c9aad01d000ea9d"
+      },
+      {
+        "name": "pam",
+        "version": "1.1.8",
+        "release": "12.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "89fb119bc96c58eb8ae36bbfb7c7a9ac"
+      },
+      {
+        "name": "pam-config",
+        "version": "0.88",
+        "release": "3.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4ac861a96312be035c91508616440e42"
+      },
+      {
+        "name": "parted",
+        "version": "3.1",
+        "release": "17.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "78ce8ad64acf97448971662040c08bbe"
+      },
+      {
+        "name": "patterns-openSUSE-base",
+        "version": "20150918",
+        "release": "10.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "535a49dfcc33dc71e5c449a670f5bf0c"
+      },
+      {
+        "name": "perl",
+        "version": "5.18.2",
+        "release": "3.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "fec639f37724b6db5d19ec0e75079874"
+      },
+      {
+        "name": "perl-Bootloader",
+        "version": "0.844",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "8d1f9810985464b3455c08f429c6b1a0"
+      },
+      {
+        "name": "perl-base",
+        "version": "5.18.2",
+        "release": "3.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "70ede2005fd4aea48172f92a53d340c8"
+      },
+      {
+        "name": "permissions",
+        "version": "2014.08.26.1452",
+        "release": "3.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c0dcb6d707f29d97922b2554ab9094c9"
+      },
+      {
+        "name": "pigz",
+        "version": "2.3",
+        "release": "5.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d71f853f036d3f067084141821f4a724"
+      },
+      {
+        "name": "pinentry",
+        "version": "0.8.3",
+        "release": "3.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4515aba86a21e012b38f235f1e58216e"
+      },
+      {
+        "name": "pkg-config",
+        "version": "0.28",
+        "release": "8.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0c6e3c89832083f13c3ac8d9eedaec43"
+      },
+      {
+        "name": "polkit",
+        "version": "0.112",
+        "release": "4.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c698acc85baf46a9d53660e712c1d139"
+      },
+      {
+        "name": "polkit-default-privs",
+        "version": "13.2",
+        "release": "8.1",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "7e72805bfa7be325ad3ff2598dcaa0fa"
+      },
+      {
+        "name": "procps",
+        "version": "3.3.9",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "1099d51ad98a72c950bb7a2e265d8ab2"
+      },
+      {
+        "name": "rpcbind",
+        "version": "0.2.1_rc4",
+        "release": "9.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "7fdb3e2ab5f5626a5ecac1007d69a886"
+      },
+      {
+        "name": "rpm",
+        "version": "4.11.2",
+        "release": "6.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c1165f89362d61a7cd5ce3c4c57c0db2"
+      },
+      {
+        "name": "rsync",
+        "version": "3.1.0",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6e6589c90f073872ca934b5780599a5a"
+      },
+      {
+        "name": "sed",
+        "version": "4.2.2",
+        "release": "6.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d591d4a09e1c8801df91e6fafc6775bd"
+      },
+      {
+        "name": "sg3_utils",
+        "version": "1.41",
+        "release": "6.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d99c08b0c56c5e7c62de3cb39de45468"
+      },
+      {
+        "name": "shadow",
+        "version": "4.1.5.1",
+        "release": "14.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e675bf8b52ada6b99d1d2782c4907740"
+      },
+      {
+        "name": "shared-mime-info",
+        "version": "1.2",
+        "release": "3.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "feff5c41f619f236e2b722c192d2464a"
+      },
+      {
+        "name": "squashfs",
+        "version": "4.3",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "576c75d423e50ebcd6affbd806ef8d06"
+      },
+      {
+        "name": "sudo",
+        "version": "1.8.10p3",
+        "release": "3.8",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "cbad9e70c306d1bde094a0c7b47fc705"
+      },
+      {
+        "name": "suse-module-tools",
+        "version": "12.3",
+        "release": "16.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "74ec43dcfd6f8d0cf2d538b073a4a017"
+      },
+      {
+        "name": "sysconfig",
+        "version": "0.83.8",
+        "release": "5.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "539d89d9bcb2f2a0cb7e39e2b85a66f3"
+      },
+      {
+        "name": "sysconfig-netconfig",
+        "version": "0.83.8",
+        "release": "5.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a61fe5590444b230c1c9aff63e108fb1"
+      },
+      {
+        "name": "syslinux",
+        "version": "4.04",
+        "release": "34.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c94acd46c7dc72a21380e0f634afbf01"
+      },
+      {
+        "name": "systemd",
+        "version": "210",
+        "release": "84.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "8406d85954619896606bc5cfa867f942"
+      },
+      {
+        "name": "systemd-presets-branding-openSUSE",
+        "version": "0.3.0",
+        "release": "23.2",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "e6b50b275e529bbeaa09b917eac30a12"
+      },
+      {
+        "name": "systemd-sysvinit",
+        "version": "210",
+        "release": "84.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "2caa2bae61cbae5627162f8eb505cc0e"
+      },
+      {
+        "name": "sysvinit-tools",
+        "version": "2.88+",
+        "release": "97.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "af5d2e1a6a5992d29d124d3b1a89d0da"
+      },
+      {
+        "name": "tar",
+        "version": "1.27.1",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "84c421ba47651f0a38f9cb32fa603b2d"
+      },
+      {
+        "name": "terminfo-base",
+        "version": "5.9",
+        "release": "53.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "cb09a6420e75ebaf4b814caf6b7c600d"
+      },
+      {
+        "name": "time",
+        "version": "1.7",
+        "release": "8.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "97e358055cbc505d87f8afbc4442a5de"
+      },
+      {
+        "name": "udev",
+        "version": "210",
+        "release": "84.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5bb2181e5953920e9f8824835620a2b4"
+      },
+      {
+        "name": "update-alternatives",
+        "version": "1.16.10",
+        "release": "9.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "2583a577d67e2c8ec2fa9fc84b5dc809"
+      },
+      {
+        "name": "util-linux",
+        "version": "2.25",
+        "release": "7.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "fc4f36ccf6e1b915862791d91b00b8bb"
+      },
+      {
+        "name": "util-linux-systemd",
+        "version": "2.25",
+        "release": "7.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f87f35b663f13a8cefccf876105a128a"
+      },
+      {
+        "name": "vim",
+        "version": "7.4.326",
+        "release": "3.10",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c62ce9aab34a37677d88017ecd99d958"
+      },
+      {
+        "name": "wallpaper-branding-openSUSE",
+        "version": "42.1",
+        "release": "6.2",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "28ee7958284becfb2df2edb45b2388a8"
+      },
+      {
+        "name": "which",
+        "version": "2.20",
+        "release": "5.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "8a8770b618f1eaed28bc8a96f50b0ed1"
+      },
+      {
+        "name": "wicked",
+        "version": "0.6.27",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "13156ac1272e726120f533e0f61fbd0c"
+      },
+      {
+        "name": "wicked-service",
+        "version": "0.6.27",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "32d7ac64ca424ed626de3e867f7c145a"
+      },
+      {
+        "name": "xz",
+        "version": "5.0.5",
+        "release": "3.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e168e3853561ae5bc9daafe90dac210b"
+      },
+      {
+        "name": "zypper",
+        "version": "1.12.23",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "8d772eca4a59f14171e715237caee9a1"
+      }
+    ]
+  },
   "patterns": [
     {
       "name": "base",
@@ -2947,7 +2950,7 @@
     ]
   },
   "meta": {
-    "format_version": 5,
+    "format_version": 6,
     "os": {
       "modified": "2015-11-19T16:08:46Z",
       "hostname": "192.168.121.32"

--- a/spec/data/descriptions/jeos/opensuse_leap/manifest.json
+++ b/spec/data/descriptions/jeos/opensuse_leap/manifest.json
@@ -9,8 +9,10 @@
     "architecture": "x86_64"
   },
   "packages": {
-    "package_system": "rpm",
-    "packages": [
+    "_attributes": {
+      "package_system": "rpm"
+    },
+    "_elements": [
       {
         "name": "aaa_base",
         "version": "13.2+git20140911.61c1681",

--- a/spec/data/descriptions/opensuse_leap-build/manifest.json
+++ b/spec/data/descriptions/opensuse_leap-build/manifest.json
@@ -8,1768 +8,1771 @@
     "version": "42.1",
     "architecture": "x86_64"
   },
-  "packages": [
-    {
-      "name": "aaa_base",
-      "version": "13.2+git20140911.61c1681",
-      "release": "4.6",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "081158cbce7420230e5debfc93e489f0"
-    },
-    {
-      "name": "acl",
-      "version": "2.2.52",
-      "release": "6.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "766d1f6f9b2523ce864bde867e81557e"
-    },
-    {
-      "name": "autofs",
-      "version": "5.0.9",
-      "release": "4.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "7bc71d01fff912393048d72034e2de73"
-    },
-    {
-      "name": "bash",
-      "version": "4.2",
-      "release": "76.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "561f9d9e35793b8420bf38be8b3ee922"
-    },
-    {
-      "name": "btrfsprogs",
-      "version": "4.1.2",
-      "release": "8.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6c402497faf63d4e3bc42bc0c8933594"
-    },
-    {
-      "name": "bzip2",
-      "version": "1.0.6",
-      "release": "30.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ecb5db1d84561924017cf4db72b85fdd"
-    },
-    {
-      "name": "ca-certificates",
-      "version": "1_201403302107",
-      "release": "9.1",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "be1740cc1c20a08890800ca732872940"
-    },
-    {
-      "name": "coreutils",
-      "version": "8.22",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "3d02b57038ef0896d85da7c0801b1d5c"
-    },
-    {
-      "name": "cpio",
-      "version": "2.11",
-      "release": "30.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c39a9599f1b3f3124585a515b9522e51"
-    },
-    {
-      "name": "cracklib",
-      "version": "2.9.0",
-      "release": "5.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "42f358e756e107022e64636f7a1e3dae"
-    },
-    {
-      "name": "cracklib-dict-full",
-      "version": "2.8.12",
-      "release": "65.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "89f5ef288f7dcab86dc64b82588fc44d"
-    },
-    {
-      "name": "cron",
-      "version": "4.2",
-      "release": "57.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "9e04e3296fb2590d44b66cea2b2205dc"
-    },
-    {
-      "name": "cronie",
-      "version": "1.4.11",
-      "release": "57.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "52ed6912e670f4d4756f90f81d72f75b"
-    },
-    {
-      "name": "dbus-1",
-      "version": "1.8.16",
-      "release": "5.9",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6a03c4e5ce455f6824eb77cd2b069195"
-    },
-    {
-      "name": "dbus-1-x11",
-      "version": "1.8.16",
-      "release": "5.9",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4f16d7a5d39286f2053ceb62f43a4a4d"
-    },
-    {
-      "name": "device-mapper",
-      "version": "1.02.97",
-      "release": "62.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "388ac9d2a7e3200fefb1f0bd1baae2ff"
-    },
-    {
-      "name": "diffutils",
-      "version": "3.3",
-      "release": "7.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "21b94c7e0c99652ac9b1190e9ad4185f"
-    },
-    {
-      "name": "dirmngr",
-      "version": "1.1.1",
-      "release": "5.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b9474382c5a1a32cb4b80c8c11ad974a"
-    },
-    {
-      "name": "dmraid",
-      "version": "1.0.0.rc16",
-      "release": "37.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e73db7b22432baeae182c43e23695394"
-    },
-    {
-      "name": "dracut",
-      "version": "037",
-      "release": "66.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0754343c0f264e86d4f64542e9f400df"
-    },
-    {
-      "name": "elfutils",
-      "version": "0.158",
-      "release": "9.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0c98f93f724cd9193a4cfc677e84dee5"
-    },
-    {
-      "name": "expat",
-      "version": "2.1.0",
-      "release": "15.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f0eb5eb42ea515b2aa5bafea21fc3145"
-    },
-    {
-      "name": "file",
-      "version": "5.19",
-      "release": "5.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "477b6d9501345b433afdf6176c4a15b5"
-    },
-    {
-      "name": "file-magic",
-      "version": "5.19",
-      "release": "5.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4505cf10caf6196235ce22bb2a537ecc"
-    },
-    {
-      "name": "filesystem",
-      "version": "13.1",
-      "release": "5.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d67112cffc0a9fb857a865b3712cf31e"
-    },
-    {
-      "name": "fillup",
-      "version": "1.42",
-      "release": "272.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "00e96a60de4fbc763504a34c5ef89d67"
-    },
-    {
-      "name": "findutils",
-      "version": "4.5.12",
-      "release": "3.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "9ed445ac242d021d78bde3d85916b4e9"
-    },
-    {
-      "name": "fipscheck",
-      "version": "1.2.0",
-      "release": "7.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "576b4b85fb2d98190c933c258fc02006"
-    },
-    {
-      "name": "gawk",
-      "version": "4.1.3",
-      "release": "4.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "2ba134744092902e47fa35b6e1d57184"
-    },
-    {
-      "name": "gettext-runtime",
-      "version": "0.19.2",
-      "release": "3.6",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f3047a9549c5de7e740e3eb8cee9198d"
-    },
-    {
-      "name": "gio-branding-openSUSE",
-      "version": "42.1",
-      "release": "2.1",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "b32c86666c2c9762a6fcf2e437794522"
-    },
-    {
-      "name": "glib2-tools",
-      "version": "2.44.1",
-      "release": "2.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d45f109a13f163dcd7402583ca6a8461"
-    },
-    {
-      "name": "glibc",
-      "version": "2.19",
-      "release": "17.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0c43af7fce881df707d8f8fdba431028"
-    },
-    {
-      "name": "glibc-locale",
-      "version": "2.19",
-      "release": "17.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "275cef46e18ae2f9f3ab86b7f45c6a12"
-    },
-    {
-      "name": "gpg2",
-      "version": "2.0.24",
-      "release": "3.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4d584a80bb8e61c3186832468e0f433d"
-    },
-    {
-      "name": "grep",
-      "version": "2.16",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0261d7c67ef4ef1b3ee2886f9d221a7d"
-    },
-    {
-      "name": "grub2",
-      "version": "2.02~beta2",
-      "release": "68.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d97a40a45fe97a05623192d1aba31979"
-    },
-    {
-      "name": "grub2-i386-pc",
-      "version": "2.02~beta2",
-      "release": "68.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "460b36f7bd90ee29357293d67ea0a8f8"
-    },
-    {
-      "name": "gzip",
-      "version": "1.6",
-      "release": "9.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "8805cc4b5481248c76fbf73b25d0967c"
-    },
-    {
-      "name": "hardlink",
-      "version": "1.0",
-      "release": "8.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6949f7db310547a5a7b5f3876c211544"
-    },
-    {
-      "name": "hwinfo",
-      "version": "21.23",
-      "release": "1.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "1148f436ee53a5c8d425b0b91c2d3eaa"
-    },
-    {
-      "name": "ifplugd",
-      "version": "0.28",
-      "release": "236.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b29aaa55b0cd4443969eab33c0a7a9b6"
-    },
-    {
-      "name": "info",
-      "version": "4.13a",
-      "release": "39.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4106a30405ac8522219eda9b45021f13"
-    },
-    {
-      "name": "insserv-compat",
-      "version": "0.1",
-      "release": "13.4",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "16224bf774a3714d55be6355dd4ea528"
-    },
-    {
-      "name": "iproute2",
-      "version": "4.2",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d0fdaecdd4c27a83ca14f250993c8c30"
-    },
-    {
-      "name": "iputils",
-      "version": "s20121221",
-      "release": "3.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b8a76296b8d39aa9340dfb9677f33800"
-    },
-    {
-      "name": "kbd",
-      "version": "1.15.5",
-      "release": "6.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "38bb82ee41f8cfdac42098970bab7fc3"
-    },
-    {
-      "name": "kernel-default",
-      "version": "4.1.12",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c9d0cbe850fe6b6c30110c398e5cf5de"
-    },
-    {
-      "name": "keyutils",
-      "version": "1.5.9",
-      "release": "4.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "746c5a4a2b7380a61d1f46d194601bfb"
-    },
-    {
-      "name": "klogd",
-      "version": "1.4.1",
-      "release": "779.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6c0ebedc416ab10be2cc9ebbf4a4afbc"
-    },
-    {
-      "name": "kmod",
-      "version": "17",
-      "release": "3.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "bf83b106d2e969e1f67059e40285670f"
-    },
-    {
-      "name": "kmod-compat",
-      "version": "17",
-      "release": "3.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6e4c906c5a8aa763abe7807faef9656f"
-    },
-    {
-      "name": "kpartx",
-      "version": "0.5.0",
-      "release": "48.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b1b43779794a5a20df4daea8f8ef2eaa"
-    },
-    {
-      "name": "krb5",
-      "version": "1.12.1",
-      "release": "19.9",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "bdab6842125d0170f176e5293fc7bc57"
-    },
-    {
-      "name": "libX11-6",
-      "version": "1.6.3",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d81e5d726512266dad5bd41a3ee673ff"
-    },
-    {
-      "name": "libX11-data",
-      "version": "1.6.3",
-      "release": "1.1",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "84a346123235e8fffed79b1d16e4d202"
-    },
-    {
-      "name": "libXau6",
-      "version": "1.0.8",
-      "release": "6.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "fc6392b8bfb72b5a5ef8fb6f3103b113"
-    },
-    {
-      "name": "libacl1",
-      "version": "2.2.52",
-      "release": "6.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "99c7abed9b2f6ed6171c583a0656544f"
-    },
-    {
-      "name": "libadns1",
-      "version": "1.4",
-      "release": "103.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "71e817de14d7efc51084fea99c4c83ec"
-    },
-    {
-      "name": "libaio1",
-      "version": "0.3.109",
-      "release": "19.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "385acc095a701bdd1fdc81d136f64ade"
-    },
-    {
-      "name": "libapparmor1",
-      "version": "2.10",
-      "release": "3.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "57c78c11189b3c0118b76732dae8c038"
-    },
-    {
-      "name": "libasm1",
-      "version": "0.158",
-      "release": "9.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "595c731f1ca8cfd566c79c865ad5c934"
-    },
-    {
-      "name": "libassuan0",
-      "version": "2.1.1",
-      "release": "3.6",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "13119dd654a231d1ef393575698daf43"
-    },
-    {
-      "name": "libattr1",
-      "version": "2.4.47",
-      "release": "5.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5ecf26b664bf5e39c044d7dc55613503"
-    },
-    {
-      "name": "libaudit1",
-      "version": "2.3.6",
-      "release": "3.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ae9a9128aef35481887aaf7f4fdb7395"
-    },
-    {
-      "name": "libaugeas0",
-      "version": "1.2.0",
-      "release": "6.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "978d76d447de6877eee5fb35ba470e08"
-    },
-    {
-      "name": "libblkid1",
-      "version": "2.25",
-      "release": "7.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "24976d4ae7ae4378664cb1e008374370"
-    },
-    {
-      "name": "libbz2-1",
-      "version": "1.0.6",
-      "release": "30.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "7fdc7c1ddd6f315d72bf27989e27d65f"
-    },
-    {
-      "name": "libcap-ng0",
-      "version": "0.7.3",
-      "release": "3.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5ad0f4c8860079f035adca5117faed16"
-    },
-    {
-      "name": "libcap2",
-      "version": "2.22",
-      "release": "14.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "474398c10aeb7a0427f6d46d55db7c8d"
-    },
-    {
-      "name": "libcom_err2",
-      "version": "1.42.11",
-      "release": "10.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "968bc37bcfde17cd1a67a0c14f741959"
-    },
-    {
-      "name": "libcrack2",
-      "version": "2.9.0",
-      "release": "5.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ed710df3d688ddfaee6b8f16f0fab94a"
-    },
-    {
-      "name": "libcroco-0_6-3",
-      "version": "0.6.8",
-      "release": "8.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4c6816f85d96c95e75ead6fa1b5e1a93"
-    },
-    {
-      "name": "libcryptsetup4",
-      "version": "1.6.4",
-      "release": "3.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "cf52d77b951c552ee1e9d49b5653957b"
-    },
-    {
-      "name": "libcurl4",
-      "version": "7.37.0",
-      "release": "5.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "9b275f787e46ba192a4b419d8dafcc59"
-    },
-    {
-      "name": "libdaemon0",
-      "version": "0.14",
-      "release": "16.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "98c1da92d5765c028ec377869948d963"
-    },
-    {
-      "name": "libdb-4_8",
-      "version": "4.8.30",
-      "release": "30.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "9048c99c58b699941ebbb5379e22800e"
-    },
-    {
-      "name": "libdbus-1-3",
-      "version": "1.8.16",
-      "release": "5.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b33f7d7cf3bb4b0dd67864c82c9c7d89"
-    },
-    {
-      "name": "libdw1",
-      "version": "0.158",
-      "release": "9.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "63c5fa258664ab3f4aa4e946e7c09415"
-    },
-    {
-      "name": "libedit0",
-      "version": "3.1.snap20140620",
-      "release": "3.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "3b3f2fbf583d24bf8084deffe4a1c6c4"
-    },
-    {
-      "name": "libelf0",
-      "version": "0.8.13",
-      "release": "20.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "067caff382236fe4116f092b466fa4b0"
-    },
-    {
-      "name": "libelf1",
-      "version": "0.158",
-      "release": "9.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "9fbf4e75e7ce3fa57a7c05ce94cdd131"
-    },
-    {
-      "name": "libevent-2_0-5",
-      "version": "2.0.21",
-      "release": "5.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6af8fdf972d32d65c9344432f63f3810"
-    },
-    {
-      "name": "libexpat1",
-      "version": "2.1.0",
-      "release": "15.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d817724be54a59c550770448be55e850"
-    },
-    {
-      "name": "libext2fs2",
-      "version": "1.42.11",
-      "release": "10.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0f06977a3e9111fc65c435eacbd70401"
-    },
-    {
-      "name": "libffi4",
-      "version": "5.2.1+r226025",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5d80ff50e7a524845a6d9a040bf8d847"
-    },
-    {
-      "name": "libfipscheck1",
-      "version": "1.2.0",
-      "release": "7.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ae58f0bbe2cf9014f9c2bdd70b826e8c"
-    },
-    {
-      "name": "libfreetype6",
-      "version": "2.5.5",
-      "release": "8.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b71acf65d24b66a023350974c3283a57"
-    },
-    {
-      "name": "libfuse2",
-      "version": "2.9.3",
-      "release": "8.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c1f672440dc6ba4f9b70faaf2f179bcc"
-    },
-    {
-      "name": "libgcc_s1",
-      "version": "5.2.1+r226025",
-      "release": "4.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "62c714318520d5f9470255ea7e014b7f"
-    },
-    {
-      "name": "libgcrypt20",
-      "version": "1.6.1",
-      "release": "18.7",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "2a969479224d8c343043e895157f5a39"
-    },
-    {
-      "name": "libgdbm4",
-      "version": "1.10",
-      "release": "3.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "7a6a9015c0888529a5d219ef622c1c3d"
-    },
-    {
-      "name": "libgio-2_0-0",
-      "version": "2.44.1",
-      "release": "2.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e1be5315ad7bf5eb37f62bcc3fb3a374"
-    },
-    {
-      "name": "libglib-2_0-0",
-      "version": "2.44.1",
-      "release": "2.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5675fc8cd8df92a1b14a142ae386d647"
-    },
-    {
-      "name": "libgmodule-2_0-0",
-      "version": "2.44.1",
-      "release": "2.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "673f815ca542e7c68ddf2077a3bd23e6"
-    },
-    {
-      "name": "libgmp10",
-      "version": "5.1.3",
-      "release": "4.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a0e62fa96082c4b2795d039c04bd59c7"
-    },
-    {
-      "name": "libgobject-2_0-0",
-      "version": "2.44.1",
-      "release": "2.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5b43dc73af4181a66be2aee91d61132a"
-    },
-    {
-      "name": "libgpg-error0",
-      "version": "1.13",
-      "release": "3.6",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "8c53b983461b2b5b176a5c38197fff27"
-    },
-    {
-      "name": "libidn11",
-      "version": "1.28",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ec33361965f206dba5375f5ee6684847"
-    },
-    {
-      "name": "libkeyutils1",
-      "version": "1.5.9",
-      "release": "4.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0d17a38828ebd5b477c47682ef7ace5f"
-    },
-    {
-      "name": "libkmod2",
-      "version": "17",
-      "release": "3.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a3ea927784b790bdc72b1924bfaccbc3"
-    },
-    {
-      "name": "libksba8",
-      "version": "1.3.0",
-      "release": "2.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "3d3443b50ac034e1415f00bf95753889"
-    },
-    {
-      "name": "libldap-2_4-2",
-      "version": "2.4.41",
-      "release": "9.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4aa486177ff244a96c3d114a91472406"
-    },
-    {
-      "name": "liblua5_1",
-      "version": "5.1.5",
-      "release": "11.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "3d70c542cf88d65ae03ba9c440a31c20"
-    },
-    {
-      "name": "liblzma5",
-      "version": "5.0.5",
-      "release": "3.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a7549cb7b79d2e598414ec11291dc3b3"
-    },
-    {
-      "name": "liblzo2-2",
-      "version": "2.08",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c1c980b7163b805cf53c76e0df1dd5c8"
-    },
-    {
-      "name": "libmagic1",
-      "version": "5.19",
-      "release": "5.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "35f913015516d358f919a9bf2a151c60"
-    },
-    {
-      "name": "libmnl0",
-      "version": "1.0.3",
-      "release": "11.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e9eedd7d320fe800ecfb3eb6755aac5d"
-    },
-    {
-      "name": "libmodman1",
-      "version": "2.0.1",
-      "release": "17.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "09ee09a7401aee9cb708f633667419cf"
-    },
-    {
-      "name": "libmount1",
-      "version": "2.25",
-      "release": "7.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d89d7ef9180cbf0b6652cc55ec25816b"
-    },
-    {
-      "name": "libmozjs-17_0",
-      "version": "17.0",
-      "release": "9.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5948f68685d467b399160953e14cd657"
-    },
-    {
-      "name": "libncurses5",
-      "version": "5.9",
-      "release": "53.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "bd073814979cf7ec44be4e0e6709b4e0"
-    },
-    {
-      "name": "libncurses6",
-      "version": "5.9",
-      "release": "53.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "59fd948b23f023d6d58a6996d1165e96"
-    },
-    {
-      "name": "libnl-config",
-      "version": "3.2.23",
-      "release": "3.2",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "716e44608b489a0f5d7dad76a4c3f4fc"
-    },
-    {
-      "name": "libnl3-200",
-      "version": "3.2.23",
-      "release": "3.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a37fda4081aa7167a1e720c46dd77cfb"
-    },
-    {
-      "name": "libopenssl1_0_0",
-      "version": "1.0.1i",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4c3448b2c5e136182c85ccb50bcf7f87"
-    },
-    {
-      "name": "libp11-kit0",
-      "version": "0.20.3",
-      "release": "7.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "b31820a5ab481c71c27011300b97c342"
-    },
-    {
-      "name": "libparted0",
-      "version": "3.1",
-      "release": "17.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d6a086e3519db99b49e610a1d2988540"
-    },
-    {
-      "name": "libpcre1",
-      "version": "8.33",
-      "release": "3.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "395ad9aedce1ab1cdae65e15f9fdac27"
-    },
-    {
-      "name": "libpng16-16",
-      "version": "1.6.8",
-      "release": "2.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0ec7a9ef42c556b44b5675cd8b5a1fd7"
-    },
-    {
-      "name": "libpolkit0",
-      "version": "0.112",
-      "release": "4.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ffbedfb22a932d9713fe5886ffc456ec"
-    },
-    {
-      "name": "libpopt0",
-      "version": "1.16",
-      "release": "28.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a83dc8dcd88541920e3f605ee9a35f10"
-    },
-    {
-      "name": "libprocps3",
-      "version": "3.3.9",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "1eb77bbae72f9f827666451eca1d8451"
-    },
-    {
-      "name": "libproxy1",
-      "version": "0.4.11",
-      "release": "13.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "bc349abdb2da93030c9d7fb883e5230b"
-    },
-    {
-      "name": "libpth20",
-      "version": "2.0.7",
-      "release": "141.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f46f7a186081948253d3d9d5b0dea85a"
-    },
-    {
-      "name": "libqrencode3",
-      "version": "3.4.3",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "933ff2856ce1043768f777f6beedea58"
-    },
-    {
-      "name": "libreadline6",
-      "version": "6.2",
-      "release": "76.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "1362ad02cc6eb801668e2e8b0ce22d8c"
-    },
-    {
-      "name": "libreiserfscore0",
-      "version": "3.6.24",
-      "release": "7.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "eae1c65bc257b18bc12976a13c51a28c"
-    },
-    {
-      "name": "libsasl2-3",
-      "version": "2.1.26",
-      "release": "8.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "603031f8e40da1ad042cef4cf290f809"
-    },
-    {
-      "name": "libseccomp2",
-      "version": "2.1.1",
-      "release": "3.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "30b388d17a2b2e44cb4b1e1a3aded378"
-    },
-    {
-      "name": "libselinux1",
-      "version": "2.3",
-      "release": "3.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5704953fa5cc9534f0130186b5eed86c"
-    },
-    {
-      "name": "libsemanage1",
-      "version": "2.3",
-      "release": "3.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "966de4475e7ef999a6dcc2167628e96a"
-    },
-    {
-      "name": "libsepol1",
-      "version": "2.3",
-      "release": "3.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "25a44cb17af04ed900838524458fabea"
-    },
-    {
-      "name": "libsgutils2-2",
-      "version": "1.41",
-      "release": "6.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e33ceadb5471bda94a0447871988886a"
-    },
-    {
-      "name": "libsmartcols1",
-      "version": "2.25",
-      "release": "7.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "598157b2169ea2e4d5664c621c1b459e"
-    },
-    {
-      "name": "libsolv-tools",
-      "version": "0.6.14",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5e496bfdc84c4b6b9076528d01ffa837"
-    },
-    {
-      "name": "libsqlite3-0",
-      "version": "3.8.10.2",
-      "release": "5.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4011163d31a62520d53b98a417d2ae78"
-    },
-    {
-      "name": "libssh2-1",
-      "version": "1.4.3",
-      "release": "10.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6f909139497c6170b307bd3dfba62aea"
-    },
-    {
-      "name": "libstdc++6",
-      "version": "5.2.1+r226025",
-      "release": "4.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "dd6917616d8419dac960316b4d1b5dd0"
-    },
-    {
-      "name": "libtasn1",
-      "version": "3.7",
-      "release": "10.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "8d4ba27025e4e3697378f3a4ac1fdeb2"
-    },
-    {
-      "name": "libtasn1-6",
-      "version": "3.7",
-      "release": "10.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "1987356b9f5cd5b4e748c353a3452a15"
-    },
-    {
-      "name": "libtirpc1",
-      "version": "0.2.3",
-      "release": "7.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "87af35eb8c5b377e943af42a500665ac"
-    },
-    {
-      "name": "libudev1",
-      "version": "210",
-      "release": "84.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "21294775d0f7c459442da007e602fc46"
-    },
-    {
-      "name": "libusb-0_1-4",
-      "version": "0.1.13",
-      "release": "31.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e0c33d8f1b2124ac4cd406ca02fa26fc"
-    },
-    {
-      "name": "libusb-1_0-0",
-      "version": "1.0.20",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "fe534a1b8543d13afa6ace2ac9ac9fc0"
-    },
-    {
-      "name": "libustr-1_0-1",
-      "version": "1.0.4",
-      "release": "34.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5867189d1be04094b6803055d76fa9ed"
-    },
-    {
-      "name": "libutempter0",
-      "version": "1.1.6",
-      "release": "6.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "725851a15ad68060a1879bc52bc038bd"
-    },
-    {
-      "name": "libuuid1",
-      "version": "2.25",
-      "release": "7.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "763bf8fb1585c384577b3519bd971fd8"
-    },
-    {
-      "name": "libwicked-0-6",
-      "version": "0.6.27",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f063b6ba778b43ba581f683c72bc0a39"
-    },
-    {
-      "name": "libwrap0",
-      "version": "7.6",
-      "release": "885.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4d030beb9444548a64b968cbedbd503a"
-    },
-    {
-      "name": "libx86emu1",
-      "version": "1.5",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4f5294a5f06ceae33e6dcf4553af8c16"
-    },
-    {
-      "name": "libxcb1",
-      "version": "1.11.1",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "68594c8b6d82583fb9b18183b27ed2ed"
-    },
-    {
-      "name": "libxml2-2",
-      "version": "2.9.1",
-      "release": "8.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "dca88cfe4ddad156a8b3ec63340a5d79"
-    },
-    {
-      "name": "libxtables10",
-      "version": "1.4.21",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6686e7170269c59e4241e96f71482bec"
-    },
-    {
-      "name": "libz1",
-      "version": "1.2.8",
-      "release": "6.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "2b0e8459c17ff7c18d7fa603e46d8af8"
-    },
-    {
-      "name": "libzio1",
-      "version": "1.00",
-      "release": "11.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d3bed4bab54ef017f6ec2f7eab2a2eab"
-    },
-    {
-      "name": "libzypp",
-      "version": "15.19.5",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e24a7299bcf72ecfe1b53d1f079b1b22"
-    },
-    {
-      "name": "lvm2",
-      "version": "2.02.120",
-      "release": "62.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "07c47e34c1f7450dd883f713f98dfba3"
-    },
-    {
-      "name": "mozilla-nspr",
-      "version": "4.10.8",
-      "release": "2.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d60f71e6c41b0f8427fbf6f05a7ff859"
-    },
-    {
-      "name": "ncurses-utils",
-      "version": "5.9",
-      "release": "53.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "be7ec4b37a45f3d6203f34be710028d7"
-    },
-    {
-      "name": "netcfg",
-      "version": "11.5",
-      "release": "26.1",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "bd43ad2811d57ebfa714ad917585176c"
-    },
-    {
-      "name": "nfs-client",
-      "version": "1.3.0",
-      "release": "9.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "27c3111ec42452de1c096a8b5cd8406b"
-    },
-    {
-      "name": "nfs-kernel-server",
-      "version": "1.3.0",
-      "release": "9.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "ce51e81bb9bfcbc36a25bf7a6dbedb8d"
-    },
-    {
-      "name": "nfsidmap",
-      "version": "0.25",
-      "release": "7.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e136fa60a9f8a17c1a65bce79399f8eb"
-    },
-    {
-      "name": "openSUSE-build-key",
-      "version": "1.0",
-      "release": "32.2",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "e9b1b6a0acab733785c1917a614bec4c"
-    },
-    {
-      "name": "openSUSE-release",
-      "version": "42.1",
-      "release": "1.46",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "cf9d4736a3f57d1ba2737acce151de88"
-    },
-    {
-      "name": "openSUSE-release-ftp",
-      "version": "42.1",
-      "release": "1.46",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f59b8c889e3be76d2e5cd48386bd769d"
-    },
-    {
-      "name": "openslp",
-      "version": "2.0.0",
-      "release": "8.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "41ac615914d0d4963d1fa7142f5397ac"
-    },
-    {
-      "name": "openssh",
-      "version": "6.6p1",
-      "release": "6.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "77bd1c768d5e18514346e0ce1919ebf8"
-    },
-    {
-      "name": "openssl",
-      "version": "1.0.1i",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c3ae00e7c026622b581cb7c787e862b2"
-    },
-    {
-      "name": "os-prober",
-      "version": "1.61",
-      "release": "13.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "2a5914bf642f1c3dd58b04dbf2f224ff"
-    },
-    {
-      "name": "p11-kit",
-      "version": "0.20.3",
-      "release": "7.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "1a4fbf51e1e7f2ea702b56ac0a5f8629"
-    },
-    {
-      "name": "p11-kit-tools",
-      "version": "0.20.3",
-      "release": "7.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "76e1262aa55518dd9c9aad01d000ea9d"
-    },
-    {
-      "name": "pam",
-      "version": "1.1.8",
-      "release": "12.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "89fb119bc96c58eb8ae36bbfb7c7a9ac"
-    },
-    {
-      "name": "pam-config",
-      "version": "0.88",
-      "release": "3.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4ac861a96312be035c91508616440e42"
-    },
-    {
-      "name": "parted",
-      "version": "3.1",
-      "release": "17.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "78ce8ad64acf97448971662040c08bbe"
-    },
-    {
-      "name": "patterns-openSUSE-base",
-      "version": "20150918",
-      "release": "10.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "535a49dfcc33dc71e5c449a670f5bf0c"
-    },
-    {
-      "name": "perl",
-      "version": "5.18.2",
-      "release": "3.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "fec639f37724b6db5d19ec0e75079874"
-    },
-    {
-      "name": "perl-Bootloader",
-      "version": "0.844",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "8d1f9810985464b3455c08f429c6b1a0"
-    },
-    {
-      "name": "perl-base",
-      "version": "5.18.2",
-      "release": "3.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "70ede2005fd4aea48172f92a53d340c8"
-    },
-    {
-      "name": "permissions",
-      "version": "2014.08.26.1452",
-      "release": "3.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c0dcb6d707f29d97922b2554ab9094c9"
-    },
-    {
-      "name": "pigz",
-      "version": "2.3",
-      "release": "5.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d71f853f036d3f067084141821f4a724"
-    },
-    {
-      "name": "pinentry",
-      "version": "0.8.3",
-      "release": "3.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "4515aba86a21e012b38f235f1e58216e"
-    },
-    {
-      "name": "pkg-config",
-      "version": "0.28",
-      "release": "8.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "0c6e3c89832083f13c3ac8d9eedaec43"
-    },
-    {
-      "name": "polkit",
-      "version": "0.112",
-      "release": "4.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c698acc85baf46a9d53660e712c1d139"
-    },
-    {
-      "name": "polkit-default-privs",
-      "version": "13.2",
-      "release": "8.1",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "7e72805bfa7be325ad3ff2598dcaa0fa"
-    },
-    {
-      "name": "postfix",
-      "version": "2.11.6",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6335d8c84702380157aa4fe41a75b28b"
-    },
-    {
-      "name": "procps",
-      "version": "3.3.9",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "1099d51ad98a72c950bb7a2e265d8ab2"
-    },
-    {
-      "name": "rpcbind",
-      "version": "0.2.1_rc4",
-      "release": "9.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "7fdb3e2ab5f5626a5ecac1007d69a886"
-    },
-    {
-      "name": "rpm",
-      "version": "4.11.2",
-      "release": "6.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c1165f89362d61a7cd5ce3c4c57c0db2"
-    },
-    {
-      "name": "rsync",
-      "version": "3.1.0",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "6e6589c90f073872ca934b5780599a5a"
-    },
-    {
-      "name": "sed",
-      "version": "4.2.2",
-      "release": "6.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d591d4a09e1c8801df91e6fafc6775bd"
-    },
-    {
-      "name": "sg3_utils",
-      "version": "1.41",
-      "release": "6.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "d99c08b0c56c5e7c62de3cb39de45468"
-    },
-    {
-      "name": "shadow",
-      "version": "4.1.5.1",
-      "release": "14.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e675bf8b52ada6b99d1d2782c4907740"
-    },
-    {
-      "name": "shared-mime-info",
-      "version": "1.2",
-      "release": "3.3",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "feff5c41f619f236e2b722c192d2464a"
-    },
-    {
-      "name": "squashfs",
-      "version": "4.3",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "576c75d423e50ebcd6affbd806ef8d06"
-    },
-    {
-      "name": "sudo",
-      "version": "1.8.10p3",
-      "release": "3.8",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "cbad9e70c306d1bde094a0c7b47fc705"
-    },
-    {
-      "name": "suse-module-tools",
-      "version": "12.3",
-      "release": "16.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "74ec43dcfd6f8d0cf2d538b073a4a017"
-    },
-    {
-      "name": "sysconfig",
-      "version": "0.83.8",
-      "release": "5.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "539d89d9bcb2f2a0cb7e39e2b85a66f3"
-    },
-    {
-      "name": "sysconfig-netconfig",
-      "version": "0.83.8",
-      "release": "5.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "a61fe5590444b230c1c9aff63e108fb1"
-    },
-    {
-      "name": "syslinux",
-      "version": "4.04",
-      "release": "34.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c94acd46c7dc72a21380e0f634afbf01"
-    },
-    {
-      "name": "systemd",
-      "version": "210",
-      "release": "84.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "8406d85954619896606bc5cfa867f942"
-    },
-    {
-      "name": "systemd-logger",
-      "version": "210",
-      "release": "84.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "745e68c94c9a1b14dc97ea0a75fd83a4"
-    },
-    {
-      "name": "systemd-presets-branding-openSUSE",
-      "version": "0.3.0",
-      "release": "23.2",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "e6b50b275e529bbeaa09b917eac30a12"
-    },
-    {
-      "name": "systemd-sysvinit",
-      "version": "210",
-      "release": "84.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "2caa2bae61cbae5627162f8eb505cc0e"
-    },
-    {
-      "name": "sysvinit-tools",
-      "version": "2.88+",
-      "release": "97.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "af5d2e1a6a5992d29d124d3b1a89d0da"
-    },
-    {
-      "name": "tar",
-      "version": "1.27.1",
-      "release": "4.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "84c421ba47651f0a38f9cb32fa603b2d"
-    },
-    {
-      "name": "terminfo-base",
-      "version": "5.9",
-      "release": "53.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "cb09a6420e75ebaf4b814caf6b7c600d"
-    },
-    {
-      "name": "time",
-      "version": "1.7",
-      "release": "8.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "97e358055cbc505d87f8afbc4442a5de"
-    },
-    {
-      "name": "udev",
-      "version": "210",
-      "release": "84.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "5bb2181e5953920e9f8824835620a2b4"
-    },
-    {
-      "name": "update-alternatives",
-      "version": "1.16.10",
-      "release": "9.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "2583a577d67e2c8ec2fa9fc84b5dc809"
-    },
-    {
-      "name": "util-linux",
-      "version": "2.25",
-      "release": "7.2",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "fc4f36ccf6e1b915862791d91b00b8bb"
-    },
-    {
-      "name": "util-linux-systemd",
-      "version": "2.25",
-      "release": "7.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "f87f35b663f13a8cefccf876105a128a"
-    },
-    {
-      "name": "vim",
-      "version": "7.4.326",
-      "release": "3.10",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "c62ce9aab34a37677d88017ecd99d958"
-    },
-    {
-      "name": "wallpaper-branding-openSUSE",
-      "version": "42.1",
-      "release": "6.2",
-      "arch": "noarch",
-      "vendor": "openSUSE",
-      "checksum": "28ee7958284becfb2df2edb45b2388a8"
-    },
-    {
-      "name": "which",
-      "version": "2.20",
-      "release": "5.4",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "8a8770b618f1eaed28bc8a96f50b0ed1"
-    },
-    {
-      "name": "wicked",
-      "version": "0.6.27",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "13156ac1272e726120f533e0f61fbd0c"
-    },
-    {
-      "name": "wicked-service",
-      "version": "0.6.27",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "32d7ac64ca424ed626de3e867f7c145a"
-    },
-    {
-      "name": "xz",
-      "version": "5.0.5",
-      "release": "3.5",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "e168e3853561ae5bc9daafe90dac210b"
-    },
-    {
-      "name": "zypper",
-      "version": "1.12.23",
-      "release": "1.1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "8d772eca4a59f14171e715237caee9a1"
-    }
-  ],
+  "packages": {
+    "package_system": "rpm",
+    "packages": [
+      {
+        "name": "aaa_base",
+        "version": "13.2+git20140911.61c1681",
+        "release": "4.6",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "081158cbce7420230e5debfc93e489f0"
+      },
+      {
+        "name": "acl",
+        "version": "2.2.52",
+        "release": "6.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "766d1f6f9b2523ce864bde867e81557e"
+      },
+      {
+        "name": "autofs",
+        "version": "5.0.9",
+        "release": "4.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "7bc71d01fff912393048d72034e2de73"
+      },
+      {
+        "name": "bash",
+        "version": "4.2",
+        "release": "76.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "561f9d9e35793b8420bf38be8b3ee922"
+      },
+      {
+        "name": "btrfsprogs",
+        "version": "4.1.2",
+        "release": "8.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6c402497faf63d4e3bc42bc0c8933594"
+      },
+      {
+        "name": "bzip2",
+        "version": "1.0.6",
+        "release": "30.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ecb5db1d84561924017cf4db72b85fdd"
+      },
+      {
+        "name": "ca-certificates",
+        "version": "1_201403302107",
+        "release": "9.1",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "be1740cc1c20a08890800ca732872940"
+      },
+      {
+        "name": "coreutils",
+        "version": "8.22",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "3d02b57038ef0896d85da7c0801b1d5c"
+      },
+      {
+        "name": "cpio",
+        "version": "2.11",
+        "release": "30.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c39a9599f1b3f3124585a515b9522e51"
+      },
+      {
+        "name": "cracklib",
+        "version": "2.9.0",
+        "release": "5.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "42f358e756e107022e64636f7a1e3dae"
+      },
+      {
+        "name": "cracklib-dict-full",
+        "version": "2.8.12",
+        "release": "65.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "89f5ef288f7dcab86dc64b82588fc44d"
+      },
+      {
+        "name": "cron",
+        "version": "4.2",
+        "release": "57.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "9e04e3296fb2590d44b66cea2b2205dc"
+      },
+      {
+        "name": "cronie",
+        "version": "1.4.11",
+        "release": "57.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "52ed6912e670f4d4756f90f81d72f75b"
+      },
+      {
+        "name": "dbus-1",
+        "version": "1.8.16",
+        "release": "5.9",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6a03c4e5ce455f6824eb77cd2b069195"
+      },
+      {
+        "name": "dbus-1-x11",
+        "version": "1.8.16",
+        "release": "5.9",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4f16d7a5d39286f2053ceb62f43a4a4d"
+      },
+      {
+        "name": "device-mapper",
+        "version": "1.02.97",
+        "release": "62.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "388ac9d2a7e3200fefb1f0bd1baae2ff"
+      },
+      {
+        "name": "diffutils",
+        "version": "3.3",
+        "release": "7.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "21b94c7e0c99652ac9b1190e9ad4185f"
+      },
+      {
+        "name": "dirmngr",
+        "version": "1.1.1",
+        "release": "5.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b9474382c5a1a32cb4b80c8c11ad974a"
+      },
+      {
+        "name": "dmraid",
+        "version": "1.0.0.rc16",
+        "release": "37.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e73db7b22432baeae182c43e23695394"
+      },
+      {
+        "name": "dracut",
+        "version": "037",
+        "release": "66.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0754343c0f264e86d4f64542e9f400df"
+      },
+      {
+        "name": "elfutils",
+        "version": "0.158",
+        "release": "9.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0c98f93f724cd9193a4cfc677e84dee5"
+      },
+      {
+        "name": "expat",
+        "version": "2.1.0",
+        "release": "15.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f0eb5eb42ea515b2aa5bafea21fc3145"
+      },
+      {
+        "name": "file",
+        "version": "5.19",
+        "release": "5.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "477b6d9501345b433afdf6176c4a15b5"
+      },
+      {
+        "name": "file-magic",
+        "version": "5.19",
+        "release": "5.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4505cf10caf6196235ce22bb2a537ecc"
+      },
+      {
+        "name": "filesystem",
+        "version": "13.1",
+        "release": "5.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d67112cffc0a9fb857a865b3712cf31e"
+      },
+      {
+        "name": "fillup",
+        "version": "1.42",
+        "release": "272.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "00e96a60de4fbc763504a34c5ef89d67"
+      },
+      {
+        "name": "findutils",
+        "version": "4.5.12",
+        "release": "3.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "9ed445ac242d021d78bde3d85916b4e9"
+      },
+      {
+        "name": "fipscheck",
+        "version": "1.2.0",
+        "release": "7.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "576b4b85fb2d98190c933c258fc02006"
+      },
+      {
+        "name": "gawk",
+        "version": "4.1.3",
+        "release": "4.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "2ba134744092902e47fa35b6e1d57184"
+      },
+      {
+        "name": "gettext-runtime",
+        "version": "0.19.2",
+        "release": "3.6",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f3047a9549c5de7e740e3eb8cee9198d"
+      },
+      {
+        "name": "gio-branding-openSUSE",
+        "version": "42.1",
+        "release": "2.1",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "b32c86666c2c9762a6fcf2e437794522"
+      },
+      {
+        "name": "glib2-tools",
+        "version": "2.44.1",
+        "release": "2.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d45f109a13f163dcd7402583ca6a8461"
+      },
+      {
+        "name": "glibc",
+        "version": "2.19",
+        "release": "17.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0c43af7fce881df707d8f8fdba431028"
+      },
+      {
+        "name": "glibc-locale",
+        "version": "2.19",
+        "release": "17.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "275cef46e18ae2f9f3ab86b7f45c6a12"
+      },
+      {
+        "name": "gpg2",
+        "version": "2.0.24",
+        "release": "3.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4d584a80bb8e61c3186832468e0f433d"
+      },
+      {
+        "name": "grep",
+        "version": "2.16",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0261d7c67ef4ef1b3ee2886f9d221a7d"
+      },
+      {
+        "name": "grub2",
+        "version": "2.02~beta2",
+        "release": "68.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d97a40a45fe97a05623192d1aba31979"
+      },
+      {
+        "name": "grub2-i386-pc",
+        "version": "2.02~beta2",
+        "release": "68.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "460b36f7bd90ee29357293d67ea0a8f8"
+      },
+      {
+        "name": "gzip",
+        "version": "1.6",
+        "release": "9.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "8805cc4b5481248c76fbf73b25d0967c"
+      },
+      {
+        "name": "hardlink",
+        "version": "1.0",
+        "release": "8.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6949f7db310547a5a7b5f3876c211544"
+      },
+      {
+        "name": "hwinfo",
+        "version": "21.23",
+        "release": "1.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "1148f436ee53a5c8d425b0b91c2d3eaa"
+      },
+      {
+        "name": "ifplugd",
+        "version": "0.28",
+        "release": "236.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b29aaa55b0cd4443969eab33c0a7a9b6"
+      },
+      {
+        "name": "info",
+        "version": "4.13a",
+        "release": "39.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4106a30405ac8522219eda9b45021f13"
+      },
+      {
+        "name": "insserv-compat",
+        "version": "0.1",
+        "release": "13.4",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "16224bf774a3714d55be6355dd4ea528"
+      },
+      {
+        "name": "iproute2",
+        "version": "4.2",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d0fdaecdd4c27a83ca14f250993c8c30"
+      },
+      {
+        "name": "iputils",
+        "version": "s20121221",
+        "release": "3.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b8a76296b8d39aa9340dfb9677f33800"
+      },
+      {
+        "name": "kbd",
+        "version": "1.15.5",
+        "release": "6.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "38bb82ee41f8cfdac42098970bab7fc3"
+      },
+      {
+        "name": "kernel-default",
+        "version": "4.1.12",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c9d0cbe850fe6b6c30110c398e5cf5de"
+      },
+      {
+        "name": "keyutils",
+        "version": "1.5.9",
+        "release": "4.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "746c5a4a2b7380a61d1f46d194601bfb"
+      },
+      {
+        "name": "klogd",
+        "version": "1.4.1",
+        "release": "779.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6c0ebedc416ab10be2cc9ebbf4a4afbc"
+      },
+      {
+        "name": "kmod",
+        "version": "17",
+        "release": "3.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "bf83b106d2e969e1f67059e40285670f"
+      },
+      {
+        "name": "kmod-compat",
+        "version": "17",
+        "release": "3.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6e4c906c5a8aa763abe7807faef9656f"
+      },
+      {
+        "name": "kpartx",
+        "version": "0.5.0",
+        "release": "48.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b1b43779794a5a20df4daea8f8ef2eaa"
+      },
+      {
+        "name": "krb5",
+        "version": "1.12.1",
+        "release": "19.9",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "bdab6842125d0170f176e5293fc7bc57"
+      },
+      {
+        "name": "libX11-6",
+        "version": "1.6.3",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d81e5d726512266dad5bd41a3ee673ff"
+      },
+      {
+        "name": "libX11-data",
+        "version": "1.6.3",
+        "release": "1.1",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "84a346123235e8fffed79b1d16e4d202"
+      },
+      {
+        "name": "libXau6",
+        "version": "1.0.8",
+        "release": "6.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "fc6392b8bfb72b5a5ef8fb6f3103b113"
+      },
+      {
+        "name": "libacl1",
+        "version": "2.2.52",
+        "release": "6.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "99c7abed9b2f6ed6171c583a0656544f"
+      },
+      {
+        "name": "libadns1",
+        "version": "1.4",
+        "release": "103.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "71e817de14d7efc51084fea99c4c83ec"
+      },
+      {
+        "name": "libaio1",
+        "version": "0.3.109",
+        "release": "19.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "385acc095a701bdd1fdc81d136f64ade"
+      },
+      {
+        "name": "libapparmor1",
+        "version": "2.10",
+        "release": "3.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "57c78c11189b3c0118b76732dae8c038"
+      },
+      {
+        "name": "libasm1",
+        "version": "0.158",
+        "release": "9.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "595c731f1ca8cfd566c79c865ad5c934"
+      },
+      {
+        "name": "libassuan0",
+        "version": "2.1.1",
+        "release": "3.6",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "13119dd654a231d1ef393575698daf43"
+      },
+      {
+        "name": "libattr1",
+        "version": "2.4.47",
+        "release": "5.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5ecf26b664bf5e39c044d7dc55613503"
+      },
+      {
+        "name": "libaudit1",
+        "version": "2.3.6",
+        "release": "3.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ae9a9128aef35481887aaf7f4fdb7395"
+      },
+      {
+        "name": "libaugeas0",
+        "version": "1.2.0",
+        "release": "6.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "978d76d447de6877eee5fb35ba470e08"
+      },
+      {
+        "name": "libblkid1",
+        "version": "2.25",
+        "release": "7.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "24976d4ae7ae4378664cb1e008374370"
+      },
+      {
+        "name": "libbz2-1",
+        "version": "1.0.6",
+        "release": "30.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "7fdc7c1ddd6f315d72bf27989e27d65f"
+      },
+      {
+        "name": "libcap-ng0",
+        "version": "0.7.3",
+        "release": "3.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5ad0f4c8860079f035adca5117faed16"
+      },
+      {
+        "name": "libcap2",
+        "version": "2.22",
+        "release": "14.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "474398c10aeb7a0427f6d46d55db7c8d"
+      },
+      {
+        "name": "libcom_err2",
+        "version": "1.42.11",
+        "release": "10.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "968bc37bcfde17cd1a67a0c14f741959"
+      },
+      {
+        "name": "libcrack2",
+        "version": "2.9.0",
+        "release": "5.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ed710df3d688ddfaee6b8f16f0fab94a"
+      },
+      {
+        "name": "libcroco-0_6-3",
+        "version": "0.6.8",
+        "release": "8.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4c6816f85d96c95e75ead6fa1b5e1a93"
+      },
+      {
+        "name": "libcryptsetup4",
+        "version": "1.6.4",
+        "release": "3.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "cf52d77b951c552ee1e9d49b5653957b"
+      },
+      {
+        "name": "libcurl4",
+        "version": "7.37.0",
+        "release": "5.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "9b275f787e46ba192a4b419d8dafcc59"
+      },
+      {
+        "name": "libdaemon0",
+        "version": "0.14",
+        "release": "16.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "98c1da92d5765c028ec377869948d963"
+      },
+      {
+        "name": "libdb-4_8",
+        "version": "4.8.30",
+        "release": "30.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "9048c99c58b699941ebbb5379e22800e"
+      },
+      {
+        "name": "libdbus-1-3",
+        "version": "1.8.16",
+        "release": "5.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b33f7d7cf3bb4b0dd67864c82c9c7d89"
+      },
+      {
+        "name": "libdw1",
+        "version": "0.158",
+        "release": "9.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "63c5fa258664ab3f4aa4e946e7c09415"
+      },
+      {
+        "name": "libedit0",
+        "version": "3.1.snap20140620",
+        "release": "3.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "3b3f2fbf583d24bf8084deffe4a1c6c4"
+      },
+      {
+        "name": "libelf0",
+        "version": "0.8.13",
+        "release": "20.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "067caff382236fe4116f092b466fa4b0"
+      },
+      {
+        "name": "libelf1",
+        "version": "0.158",
+        "release": "9.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "9fbf4e75e7ce3fa57a7c05ce94cdd131"
+      },
+      {
+        "name": "libevent-2_0-5",
+        "version": "2.0.21",
+        "release": "5.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6af8fdf972d32d65c9344432f63f3810"
+      },
+      {
+        "name": "libexpat1",
+        "version": "2.1.0",
+        "release": "15.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d817724be54a59c550770448be55e850"
+      },
+      {
+        "name": "libext2fs2",
+        "version": "1.42.11",
+        "release": "10.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0f06977a3e9111fc65c435eacbd70401"
+      },
+      {
+        "name": "libffi4",
+        "version": "5.2.1+r226025",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5d80ff50e7a524845a6d9a040bf8d847"
+      },
+      {
+        "name": "libfipscheck1",
+        "version": "1.2.0",
+        "release": "7.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ae58f0bbe2cf9014f9c2bdd70b826e8c"
+      },
+      {
+        "name": "libfreetype6",
+        "version": "2.5.5",
+        "release": "8.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b71acf65d24b66a023350974c3283a57"
+      },
+      {
+        "name": "libfuse2",
+        "version": "2.9.3",
+        "release": "8.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c1f672440dc6ba4f9b70faaf2f179bcc"
+      },
+      {
+        "name": "libgcc_s1",
+        "version": "5.2.1+r226025",
+        "release": "4.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "62c714318520d5f9470255ea7e014b7f"
+      },
+      {
+        "name": "libgcrypt20",
+        "version": "1.6.1",
+        "release": "18.7",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "2a969479224d8c343043e895157f5a39"
+      },
+      {
+        "name": "libgdbm4",
+        "version": "1.10",
+        "release": "3.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "7a6a9015c0888529a5d219ef622c1c3d"
+      },
+      {
+        "name": "libgio-2_0-0",
+        "version": "2.44.1",
+        "release": "2.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e1be5315ad7bf5eb37f62bcc3fb3a374"
+      },
+      {
+        "name": "libglib-2_0-0",
+        "version": "2.44.1",
+        "release": "2.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5675fc8cd8df92a1b14a142ae386d647"
+      },
+      {
+        "name": "libgmodule-2_0-0",
+        "version": "2.44.1",
+        "release": "2.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "673f815ca542e7c68ddf2077a3bd23e6"
+      },
+      {
+        "name": "libgmp10",
+        "version": "5.1.3",
+        "release": "4.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a0e62fa96082c4b2795d039c04bd59c7"
+      },
+      {
+        "name": "libgobject-2_0-0",
+        "version": "2.44.1",
+        "release": "2.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5b43dc73af4181a66be2aee91d61132a"
+      },
+      {
+        "name": "libgpg-error0",
+        "version": "1.13",
+        "release": "3.6",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "8c53b983461b2b5b176a5c38197fff27"
+      },
+      {
+        "name": "libidn11",
+        "version": "1.28",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ec33361965f206dba5375f5ee6684847"
+      },
+      {
+        "name": "libkeyutils1",
+        "version": "1.5.9",
+        "release": "4.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0d17a38828ebd5b477c47682ef7ace5f"
+      },
+      {
+        "name": "libkmod2",
+        "version": "17",
+        "release": "3.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a3ea927784b790bdc72b1924bfaccbc3"
+      },
+      {
+        "name": "libksba8",
+        "version": "1.3.0",
+        "release": "2.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "3d3443b50ac034e1415f00bf95753889"
+      },
+      {
+        "name": "libldap-2_4-2",
+        "version": "2.4.41",
+        "release": "9.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4aa486177ff244a96c3d114a91472406"
+      },
+      {
+        "name": "liblua5_1",
+        "version": "5.1.5",
+        "release": "11.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "3d70c542cf88d65ae03ba9c440a31c20"
+      },
+      {
+        "name": "liblzma5",
+        "version": "5.0.5",
+        "release": "3.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a7549cb7b79d2e598414ec11291dc3b3"
+      },
+      {
+        "name": "liblzo2-2",
+        "version": "2.08",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c1c980b7163b805cf53c76e0df1dd5c8"
+      },
+      {
+        "name": "libmagic1",
+        "version": "5.19",
+        "release": "5.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "35f913015516d358f919a9bf2a151c60"
+      },
+      {
+        "name": "libmnl0",
+        "version": "1.0.3",
+        "release": "11.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e9eedd7d320fe800ecfb3eb6755aac5d"
+      },
+      {
+        "name": "libmodman1",
+        "version": "2.0.1",
+        "release": "17.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "09ee09a7401aee9cb708f633667419cf"
+      },
+      {
+        "name": "libmount1",
+        "version": "2.25",
+        "release": "7.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d89d7ef9180cbf0b6652cc55ec25816b"
+      },
+      {
+        "name": "libmozjs-17_0",
+        "version": "17.0",
+        "release": "9.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5948f68685d467b399160953e14cd657"
+      },
+      {
+        "name": "libncurses5",
+        "version": "5.9",
+        "release": "53.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "bd073814979cf7ec44be4e0e6709b4e0"
+      },
+      {
+        "name": "libncurses6",
+        "version": "5.9",
+        "release": "53.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "59fd948b23f023d6d58a6996d1165e96"
+      },
+      {
+        "name": "libnl-config",
+        "version": "3.2.23",
+        "release": "3.2",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "716e44608b489a0f5d7dad76a4c3f4fc"
+      },
+      {
+        "name": "libnl3-200",
+        "version": "3.2.23",
+        "release": "3.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a37fda4081aa7167a1e720c46dd77cfb"
+      },
+      {
+        "name": "libopenssl1_0_0",
+        "version": "1.0.1i",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4c3448b2c5e136182c85ccb50bcf7f87"
+      },
+      {
+        "name": "libp11-kit0",
+        "version": "0.20.3",
+        "release": "7.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "b31820a5ab481c71c27011300b97c342"
+      },
+      {
+        "name": "libparted0",
+        "version": "3.1",
+        "release": "17.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d6a086e3519db99b49e610a1d2988540"
+      },
+      {
+        "name": "libpcre1",
+        "version": "8.33",
+        "release": "3.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "395ad9aedce1ab1cdae65e15f9fdac27"
+      },
+      {
+        "name": "libpng16-16",
+        "version": "1.6.8",
+        "release": "2.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0ec7a9ef42c556b44b5675cd8b5a1fd7"
+      },
+      {
+        "name": "libpolkit0",
+        "version": "0.112",
+        "release": "4.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ffbedfb22a932d9713fe5886ffc456ec"
+      },
+      {
+        "name": "libpopt0",
+        "version": "1.16",
+        "release": "28.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a83dc8dcd88541920e3f605ee9a35f10"
+      },
+      {
+        "name": "libprocps3",
+        "version": "3.3.9",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "1eb77bbae72f9f827666451eca1d8451"
+      },
+      {
+        "name": "libproxy1",
+        "version": "0.4.11",
+        "release": "13.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "bc349abdb2da93030c9d7fb883e5230b"
+      },
+      {
+        "name": "libpth20",
+        "version": "2.0.7",
+        "release": "141.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f46f7a186081948253d3d9d5b0dea85a"
+      },
+      {
+        "name": "libqrencode3",
+        "version": "3.4.3",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "933ff2856ce1043768f777f6beedea58"
+      },
+      {
+        "name": "libreadline6",
+        "version": "6.2",
+        "release": "76.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "1362ad02cc6eb801668e2e8b0ce22d8c"
+      },
+      {
+        "name": "libreiserfscore0",
+        "version": "3.6.24",
+        "release": "7.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "eae1c65bc257b18bc12976a13c51a28c"
+      },
+      {
+        "name": "libsasl2-3",
+        "version": "2.1.26",
+        "release": "8.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "603031f8e40da1ad042cef4cf290f809"
+      },
+      {
+        "name": "libseccomp2",
+        "version": "2.1.1",
+        "release": "3.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "30b388d17a2b2e44cb4b1e1a3aded378"
+      },
+      {
+        "name": "libselinux1",
+        "version": "2.3",
+        "release": "3.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5704953fa5cc9534f0130186b5eed86c"
+      },
+      {
+        "name": "libsemanage1",
+        "version": "2.3",
+        "release": "3.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "966de4475e7ef999a6dcc2167628e96a"
+      },
+      {
+        "name": "libsepol1",
+        "version": "2.3",
+        "release": "3.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "25a44cb17af04ed900838524458fabea"
+      },
+      {
+        "name": "libsgutils2-2",
+        "version": "1.41",
+        "release": "6.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e33ceadb5471bda94a0447871988886a"
+      },
+      {
+        "name": "libsmartcols1",
+        "version": "2.25",
+        "release": "7.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "598157b2169ea2e4d5664c621c1b459e"
+      },
+      {
+        "name": "libsolv-tools",
+        "version": "0.6.14",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5e496bfdc84c4b6b9076528d01ffa837"
+      },
+      {
+        "name": "libsqlite3-0",
+        "version": "3.8.10.2",
+        "release": "5.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4011163d31a62520d53b98a417d2ae78"
+      },
+      {
+        "name": "libssh2-1",
+        "version": "1.4.3",
+        "release": "10.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6f909139497c6170b307bd3dfba62aea"
+      },
+      {
+        "name": "libstdc++6",
+        "version": "5.2.1+r226025",
+        "release": "4.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "dd6917616d8419dac960316b4d1b5dd0"
+      },
+      {
+        "name": "libtasn1",
+        "version": "3.7",
+        "release": "10.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "8d4ba27025e4e3697378f3a4ac1fdeb2"
+      },
+      {
+        "name": "libtasn1-6",
+        "version": "3.7",
+        "release": "10.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "1987356b9f5cd5b4e748c353a3452a15"
+      },
+      {
+        "name": "libtirpc1",
+        "version": "0.2.3",
+        "release": "7.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "87af35eb8c5b377e943af42a500665ac"
+      },
+      {
+        "name": "libudev1",
+        "version": "210",
+        "release": "84.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "21294775d0f7c459442da007e602fc46"
+      },
+      {
+        "name": "libusb-0_1-4",
+        "version": "0.1.13",
+        "release": "31.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e0c33d8f1b2124ac4cd406ca02fa26fc"
+      },
+      {
+        "name": "libusb-1_0-0",
+        "version": "1.0.20",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "fe534a1b8543d13afa6ace2ac9ac9fc0"
+      },
+      {
+        "name": "libustr-1_0-1",
+        "version": "1.0.4",
+        "release": "34.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5867189d1be04094b6803055d76fa9ed"
+      },
+      {
+        "name": "libutempter0",
+        "version": "1.1.6",
+        "release": "6.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "725851a15ad68060a1879bc52bc038bd"
+      },
+      {
+        "name": "libuuid1",
+        "version": "2.25",
+        "release": "7.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "763bf8fb1585c384577b3519bd971fd8"
+      },
+      {
+        "name": "libwicked-0-6",
+        "version": "0.6.27",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f063b6ba778b43ba581f683c72bc0a39"
+      },
+      {
+        "name": "libwrap0",
+        "version": "7.6",
+        "release": "885.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4d030beb9444548a64b968cbedbd503a"
+      },
+      {
+        "name": "libx86emu1",
+        "version": "1.5",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4f5294a5f06ceae33e6dcf4553af8c16"
+      },
+      {
+        "name": "libxcb1",
+        "version": "1.11.1",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "68594c8b6d82583fb9b18183b27ed2ed"
+      },
+      {
+        "name": "libxml2-2",
+        "version": "2.9.1",
+        "release": "8.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "dca88cfe4ddad156a8b3ec63340a5d79"
+      },
+      {
+        "name": "libxtables10",
+        "version": "1.4.21",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6686e7170269c59e4241e96f71482bec"
+      },
+      {
+        "name": "libz1",
+        "version": "1.2.8",
+        "release": "6.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "2b0e8459c17ff7c18d7fa603e46d8af8"
+      },
+      {
+        "name": "libzio1",
+        "version": "1.00",
+        "release": "11.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d3bed4bab54ef017f6ec2f7eab2a2eab"
+      },
+      {
+        "name": "libzypp",
+        "version": "15.19.5",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e24a7299bcf72ecfe1b53d1f079b1b22"
+      },
+      {
+        "name": "lvm2",
+        "version": "2.02.120",
+        "release": "62.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "07c47e34c1f7450dd883f713f98dfba3"
+      },
+      {
+        "name": "mozilla-nspr",
+        "version": "4.10.8",
+        "release": "2.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d60f71e6c41b0f8427fbf6f05a7ff859"
+      },
+      {
+        "name": "ncurses-utils",
+        "version": "5.9",
+        "release": "53.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "be7ec4b37a45f3d6203f34be710028d7"
+      },
+      {
+        "name": "netcfg",
+        "version": "11.5",
+        "release": "26.1",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "bd43ad2811d57ebfa714ad917585176c"
+      },
+      {
+        "name": "nfs-client",
+        "version": "1.3.0",
+        "release": "9.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "27c3111ec42452de1c096a8b5cd8406b"
+      },
+      {
+        "name": "nfs-kernel-server",
+        "version": "1.3.0",
+        "release": "9.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "ce51e81bb9bfcbc36a25bf7a6dbedb8d"
+      },
+      {
+        "name": "nfsidmap",
+        "version": "0.25",
+        "release": "7.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e136fa60a9f8a17c1a65bce79399f8eb"
+      },
+      {
+        "name": "openSUSE-build-key",
+        "version": "1.0",
+        "release": "32.2",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "e9b1b6a0acab733785c1917a614bec4c"
+      },
+      {
+        "name": "openSUSE-release",
+        "version": "42.1",
+        "release": "1.46",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "cf9d4736a3f57d1ba2737acce151de88"
+      },
+      {
+        "name": "openSUSE-release-ftp",
+        "version": "42.1",
+        "release": "1.46",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f59b8c889e3be76d2e5cd48386bd769d"
+      },
+      {
+        "name": "openslp",
+        "version": "2.0.0",
+        "release": "8.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "41ac615914d0d4963d1fa7142f5397ac"
+      },
+      {
+        "name": "openssh",
+        "version": "6.6p1",
+        "release": "6.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "77bd1c768d5e18514346e0ce1919ebf8"
+      },
+      {
+        "name": "openssl",
+        "version": "1.0.1i",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c3ae00e7c026622b581cb7c787e862b2"
+      },
+      {
+        "name": "os-prober",
+        "version": "1.61",
+        "release": "13.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "2a5914bf642f1c3dd58b04dbf2f224ff"
+      },
+      {
+        "name": "p11-kit",
+        "version": "0.20.3",
+        "release": "7.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "1a4fbf51e1e7f2ea702b56ac0a5f8629"
+      },
+      {
+        "name": "p11-kit-tools",
+        "version": "0.20.3",
+        "release": "7.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "76e1262aa55518dd9c9aad01d000ea9d"
+      },
+      {
+        "name": "pam",
+        "version": "1.1.8",
+        "release": "12.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "89fb119bc96c58eb8ae36bbfb7c7a9ac"
+      },
+      {
+        "name": "pam-config",
+        "version": "0.88",
+        "release": "3.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4ac861a96312be035c91508616440e42"
+      },
+      {
+        "name": "parted",
+        "version": "3.1",
+        "release": "17.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "78ce8ad64acf97448971662040c08bbe"
+      },
+      {
+        "name": "patterns-openSUSE-base",
+        "version": "20150918",
+        "release": "10.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "535a49dfcc33dc71e5c449a670f5bf0c"
+      },
+      {
+        "name": "perl",
+        "version": "5.18.2",
+        "release": "3.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "fec639f37724b6db5d19ec0e75079874"
+      },
+      {
+        "name": "perl-Bootloader",
+        "version": "0.844",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "8d1f9810985464b3455c08f429c6b1a0"
+      },
+      {
+        "name": "perl-base",
+        "version": "5.18.2",
+        "release": "3.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "70ede2005fd4aea48172f92a53d340c8"
+      },
+      {
+        "name": "permissions",
+        "version": "2014.08.26.1452",
+        "release": "3.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c0dcb6d707f29d97922b2554ab9094c9"
+      },
+      {
+        "name": "pigz",
+        "version": "2.3",
+        "release": "5.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d71f853f036d3f067084141821f4a724"
+      },
+      {
+        "name": "pinentry",
+        "version": "0.8.3",
+        "release": "3.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "4515aba86a21e012b38f235f1e58216e"
+      },
+      {
+        "name": "pkg-config",
+        "version": "0.28",
+        "release": "8.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "0c6e3c89832083f13c3ac8d9eedaec43"
+      },
+      {
+        "name": "polkit",
+        "version": "0.112",
+        "release": "4.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c698acc85baf46a9d53660e712c1d139"
+      },
+      {
+        "name": "polkit-default-privs",
+        "version": "13.2",
+        "release": "8.1",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "7e72805bfa7be325ad3ff2598dcaa0fa"
+      },
+      {
+        "name": "postfix",
+        "version": "2.11.6",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6335d8c84702380157aa4fe41a75b28b"
+      },
+      {
+        "name": "procps",
+        "version": "3.3.9",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "1099d51ad98a72c950bb7a2e265d8ab2"
+      },
+      {
+        "name": "rpcbind",
+        "version": "0.2.1_rc4",
+        "release": "9.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "7fdb3e2ab5f5626a5ecac1007d69a886"
+      },
+      {
+        "name": "rpm",
+        "version": "4.11.2",
+        "release": "6.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c1165f89362d61a7cd5ce3c4c57c0db2"
+      },
+      {
+        "name": "rsync",
+        "version": "3.1.0",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "6e6589c90f073872ca934b5780599a5a"
+      },
+      {
+        "name": "sed",
+        "version": "4.2.2",
+        "release": "6.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d591d4a09e1c8801df91e6fafc6775bd"
+      },
+      {
+        "name": "sg3_utils",
+        "version": "1.41",
+        "release": "6.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "d99c08b0c56c5e7c62de3cb39de45468"
+      },
+      {
+        "name": "shadow",
+        "version": "4.1.5.1",
+        "release": "14.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e675bf8b52ada6b99d1d2782c4907740"
+      },
+      {
+        "name": "shared-mime-info",
+        "version": "1.2",
+        "release": "3.3",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "feff5c41f619f236e2b722c192d2464a"
+      },
+      {
+        "name": "squashfs",
+        "version": "4.3",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "576c75d423e50ebcd6affbd806ef8d06"
+      },
+      {
+        "name": "sudo",
+        "version": "1.8.10p3",
+        "release": "3.8",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "cbad9e70c306d1bde094a0c7b47fc705"
+      },
+      {
+        "name": "suse-module-tools",
+        "version": "12.3",
+        "release": "16.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "74ec43dcfd6f8d0cf2d538b073a4a017"
+      },
+      {
+        "name": "sysconfig",
+        "version": "0.83.8",
+        "release": "5.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "539d89d9bcb2f2a0cb7e39e2b85a66f3"
+      },
+      {
+        "name": "sysconfig-netconfig",
+        "version": "0.83.8",
+        "release": "5.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "a61fe5590444b230c1c9aff63e108fb1"
+      },
+      {
+        "name": "syslinux",
+        "version": "4.04",
+        "release": "34.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c94acd46c7dc72a21380e0f634afbf01"
+      },
+      {
+        "name": "systemd",
+        "version": "210",
+        "release": "84.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "8406d85954619896606bc5cfa867f942"
+      },
+      {
+        "name": "systemd-logger",
+        "version": "210",
+        "release": "84.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "745e68c94c9a1b14dc97ea0a75fd83a4"
+      },
+      {
+        "name": "systemd-presets-branding-openSUSE",
+        "version": "0.3.0",
+        "release": "23.2",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "e6b50b275e529bbeaa09b917eac30a12"
+      },
+      {
+        "name": "systemd-sysvinit",
+        "version": "210",
+        "release": "84.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "2caa2bae61cbae5627162f8eb505cc0e"
+      },
+      {
+        "name": "sysvinit-tools",
+        "version": "2.88+",
+        "release": "97.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "af5d2e1a6a5992d29d124d3b1a89d0da"
+      },
+      {
+        "name": "tar",
+        "version": "1.27.1",
+        "release": "4.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "84c421ba47651f0a38f9cb32fa603b2d"
+      },
+      {
+        "name": "terminfo-base",
+        "version": "5.9",
+        "release": "53.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "cb09a6420e75ebaf4b814caf6b7c600d"
+      },
+      {
+        "name": "time",
+        "version": "1.7",
+        "release": "8.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "97e358055cbc505d87f8afbc4442a5de"
+      },
+      {
+        "name": "udev",
+        "version": "210",
+        "release": "84.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "5bb2181e5953920e9f8824835620a2b4"
+      },
+      {
+        "name": "update-alternatives",
+        "version": "1.16.10",
+        "release": "9.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "2583a577d67e2c8ec2fa9fc84b5dc809"
+      },
+      {
+        "name": "util-linux",
+        "version": "2.25",
+        "release": "7.2",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "fc4f36ccf6e1b915862791d91b00b8bb"
+      },
+      {
+        "name": "util-linux-systemd",
+        "version": "2.25",
+        "release": "7.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "f87f35b663f13a8cefccf876105a128a"
+      },
+      {
+        "name": "vim",
+        "version": "7.4.326",
+        "release": "3.10",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "c62ce9aab34a37677d88017ecd99d958"
+      },
+      {
+        "name": "wallpaper-branding-openSUSE",
+        "version": "42.1",
+        "release": "6.2",
+        "arch": "noarch",
+        "vendor": "openSUSE",
+        "checksum": "28ee7958284becfb2df2edb45b2388a8"
+      },
+      {
+        "name": "which",
+        "version": "2.20",
+        "release": "5.4",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "8a8770b618f1eaed28bc8a96f50b0ed1"
+      },
+      {
+        "name": "wicked",
+        "version": "0.6.27",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "13156ac1272e726120f533e0f61fbd0c"
+      },
+      {
+        "name": "wicked-service",
+        "version": "0.6.27",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "32d7ac64ca424ed626de3e867f7c145a"
+      },
+      {
+        "name": "xz",
+        "version": "5.0.5",
+        "release": "3.5",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "e168e3853561ae5bc9daafe90dac210b"
+      },
+      {
+        "name": "zypper",
+        "version": "1.12.23",
+        "release": "1.1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "8d772eca4a59f14171e715237caee9a1"
+      }
+    ]
+  },
   "patterns": [
     {
       "name": "base",
@@ -2492,7 +2495,7 @@
     ]
   },
   "meta": {
-    "format_version": 5,
+    "format_version": 6,
     "os": {
       "modified": "2015-11-19T16:08:46Z",
       "hostname": "192.168.121.32"

--- a/spec/data/descriptions/opensuse_leap-build/manifest.json
+++ b/spec/data/descriptions/opensuse_leap-build/manifest.json
@@ -9,8 +9,10 @@
     "architecture": "x86_64"
   },
   "packages": {
-    "package_system": "rpm",
-    "packages": [
+    "_attributes": {
+      "package_system": "rpm"
+    },
+    "_elements": [
       {
         "name": "aaa_base",
         "version": "13.2+git20140911.61c1681",

--- a/spec/data/descriptions/validation-error/manifest.json
+++ b/spec/data/descriptions/validation-error/manifest.json
@@ -48,7 +48,7 @@
     ]
   },
   "meta": {
-    "format_version": 5,
+    "format_version": 6,
     "repositories": {
       "modified": "2014-08-29T11:10:03Z",
       "hostname": "192.168.121.56"

--- a/spec/data/descriptions/validation/changed-managed-files-additional-files/manifest.json
+++ b/spec/data/descriptions/validation/changed-managed-files-additional-files/manifest.json
@@ -27,7 +27,7 @@
     ]
   },
   "meta": {
-    "format_version": 5,
+    "format_version": 6,
     "changed_managed_files": {
       "modified": "2014-08-27T18:00:17Z",
       "hostname": "10.122.166.77"

--- a/spec/data/descriptions/validation/changed-managed-files-bad/manifest.json
+++ b/spec/data/descriptions/validation/changed-managed-files-bad/manifest.json
@@ -31,7 +31,7 @@
     ]
   },
   "meta": {
-    "format_version": 5,
+    "format_version": 6,
     "changed_managed_files": {
       "modified": "2014-08-27T18:00:17Z",
       "hostname": "10.122.166.77"

--- a/spec/data/descriptions/validation/changed-managed-files-good/manifest.json
+++ b/spec/data/descriptions/validation/changed-managed-files-good/manifest.json
@@ -79,7 +79,7 @@
     ]
   },
   "meta": {
-    "format_version": 5,
+    "format_version": 6,
     "changed_managed_files": {
       "modified": "2014-08-27T18:00:17Z",
       "hostname": "10.122.166.77"

--- a/spec/data/descriptions/validation/changed-managed-files-unextracted/manifest.json
+++ b/spec/data/descriptions/validation/changed-managed-files-unextracted/manifest.json
@@ -31,7 +31,7 @@
     ]
   },
   "meta": {
-    "format_version": 5,
+    "format_version": 6,
     "changed_managed_files": {
       "modified": "2014-08-27T18:00:17Z",
       "hostname": "10.122.166.77"

--- a/spec/data/descriptions/validation/config-files-additional-files/manifest.json
+++ b/spec/data/descriptions/validation/config-files-additional-files/manifest.json
@@ -28,7 +28,7 @@
     ]
   },
   "meta": {
-    "format_version": 5,
+    "format_version": 6,
     "config_files": {
       "modified": "2014-08-27T18:00:17Z",
       "hostname": "10.122.166.77"

--- a/spec/data/descriptions/validation/config-files-bad/manifest.json
+++ b/spec/data/descriptions/validation/config-files-bad/manifest.json
@@ -32,7 +32,7 @@
     ]
   },
   "meta": {
-    "format_version": 5,
+    "format_version": 6,
     "config_files": {
       "modified": "2014-08-27T18:00:17Z",
       "hostname": "10.122.166.77"

--- a/spec/data/descriptions/validation/config-files-good/manifest.json
+++ b/spec/data/descriptions/validation/config-files-good/manifest.json
@@ -41,7 +41,7 @@
     ]
   },
   "meta": {
-    "format_version": 5,
+    "format_version": 6,
     "config_files": {
       "modified": "2014-08-27T18:00:17Z",
       "hostname": "10.122.166.77"

--- a/spec/data/descriptions/validation/config-files-unextracted/manifest.json
+++ b/spec/data/descriptions/validation/config-files-unextracted/manifest.json
@@ -32,7 +32,7 @@
     ]
   },
   "meta": {
-    "format_version": 5,
+    "format_version": 6,
     "config_files": {
       "modified": "2014-08-27T18:00:17Z",
       "hostname": "10.122.166.77"

--- a/spec/data/descriptions/validation/unmanaged-files-additional-files/manifest.json
+++ b/spec/data/descriptions/validation/unmanaged-files-additional-files/manifest.json
@@ -14,7 +14,7 @@
     ]
   },
   "meta": {
-    "format_version": 5,
+    "format_version": 6,
     "unmanaged_files": {
       "modified": "2014-08-27T18:00:17Z",
       "hostname": "10.122.166.77"

--- a/spec/data/descriptions/validation/unmanaged-files-bad/manifest.json
+++ b/spec/data/descriptions/validation/unmanaged-files-bad/manifest.json
@@ -22,7 +22,7 @@
     ]
   },
   "meta": {
-    "format_version": 5,
+    "format_version": 6,
     "unmanaged_files": {
       "modified": "2014-08-27T18:00:17Z",
       "hostname": "10.122.166.77"

--- a/spec/data/descriptions/validation/unmanaged-files-good/manifest.json
+++ b/spec/data/descriptions/validation/unmanaged-files-good/manifest.json
@@ -46,7 +46,7 @@
     ]
   },
   "meta": {
-    "format_version": 5,
+    "format_version": 6,
     "unmanaged_files": {
       "modified": "2014-08-27T18:00:17Z",
       "hostname": "10.122.166.77"

--- a/spec/data/descriptions/validation/unmanaged-files-unextracted/manifest.json
+++ b/spec/data/descriptions/validation/unmanaged-files-unextracted/manifest.json
@@ -13,7 +13,7 @@
     ]
   },
   "meta": {
-    "format_version": 5,
+    "format_version": 6,
     "unmanaged_files": {
       "modified": "2014-08-27T18:00:17Z",
       "hostname": "10.122.166.77"

--- a/spec/data/schema/faulty_description/manifest.json
+++ b/spec/data/schema/faulty_description/manifest.json
@@ -1,7 +1,9 @@
 {
   "packages": {
-    "package_system": "rpm",
-    "packages": [
+    "_attributes": {
+      "package_system": "rpm"
+    },
+    "_elements": [
       {
         "name": "foo",
         "version": "1.0",

--- a/spec/data/schema/faulty_description/manifest.json
+++ b/spec/data/schema/faulty_description/manifest.json
@@ -1,16 +1,19 @@
 {
-  "packages": [
-    {
-      "name": "foo",
-      "version": "1.0",
-      "release": "1",
-      "arch": "x86_64",
-      "vendor": "openSUSE",
-      "checksum": "Invalid Checksum"
-    }
-  ],
+  "packages": {
+    "package_system": "rpm",
+    "packages": [
+      {
+        "name": "foo",
+        "version": "1.0",
+        "release": "1",
+        "arch": "x86_64",
+        "vendor": "openSUSE",
+        "checksum": "Invalid Checksum"
+      }
+    ]
+  },
   "meta": {
-    "format_version": 5,
+    "format_version": 6,
     "packages": {
       "modified": "2014-08-28T14:07:26Z",
       "hostname": "host.example.com"

--- a/spec/data/schema/valid_description/manifest.json
+++ b/spec/data/schema/valid_description/manifest.json
@@ -5,7 +5,7 @@
     "architecture": "x86_64"
   },
   "meta": {
-    "format_version": 5,
+    "format_version": 6,
     "os": {
       "modified": "2014-08-28T14:07:26Z",
       "hostname": "host.example.com"

--- a/spec/data/schema/validation_error/config_files/deleted_without_changes.json
+++ b/spec/data/schema/validation_error/config_files/deleted_without_changes.json
@@ -15,7 +15,7 @@
     ]
   },
   "meta": {
-    "format_version": 5,
+    "format_version": 6,
     "config_files": {
       "modified": "2014-08-28T15:21:21Z",
       "hostname": "192.168.121.135"

--- a/spec/data/schema/validation_error/config_files/missing_attribute.json
+++ b/spec/data/schema/validation_error/config_files/missing_attribute.json
@@ -18,7 +18,7 @@
     ]
   },
   "meta": {
-    "format_version": 5,
+    "format_version": 6,
     "config_files": {
       "modified": "2014-08-25T14:45:38Z",
       "hostname": "192.168.121.68"

--- a/spec/data/schema/validation_error/config_files/pattern_mismatch.json
+++ b/spec/data/schema/validation_error/config_files/pattern_mismatch.json
@@ -19,7 +19,7 @@
     ]
   },
   "meta": {
-    "format_version": 5,
+    "format_version": 6,
     "config_files": {
       "modified": "2014-08-25T14:45:38Z",
       "hostname": "192.168.121.68"

--- a/spec/data/schema/validation_error/config_files/unknown_status.json
+++ b/spec/data/schema/validation_error/config_files/unknown_status.json
@@ -19,7 +19,7 @@
     ]
   },
   "meta": {
-    "format_version": 5,
+    "format_version": 6,
     "config_files": {
       "modified": "2014-08-25T14:45:38Z",
       "hostname": "192.168.121.68"

--- a/spec/data/schema/validation_error/unmanaged_files/extracted_unknown_type.json
+++ b/spec/data/schema/validation_error/unmanaged_files/extracted_unknown_type.json
@@ -13,7 +13,7 @@
     ]
   },
   "meta": {
-    "format_version": 5,
+    "format_version": 6,
     "unmanaged_files": {
       "modified": "2014-08-25T14:45:38Z",
       "hostname": "192.168.121.68"

--- a/spec/support/system_description_factory.rb
+++ b/spec/support/system_description_factory.rb
@@ -339,14 +339,18 @@ module SystemDescriptionFactory
   EOF
   EXAMPLE_SCOPES["empty_packages"] = <<-EOF.chomp
     "packages": {
-      "package_system": "rpm",
-      "packages": []
+      "_attributes": {
+        "package_system": "rpm"
+      },
+      "_elements": []
     }
   EOF
   EXAMPLE_SCOPES["packages"] = <<-EOF.chomp
     "packages": {
-      "package_system": "rpm",
-      "packages": [
+      "_attributes": {
+        "package_system": "rpm"
+      },
+      "_elements": [
         {
           "name": "bash",
           "version": "4.2",
@@ -376,8 +380,10 @@ module SystemDescriptionFactory
   EOF
   EXAMPLE_SCOPES["packages2"] = <<-EOF.chomp
     "packages": {
-      "package_system": "rpm",
-      "packages": [
+      "_attributes": {
+        "package_system": "rpm"
+      },
+      "_elements": [
         {
           "name": "bash",
           "version": "4.3",

--- a/spec/support/system_description_factory.rb
+++ b/spec/support/system_description_factory.rb
@@ -105,7 +105,7 @@ module SystemDescriptionFactory
 
     json_objects = []
     meta = {
-      format_version: 5
+      format_version: 6
     }
     meta[:filters] = options[:filter_definitions] if options[:filter_definitions]
 
@@ -338,63 +338,72 @@ module SystemDescriptionFactory
     }
   EOF
   EXAMPLE_SCOPES["empty_packages"] = <<-EOF.chomp
-    "packages": []
+    "packages": {
+      "package_system": "rpm",
+      "packages": []
+    }
   EOF
   EXAMPLE_SCOPES["packages"] = <<-EOF.chomp
-    "packages": [
-      {
-        "name": "bash",
-        "version": "4.2",
-        "release": "68.1.5",
-        "arch": "x86_64",
-        "vendor": "openSUSE",
-        "checksum": "533e40ba8a5551204b528c047e45c169"
-      },
-      {
-        "name": "openSUSE-release-dvd",
-        "version": "13.1",
-        "release": "1.10",
-        "arch": "x86_64",
-        "vendor": "SUSE LINUX Products GmbH, Nuernberg, Germany",
-        "checksum": "2a3d5b29179daa1e65e391d0a0c1442d"
-      },
-      {
-        "name": "autofs",
-        "version": "5.0.9",
-        "release": "3.6",
-        "arch": "x86_64",
-        "vendor": "Packman",
-        "checksum": "6d5d012b0e8d33cf93e216dfab6b174e"
-      }
-    ]
+    "packages": {
+      "package_system": "rpm",
+      "packages": [
+        {
+          "name": "bash",
+          "version": "4.2",
+          "release": "68.1.5",
+          "arch": "x86_64",
+          "vendor": "openSUSE",
+          "checksum": "533e40ba8a5551204b528c047e45c169"
+        },
+        {
+          "name": "openSUSE-release-dvd",
+          "version": "13.1",
+          "release": "1.10",
+          "arch": "x86_64",
+          "vendor": "SUSE LINUX Products GmbH, Nuernberg, Germany",
+          "checksum": "2a3d5b29179daa1e65e391d0a0c1442d"
+        },
+        {
+          "name": "autofs",
+          "version": "5.0.9",
+          "release": "3.6",
+          "arch": "x86_64",
+          "vendor": "Packman",
+          "checksum": "6d5d012b0e8d33cf93e216dfab6b174e"
+        }
+      ]
+    }
   EOF
   EXAMPLE_SCOPES["packages2"] = <<-EOF.chomp
-    "packages": [
-      {
-        "name": "bash",
-        "version": "4.3",
-        "release": "68.1.5",
-        "arch": "x86_64",
-        "vendor": "openSUSE",
-        "checksum": "533e40ba8a5551204b528c047e45c169"
-      },
-      {
-        "name": "kernel-desktop",
-        "version": "3.7.10",
-        "release": "1.0",
-        "arch": "i586",
-        "vendor": "openSUSE",
-        "checksum": "4a87f6b9ceae5d40a411fe52d0f17050"
-      },
-      {
-        "name": "autofs",
-        "version": "5.0.9",
-        "release": "3.6",
-        "arch": "x86_64",
-        "vendor": "Packman",
-        "checksum": "6d5d012b0e8d33cf93e216dfab6b174e"
-      }
-    ]
+    "packages": {
+      "package_system": "rpm",
+      "packages": [
+        {
+          "name": "bash",
+          "version": "4.3",
+          "release": "68.1.5",
+          "arch": "x86_64",
+          "vendor": "openSUSE",
+          "checksum": "533e40ba8a5551204b528c047e45c169"
+        },
+        {
+          "name": "kernel-desktop",
+          "version": "3.7.10",
+          "release": "1.0",
+          "arch": "i586",
+          "vendor": "openSUSE",
+          "checksum": "4a87f6b9ceae5d40a411fe52d0f17050"
+        },
+        {
+          "name": "autofs",
+          "version": "5.0.9",
+          "release": "3.6",
+          "arch": "x86_64",
+          "vendor": "Packman",
+          "checksum": "6d5d012b0e8d33cf93e216dfab6b174e"
+        }
+      ]
+    }
   EOF
   EXAMPLE_SCOPES["empty_patterns"] = <<-EOF.chomp
     "patterns": [ ]

--- a/spec/unit/array_spec.rb
+++ b/spec/unit/array_spec.rb
@@ -35,28 +35,60 @@ describe Machinery::Array do
   }
 
   describe "#from_json" do
-    it "delegates to specialized class when the element class is set" do
-      json_object = [
-        { a: 1 },
-        { b: 2 }
-      ]
+    describe "plain arrays" do
+      it "delegates to specialized class when the element class is set" do
+        json_object = [
+          { a: 1 },
+          { b: 2 }
+        ]
 
-      array = ArrayExampleArray.from_json(json_object)
-      expect(array[0]).to eq(ArrayExampleObject.new(a: 1))
-      expect(array[1]).to eq(ArrayExampleObject.new(b: 2))
+        array = ArrayExampleArray.from_json(json_object)
+        expect(array[0]).to eq(ArrayExampleObject.new(a: 1))
+        expect(array[1]).to eq(ArrayExampleObject.new(b: 2))
+      end
+
+      it "uses generic classes when no element class is set" do
+        json_object = [1, {2 => "2"}, [3, "3"]]
+
+        expected = Machinery::Array.new(
+          [
+            1,
+            Machinery::Object.new(2 => "2"),
+            Machinery::Array.new([3, "3"])
+          ]
+        )
+        expect(Machinery::Array.from_json(json_object)).to eq(expected)
+      end
     end
 
-    it "uses generic classes when no element class is set" do
-      json_object = [1, {2 => "2"}, [3, "3"]]
+    describe "complex arrays" do
+      let(:array) {
+        json_object = {
+          "_attributes" => {
+            "foo" => "bar"
+          },
+          "_elements" => [
+            1,
+            2,
+            {
+              "_attributes" => {},
+              "_elements" => [ 1 ]
+            }
+          ]
+        }
 
-      expected = Machinery::Array.new(
-        [
-          1,
-          Machinery::Object.new(2 => "2"),
-          Machinery::Array.new([3, "3"])
-        ]
-      )
-      expect(Machinery::Array.from_json(json_object)).to eq(expected)
+        Machinery::Array.from_json(json_object)
+      }
+
+      it "makes the elements available as the payload" do
+        expect(array.first).to eq(1)
+        expect(array[1]).to eq(2)
+        expect(array[2]).to eq(Machinery::Array.new([1]))
+      end
+
+      it "makes the attributes available on the array object" do
+        expect(array.foo).to eq("bar")
+      end
     end
   end
 
@@ -134,10 +166,24 @@ describe Machinery::Array do
     it "serializes all objects to native ruby objects" do
       embedded_array = ArrayExampleArray.new([json_element_a])
       embedded_object = Machinery::Object.new(json_element_b)
-      array = Machinery::Array.new([1, embedded_array, embedded_object])
+      array = Machinery::Array.new([1, embedded_array, embedded_object], foo: "bar")
 
       result = array.as_json
-      expect(result).to eq([1, ["a" => 1], { "b" => 2 }])
+      expect(result).to eq(
+        {
+          "_attributes" => {
+            foo: "bar"
+          },
+          "_elements" => [
+            1,
+            {
+              "_attributes" => {},
+              "_elements" => [ "a" => 1 ]
+            },
+            { "b" => 2 }
+          ]
+        }
+      )
     end
   end
 

--- a/spec/unit/array_spec.rb
+++ b/spec/unit/array_spec.rb
@@ -20,7 +20,7 @@ require_relative "spec_helper"
 describe Machinery::Array do
   class ArrayExampleObject < Machinery::Object; end
   class ArrayExampleArray < Machinery::Array
-    has_properties :foo, :bar
+    has_attributes :foo, :bar
     has_elements class: ArrayExampleObject
   end
 

--- a/spec/unit/array_spec.rb
+++ b/spec/unit/array_spec.rb
@@ -48,7 +48,7 @@ describe Machinery::Array do
       end
 
       it "uses generic classes when no element class is set" do
-        json_object = [1, {2 => "2"}, [3, "3"]]
+        json_object = [1, { 2 => "2" }, [3, "3"]]
 
         expected = Machinery::Array.new(
           [
@@ -72,7 +72,7 @@ describe Machinery::Array do
             2,
             {
               "_attributes" => {},
-              "_elements" => [ 1 ]
+              "_elements" => [1]
             }
           ]
         }
@@ -170,19 +170,17 @@ describe Machinery::Array do
 
       result = array.as_json
       expect(result).to eq(
-        {
-          "_attributes" => {
-            foo: "bar"
+        "_attributes" => {
+          foo: "bar"
+        },
+        "_elements" => [
+          1,
+          {
+            "_attributes" => {},
+            "_elements" => ["a" => 1]
           },
-          "_elements" => [
-            1,
-            {
-              "_attributes" => {},
-              "_elements" => [ "a" => 1 ]
-            },
-            { "b" => 2 }
-          ]
-        }
+          { "b" => 2 }
+        ]
       )
     end
   end

--- a/spec/unit/compare_task_spec.rb
+++ b/spec/unit/compare_task_spec.rb
@@ -380,8 +380,10 @@ EOT
       system_description1 = create_test_description(json: <<-EOT, name: "one")
         {
           "packages": {
-            "package_system": "rpm",
-            "packages": [
+            "_attributes": {
+              "package_system": "rpm"
+            },
+            "_elements": [
               {
                 "name": "bash",
                 "version": "4.2",
@@ -406,8 +408,10 @@ EOT
       system_description2 = create_test_description(json: <<-EOT, name: "two")
         {
           "packages": {
-            "package_system": "rpm",
-            "packages": [
+            "_attributes": {
+              "package_system": "rpm"
+            },
+            "_elements": [
               {
                 "name": "bash",
                 "version": "4.2",
@@ -438,8 +442,10 @@ EOT
       system_description1 = create_test_description(json: <<-EOT, name: "one")
         {
           "packages": {
-            "package_system": "rpm",
-            "packages": [
+            "_attributes": {
+              "package_system": "rpm"
+            },
+            "_elements": [
               {
                 "name": "bash",
                 "version": "4.2",
@@ -464,8 +470,10 @@ EOT
       system_description2 = create_test_description(json: <<-EOT, name: "two")
         {
           "packages": {
-            "package_system": "rpm",
-            "packages": [
+            "_attributes": {
+              "package_system": "rpm"
+            },
+            "_elements": [
               {
                 "name": "bash",
                 "version": "4.2",
@@ -494,6 +502,7 @@ In both with different attributes ('one' <> 'two'):
   * kernel (version: 3 <> 4)
 
 EOT
+
       output = CompareTask.new.render_comparison(system_description1,
         system_description2, ["packages"])
 

--- a/spec/unit/compare_task_spec.rb
+++ b/spec/unit/compare_task_spec.rb
@@ -379,39 +379,45 @@ EOT
     it "shows that a package has been added to a list" do
       system_description1 = create_test_description(json: <<-EOT, name: "one")
         {
-          "packages": [
-             {
-               "name": "bash",
-               "version": "4.2",
-               "release": "68.1.5",
-               "arch": "x86_64",
-               "vendor": "openSUSE",
-               "checksum": "2a3d5b29179daa1e65e391d0a0c1442d"
-             },
-             {
-               "name": "kernel",
-               "version": "3",
-               "release": "1",
-               "arch": "x86_64",
-               "vendor": "openSUSE",
-               "checksum": "7dfdd742a9b7d60c75bf4844d294716d"
-             }
-           ]
+          "packages": {
+            "package_system": "rpm",
+            "packages": [
+              {
+                "name": "bash",
+                "version": "4.2",
+                "release": "68.1.5",
+                "arch": "x86_64",
+                "vendor": "openSUSE",
+                "checksum": "2a3d5b29179daa1e65e391d0a0c1442d"
+              },
+              {
+                "name": "kernel",
+                "version": "3",
+                "release": "1",
+                "arch": "x86_64",
+                "vendor": "openSUSE",
+                "checksum": "7dfdd742a9b7d60c75bf4844d294716d"
+              }
+            ]
+          }
         }
       EOT
 
       system_description2 = create_test_description(json: <<-EOT, name: "two")
         {
-          "packages": [
-             {
-               "name": "bash",
-               "version": "4.2",
-               "release": "68.1.5",
-               "arch": "x86_64",
-               "vendor": "openSUSE",
-               "checksum": "2a3d5b29179daa1e65e391d0a0c1442d"
-             }
-           ]
+          "packages": {
+            "package_system": "rpm",
+            "packages": [
+              {
+                "name": "bash",
+                "version": "4.2",
+                "release": "68.1.5",
+                "arch": "x86_64",
+                "vendor": "openSUSE",
+                "checksum": "2a3d5b29179daa1e65e391d0a0c1442d"
+              }
+            ]
+          }
         }
       EOT
 
@@ -431,47 +437,53 @@ EOT
     it "shows that a package has been changed in a list" do
       system_description1 = create_test_description(json: <<-EOT, name: "one")
         {
-          "packages": [
-             {
-               "name": "bash",
-               "version": "4.2",
-               "release": "68.1.5",
-               "arch": "x86_64",
-               "vendor": "openSUSE",
-               "checksum": "2a3d5b29179daa1e65e391d0a0c1442d"
-             },
-             {
-               "name": "kernel",
-               "version": "3",
-               "release": "1",
-               "arch": "x86_64",
-               "vendor": "openSUSE",
-               "checksum": "7dfdd742a9b7d60c75bf4844d294716d"
-             }
-           ]
+          "packages": {
+            "package_system": "rpm",
+            "packages": [
+              {
+                "name": "bash",
+                "version": "4.2",
+                "release": "68.1.5",
+                "arch": "x86_64",
+                "vendor": "openSUSE",
+                "checksum": "2a3d5b29179daa1e65e391d0a0c1442d"
+              },
+              {
+                "name": "kernel",
+                "version": "3",
+                "release": "1",
+                "arch": "x86_64",
+                "vendor": "openSUSE",
+                "checksum": "7dfdd742a9b7d60c75bf4844d294716d"
+              }
+            ]
+          }
         }
       EOT
 
       system_description2 = create_test_description(json: <<-EOT, name: "two")
         {
-          "packages": [
-             {
-               "name": "bash",
-               "version": "4.2",
-               "release": "68.1.5",
-               "arch": "x86_64",
-               "vendor": "openSUSE",
-               "checksum": "2a3d5b29179daa1e65e391d0a0c1442d"
-             },
-             {
-               "name": "kernel",
-               "version": "4",
-               "release": "1",
-               "arch": "x86_64",
-               "vendor": "openSUSE",
-               "checksum": "7dfdd742a9b7d60c75bf4844d294716d"
-             }
-           ]
+          "packages": {
+            "package_system": "rpm",
+            "packages": [
+              {
+                "name": "bash",
+                "version": "4.2",
+                "release": "68.1.5",
+                "arch": "x86_64",
+                "vendor": "openSUSE",
+                "checksum": "2a3d5b29179daa1e65e391d0a0c1442d"
+              },
+              {
+                "name": "kernel",
+                "version": "4",
+                "release": "1",
+                "arch": "x86_64",
+                "vendor": "openSUSE",
+                "checksum": "7dfdd742a9b7d60c75bf4844d294716d"
+              }
+            ]
+          }
         }
       EOT
 

--- a/spec/unit/comparison_spec.rb
+++ b/spec/unit/comparison_spec.rb
@@ -38,8 +38,7 @@ describe Comparison do
       let(:result) { subject.compare_scope(description1, description2, "packages") }
       let(:expected_only_in1) {
         PackagesScope.new(
-          package_system: "rpm",
-          packages: PackageList.new([
+          [
             Package.new(
               name: "openSUSE-release-dvd",
               version: "13.1",
@@ -48,13 +47,13 @@ describe Comparison do
               vendor: "SUSE LINUX Products GmbH, Nuernberg, Germany",
               checksum: "2a3d5b29179daa1e65e391d0a0c1442d"
             )
-          ])
+          ],
+          package_system: "rpm"
         )
       }
       let(:expected_only_in2) {
         PackagesScope.new(
-          package_system: "rpm",
-          packages: PackageList.new([
+          [
             Package.new(
               name: "kernel-desktop",
               version: "3.7.10",
@@ -63,13 +62,13 @@ describe Comparison do
               vendor: "openSUSE",
               checksum: "4a87f6b9ceae5d40a411fe52d0f17050"
             )
-          ])
+          ],
+          package_system: "rpm"
         )
       }
       let(:expected_common) {
         PackagesScope.new(
-          package_system: "rpm",
-          packages: PackageList.new([
+          [
             Package.new(
               name: "autofs",
               version: "5.0.9",
@@ -78,7 +77,8 @@ describe Comparison do
               vendor: "Packman",
               checksum: "6d5d012b0e8d33cf93e216dfab6b174e"
             )
-          ])
+          ],
+          package_system: "rpm"
         )
       }
 

--- a/spec/unit/comparison_spec.rb
+++ b/spec/unit/comparison_spec.rb
@@ -38,7 +38,8 @@ describe Comparison do
       let(:result) { subject.compare_scope(description1, description2, "packages") }
       let(:expected_only_in1) {
         PackagesScope.new(
-          [
+          package_system: "rpm",
+          packages: PackageList.new([
             Package.new(
               name: "openSUSE-release-dvd",
               version: "13.1",
@@ -47,12 +48,13 @@ describe Comparison do
               vendor: "SUSE LINUX Products GmbH, Nuernberg, Germany",
               checksum: "2a3d5b29179daa1e65e391d0a0c1442d"
             )
-          ]
+          ])
         )
       }
       let(:expected_only_in2) {
         PackagesScope.new(
-          [
+          package_system: "rpm",
+          packages: PackageList.new([
             Package.new(
               name: "kernel-desktop",
               version: "3.7.10",
@@ -61,12 +63,13 @@ describe Comparison do
               vendor: "openSUSE",
               checksum: "4a87f6b9ceae5d40a411fe52d0f17050"
             )
-          ]
+          ])
         )
       }
       let(:expected_common) {
         PackagesScope.new(
-          [
+          package_system: "rpm",
+          packages: PackageList.new([
             Package.new(
               name: "autofs",
               version: "5.0.9",
@@ -75,7 +78,7 @@ describe Comparison do
               vendor: "Packman",
               checksum: "6d5d012b0e8d33cf93e216dfab6b174e"
             )
-          ]
+          ])
         )
       }
 

--- a/spec/unit/migration_spec.rb
+++ b/spec/unit/migration_spec.rb
@@ -49,12 +49,18 @@ describe Migration do
     )
     stub_const(
       "Migrate5To6", Class.new(Migration) do
+        desc "Migrate version 5 to 6"
+        def migrate; end
+      end
+    )
+    stub_const(
+      "Migrate6To7", Class.new(Migration) do
         # Bad migration, it does not describe its purpose.
         def migrate; end
       end
     )
 
-    stub_const("SystemDescription::CURRENT_FORMAT_VERSION", 5)
+    stub_const("SystemDescription::CURRENT_FORMAT_VERSION", 6)
     stub_const("Machinery::DEFAULT_CONFIG_DIR", store.base_path)
     1.upto(SystemDescription::CURRENT_FORMAT_VERSION).each do |version|
       store_raw_description("v#{version}_description", <<-EOF)
@@ -111,9 +117,10 @@ describe Migration do
       expect_any_instance_of(Migrate2To3).to_not receive(:migrate)
       expect_any_instance_of(Migrate3To4).to_not receive(:migrate)
       expect_any_instance_of(Migrate4To5).to_not receive(:migrate)
+      expect_any_instance_of(Migrate5To6).to_not receive(:migrate)
 
-      Migration.migrate_description(store, "v5_description")
-      description = SystemDescription.load("v5_description", store)
+      Migration.migrate_description(store, "v6_description")
+      description = SystemDescription.load("v6_description", store)
       expect(description.format_version).to eq(SystemDescription::CURRENT_FORMAT_VERSION)
       expect(captured_machinery_output).to include("No upgrade necessary")
     end
@@ -133,10 +140,10 @@ describe Migration do
     end
 
     it "refuses to run migrations without a migration_desc" do
-      stub_const("SystemDescription::CURRENT_FORMAT_VERSION", 6)
+      stub_const("SystemDescription::CURRENT_FORMAT_VERSION", 7)
       expect {
-        Migration.migrate_description(store, "v5_description")
-      }.to raise_error(Machinery::Errors::MigrationError, /Invalid migration 'Migrate5To6'/)
+        Migration.migrate_description(store, "v6_description")
+      }.to raise_error(Machinery::Errors::MigrationError, /Invalid migration 'Migrate6To7'/)
     end
 
     it "deletes the backup if the migration failed" do

--- a/spec/unit/migrations/migrate5to6_spec.rb
+++ b/spec/unit/migrations/migrate5to6_spec.rb
@@ -65,11 +65,13 @@ describe Migrate5To6 do
 
   describe "packages" do
     it "adds the 'package_system' attribute" do
-      expect(description_hash["packages"]["package_system"]).to eq("rpm")
+      expect(description_hash["packages"]["_attributes"]["package_system"]).to eq("rpm")
     end
 
     it "moves the packages to packages" do
-      package_names = description_hash["packages"]["packages"].map { |package| package["name"] }
+      package_names = description_hash["packages"]["_elements"].map do |package|
+        package["name"]
+      end
       expect(package_names).to eq(["aaa_base", "adjtimex", "autofs"])
     end
   end

--- a/spec/unit/migrations/migrate5to6_spec.rb
+++ b/spec/unit/migrations/migrate5to6_spec.rb
@@ -1,0 +1,76 @@
+# Copyright (c) 2013-2014 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
+require_relative "../spec_helper"
+require File.join(Machinery::ROOT, "schema/migrations/migrate5to6.rb")
+
+describe Migrate5To6 do
+  initialize_system_description_factory_store
+
+  let(:description_hash) {
+    JSON.parse(<<-EOT)
+      {
+        "packages": [
+          {
+            "name": "aaa_base",
+            "version": "13.1",
+            "release": "16.17.1",
+            "arch": "x86_64",
+            "vendor": "openSUSE",
+            "checksum": "542cc67d16b48ea0c37b32dfb02d913c"
+          },
+          {
+            "name": "adjtimex",
+            "version": "1.29",
+            "release": "2.1.2",
+            "arch": "x86_64",
+            "vendor": "openSUSE",
+            "checksum": "6fe8798263f38820e050b3912f41b2a4"
+          },
+          {
+            "name": "autofs",
+            "version": "5.0.7",
+            "release": "19.1.1",
+            "arch": "x86_64",
+            "vendor": "openSUSE",
+            "checksum": "4db96ab66a6398ae27ee24eb793659dd"
+          }
+        ],
+        "meta": {
+          "format_version": 5
+        }
+      }
+    EOT
+  }
+  let(:description_base) { system_description_factory_store.description_path("description") }
+
+  before(:each) do
+    migration = Migrate5To6.new(description_hash, description_base)
+    migration.migrate
+  end
+
+  describe "packages" do
+    it "adds the 'package_system' attribute" do
+      expect(description_hash["packages"]["package_system"]).to eq("rpm")
+    end
+
+    it "moves the packages to packages" do
+      package_names = description_hash["packages"]["packages"].map { |package| package["name"] }
+      expect(package_names).to eq(["aaa_base", "adjtimex", "autofs"])
+    end
+  end
+end

--- a/spec/unit/models/packages_model_spec.rb
+++ b/spec/unit/models/packages_model_spec.rb
@@ -25,10 +25,11 @@ describe "packages model" do
 
   it_behaves_like "Scope"
 
-  specify { expect(scope.packages.first).to be_a(Package) }
+  specify { expect(scope.first).to be_a(Package) }
 
   it "has correct scope name" do
     expect(PackagesScope.new.scope_name).to eq("packages")
+
   end
 
   describe "#compare_with" do
@@ -36,8 +37,10 @@ describe "packages model" do
       create_test_description(json: <<-EOF, name: "description1")
         {
           "packages": {
-            "package_system": "rpm",
-            "packages": [
+            "_attributes": {
+              "package_system": "rpm"
+            },
+            "_elements": [
               {
                 "name": "bash",
                 "version": "4.2",
@@ -95,8 +98,10 @@ describe "packages model" do
       create_test_description(json: <<-EOF, name: "description2")
         {
           "packages": {
-            "package_system": "rpm",
-            "packages": [
+            "_attributes": {
+              "package_system": "rpm"
+            },
+            "_elements": [
               {
                 "name": "bash2",
                 "version": "4.2",
@@ -153,11 +158,11 @@ describe "packages model" do
     let(:comparison) { description1.packages.compare_with(description2.packages) }
 
     it "detects packages only in description1" do
-      expect(comparison[0].packages.map(&:name)).to eq(["bash"])
+      expect(comparison[0].map(&:name)).to eq(["bash"])
     end
 
     it "detects packages only in description1" do
-      expect(comparison[1].packages.map(&:name)).to eq(["bash2"])
+      expect(comparison[1].map(&:name)).to eq(["bash2"])
     end
 
     it "detects changed packages" do
@@ -185,7 +190,7 @@ describe "packages model" do
     end
 
     it "detects packages in both" do
-      expect(comparison[3].packages.map(&:name)).to eq(["konsole"])
+      expect(comparison[3].map(&:name)).to eq(["konsole"])
     end
   end
 end

--- a/spec/unit/models/packages_model_spec.rb
+++ b/spec/unit/models/packages_model_spec.rb
@@ -25,7 +25,7 @@ describe "packages model" do
 
   it_behaves_like "Scope"
 
-  specify { expect(scope.first).to be_a(Package) }
+  specify { expect(scope.packages.first).to be_a(Package) }
 
   it "has correct scope name" do
     expect(PackagesScope.new.scope_name).to eq("packages")
@@ -35,123 +35,129 @@ describe "packages model" do
     let(:description1) {
       create_test_description(json: <<-EOF, name: "description1")
         {
-          "packages": [
-            {
-              "name": "bash",
-              "version": "4.2",
-              "release": "1.0",
-              "arch": "x86_64",
-              "vendor": "openSUSE",
-              "checksum": "7dfdd742a9b7d60c75bf4844d294716d"
-            },
-            {
-              "name": "kernel-desktop",
-              "version": "3.7.10",
-              "release": "1.0",
-              "arch": "i586",
-              "vendor": "openSUSE",
-              "checksum": "4a87f6b9ceae5d40a411fe52d0f17050"
-            },
-            {
-              "name": "autofs",
-              "version": "5.0.9",
-              "release": "3.6",
-              "arch": "x86_64",
-              "vendor": "openSUSE",
-              "checksum": "6d5d012b0e8d33cf93e216dfab6b174e"
-            },
-            {
-              "name": "btrfsprogs",
-              "version": "3.16",
-              "release": "4.1",
-              "arch": "x86_64",
-              "vendor": "openSUSE",
-              "checksum": "db96018161193aaa42ee8cd1234247f9"
-            },
-            {
-              "name": "cpio",
-              "version": "2.11",
-              "release": "26.182",
-              "arch": "x86_64",
-              "vendor": "SUSE LLC <https://www.suse.com/>",
-              "checksum": "091d486ab725d7542933b74f9b3204e4"
-            },
-            {
-              "name": "konsole",
-              "version": "5.1",
-              "release": "1.1",
-              "arch": "x86_64",
-              "vendor": "SUSE LLC <https://www.suse.com/>",
-              "checksum": "091d486ab725d7542933b74f9b3204e4"
-            }
-          ]
+          "packages": {
+            "package_system": "rpm",
+            "packages": [
+              {
+                "name": "bash",
+                "version": "4.2",
+                "release": "1.0",
+                "arch": "x86_64",
+                "vendor": "openSUSE",
+                "checksum": "7dfdd742a9b7d60c75bf4844d294716d"
+              },
+              {
+                "name": "kernel-desktop",
+                "version": "3.7.10",
+                "release": "1.0",
+                "arch": "i586",
+                "vendor": "openSUSE",
+                "checksum": "4a87f6b9ceae5d40a411fe52d0f17050"
+              },
+              {
+                "name": "autofs",
+                "version": "5.0.9",
+                "release": "3.6",
+                "arch": "x86_64",
+                "vendor": "openSUSE",
+                "checksum": "6d5d012b0e8d33cf93e216dfab6b174e"
+              },
+              {
+                "name": "btrfsprogs",
+                "version": "3.16",
+                "release": "4.1",
+                "arch": "x86_64",
+                "vendor": "openSUSE",
+                "checksum": "db96018161193aaa42ee8cd1234247f9"
+              },
+              {
+                "name": "cpio",
+                "version": "2.11",
+                "release": "26.182",
+                "arch": "x86_64",
+                "vendor": "SUSE LLC <https://www.suse.com/>",
+                "checksum": "091d486ab725d7542933b74f9b3204e4"
+              },
+              {
+                "name": "konsole",
+                "version": "5.1",
+                "release": "1.1",
+                "arch": "x86_64",
+                "vendor": "SUSE LLC <https://www.suse.com/>",
+                "checksum": "091d486ab725d7542933b74f9b3204e4"
+              }
+            ]
+          }
         }
       EOF
     }
     let(:description2) {
       create_test_description(json: <<-EOF, name: "description2")
         {
-          "packages": [
-            {
-              "name": "bash2",
-              "version": "4.2",
-              "release": "1.0",
-              "arch": "x86_64",
-              "vendor": "openSUSE",
-              "checksum": "7dfdd742a9b7d60c75bf4844d294716d"
-            },
-            {
-              "name": "kernel-desktop",
-              "version": "3.7.11",
-              "release": "1.0",
-              "arch": "i586",
-              "vendor": "openSUSE",
-              "checksum": "4a87f6b9ceae5d40a411fe52d0f17050"
-            },
-            {
-              "name": "autofs",
-              "version": "5.0.9",
-              "release": "3.6",
-              "arch": "x86_64",
-              "vendor": "Packman",
-              "checksum": "6d5d012b0e8d33cf93e216dfab6b174e"
-            },
-            {
-              "name": "btrfsprogs",
-              "version": "3.18",
-              "release": "4.1",
-              "arch": "x86_64",
-              "vendor": "Packman",
-              "checksum": "db96018161193aaa42ee8cd1234247f9"
-            },
-            {
-              "name": "cpio",
-              "version": "2.11",
-              "release": "26.184",
-              "arch": "x86_64",
-              "vendor": "SUSE LLC <https://www.suse.com/>",
-              "checksum": "091d486ab725d7542933b74f9b3204e4"
-            },
-            {
-              "name": "konsole",
-              "version": "5.1",
-              "release": "1.1",
-              "arch": "x86_64",
-              "vendor": "SUSE LLC <https://www.suse.com/>",
-              "checksum": "091d486ab725d7542933b74f9b3204e4"
-            }
-          ]
+          "packages": {
+            "package_system": "rpm",
+            "packages": [
+              {
+                "name": "bash2",
+                "version": "4.2",
+                "release": "1.0",
+                "arch": "x86_64",
+                "vendor": "openSUSE",
+                "checksum": "7dfdd742a9b7d60c75bf4844d294716d"
+              },
+              {
+                "name": "kernel-desktop",
+                "version": "3.7.11",
+                "release": "1.0",
+                "arch": "i586",
+                "vendor": "openSUSE",
+                "checksum": "4a87f6b9ceae5d40a411fe52d0f17050"
+              },
+              {
+                "name": "autofs",
+                "version": "5.0.9",
+                "release": "3.6",
+                "arch": "x86_64",
+                "vendor": "Packman",
+                "checksum": "6d5d012b0e8d33cf93e216dfab6b174e"
+              },
+              {
+                "name": "btrfsprogs",
+                "version": "3.18",
+                "release": "4.1",
+                "arch": "x86_64",
+                "vendor": "Packman",
+                "checksum": "db96018161193aaa42ee8cd1234247f9"
+              },
+              {
+                "name": "cpio",
+                "version": "2.11",
+                "release": "26.184",
+                "arch": "x86_64",
+                "vendor": "SUSE LLC <https://www.suse.com/>",
+                "checksum": "091d486ab725d7542933b74f9b3204e4"
+              },
+              {
+                "name": "konsole",
+                "version": "5.1",
+                "release": "1.1",
+                "arch": "x86_64",
+                "vendor": "SUSE LLC <https://www.suse.com/>",
+                "checksum": "091d486ab725d7542933b74f9b3204e4"
+              }
+            ]
+          }
         }
       EOF
     }
     let(:comparison) { description1.packages.compare_with(description2.packages) }
 
     it "detects packages only in description1" do
-      expect(comparison[0].map(&:name)).to eq(["bash"])
+      expect(comparison[0].packages.map(&:name)).to eq(["bash"])
     end
 
     it "detects packages only in description1" do
-      expect(comparison[1].map(&:name)).to eq(["bash2"])
+      expect(comparison[1].packages.map(&:name)).to eq(["bash2"])
     end
 
     it "detects changed packages" do
@@ -179,7 +185,7 @@ describe "packages model" do
     end
 
     it "detects packages in both" do
-      expect(comparison[3].map(&:name)).to eq(["konsole"])
+      expect(comparison[3].packages.map(&:name)).to eq(["konsole"])
     end
   end
 end

--- a/spec/unit/object_spec.rb
+++ b/spec/unit/object_spec.rb
@@ -91,13 +91,18 @@ describe Machinery::Object do
       json_object = {
         a: 1,
         b: {2 => "2"},
-        c: [3, "3"]
+        c: [3, "3"],
+        d: {
+          "_attributes" => {},
+          "_elements" => [ 1 ]
+        }
       }
 
       expected = Machinery::Object.new(
         a: 1,
         b: Machinery::Object.new(2 => "2"),
-        c: Machinery::Array.new([3, "3"])
+        c: Machinery::Array.new([3, "3"]),
+        d: Machinery::Array.new([1])
       )
       expect(Machinery::Object.from_json(json_object)).to eq(expected)
     end
@@ -131,8 +136,8 @@ describe Machinery::Object do
 
       result = object.as_json
       expected = {
-        "a" => ["a"],
-        "b" => {"b" => "b"},
+        "a" => { "_attributes" => {}, "_elements" => [ "a" ] },
+        "b" => { "b" => "b" },
         "c" => 1
       }
       expect(result).to eq(expected)

--- a/spec/unit/object_spec.rb
+++ b/spec/unit/object_spec.rb
@@ -94,7 +94,7 @@ describe Machinery::Object do
         c: [3, "3"],
         d: {
           "_attributes" => {},
-          "_elements" => [ 1 ]
+          "_elements" => [1]
         }
       }
 
@@ -136,7 +136,7 @@ describe Machinery::Object do
 
       result = object.as_json
       expected = {
-        "a" => { "_attributes" => {}, "_elements" => [ "a" ] },
+        "a" => { "_attributes" => {}, "_elements" => ["a"] },
         "b" => { "b" => "b" },
         "c" => 1
       }

--- a/spec/unit/packages_inspector_spec.rb
+++ b/spec/unit/packages_inspector_spec.rb
@@ -38,8 +38,7 @@ EOF
   }
   let(:expected_packages) {
     PackagesScope.new(
-      package_system: "rpm",
-      packages: [
+      [
         Package.new(
           name: "rpm",
           version: "4.11.1",
@@ -56,7 +55,8 @@ EOF
           vendor: "openSUSE",
           checksum: "4a87f6b9ceae5d40a411fe52d0f17050"
         )
-      ]
+      ],
+      package_system: "rpm"
     )
   }
   let(:rpm_command) {
@@ -92,7 +92,7 @@ EOF
   end
 
   it "returns sorted data" do
-    names = inspect_data.packages.map(&:name)
+    names = inspect_data.map(&:name)
     expect(names).to eq(names.sort)
   end
 end

--- a/spec/unit/packages_inspector_spec.rb
+++ b/spec/unit/packages_inspector_spec.rb
@@ -38,7 +38,8 @@ EOF
   }
   let(:expected_packages) {
     PackagesScope.new(
-      [
+      package_system: "rpm",
+      packages: [
         Package.new(
           name: "rpm",
           version: "4.11.1",
@@ -91,7 +92,7 @@ EOF
   end
 
   it "returns sorted data" do
-    names = inspect_data.map(&:name)
+    names = inspect_data.packages.map(&:name)
     expect(names).to eq(names.sort)
   end
 end

--- a/spec/unit/packages_renderer_spec.rb
+++ b/spec/unit/packages_renderer_spec.rb
@@ -22,8 +22,10 @@ describe PackagesRenderer do
     create_test_description(json: <<-EOF)
       {
         "packages": {
-          "package_system": "rpm",
-          "packages": [
+          "_attributes": {
+            "package_system": "rpm"
+          },
+          "_elements": [
             {
               "name": "bash",
               "version": "4.2",
@@ -70,8 +72,10 @@ describe PackagesRenderer do
       create_test_description(json: <<-EOF, name: "description1")
         {
           "packages": {
-            "package_system": "rpm",
-            "packages": [
+            "_attributes": {
+              "package_system": "rpm"
+            },
+            "_elements": [
               {
                 "name": "bash",
                 "version": "4.2",
@@ -121,8 +125,10 @@ describe PackagesRenderer do
       create_test_description(json: <<-EOF, name: "description2")
         {
           "packages": {
-            "package_system": "rpm",
-            "packages": [
+            "_attributes": {
+              "package_system": "rpm"
+            },
+            "_elements": [
               {
                 "name": "bash2",
                 "version": "4.2",

--- a/spec/unit/packages_renderer_spec.rb
+++ b/spec/unit/packages_renderer_spec.rb
@@ -21,24 +21,27 @@ describe PackagesRenderer do
   let(:system_description) {
     create_test_description(json: <<-EOF)
       {
-        "packages": [
-          {
-            "name": "bash",
-            "version": "4.2",
-            "release": "1.0",
-            "arch": "x86_64",
-            "vendor": "openSUSE",
-            "checksum": "7dfdd742a9b7d60c75bf4844d294716d"
-          },
-          {
-            "name": "kernel-desktop",
-            "version": "3.7.10",
-            "release": "1.0",
-            "arch": "i586",
-            "vendor": "openSUSE",
-            "checksum": "4a87f6b9ceae5d40a411fe52d0f17050"
-          }
-        ]
+        "packages": {
+          "package_system": "rpm",
+          "packages": [
+            {
+              "name": "bash",
+              "version": "4.2",
+              "release": "1.0",
+              "arch": "x86_64",
+              "vendor": "openSUSE",
+              "checksum": "7dfdd742a9b7d60c75bf4844d294716d"
+            },
+            {
+              "name": "kernel-desktop",
+              "version": "3.7.10",
+              "release": "1.0",
+              "arch": "i586",
+              "vendor": "openSUSE",
+              "checksum": "4a87f6b9ceae5d40a411fe52d0f17050"
+            }
+          ]
+        }
       }
     EOF
   }
@@ -66,96 +69,102 @@ describe PackagesRenderer do
     let(:description1) {
       create_test_description(json: <<-EOF, name: "description1")
         {
-          "packages": [
-            {
-              "name": "bash",
-              "version": "4.2",
-              "release": "1.0",
-              "arch": "x86_64",
-              "vendor": "openSUSE",
-              "checksum": "7dfdd742a9b7d60c75bf4844d294716d"
-            },
-            {
-              "name": "kernel-desktop",
-              "version": "3.7.10",
-              "release": "1.0",
-              "arch": "i586",
-              "vendor": "openSUSE",
-              "checksum": "4a87f6b9ceae5d40a411fe52d0f17050"
-            },
-            {
-              "name": "autofs",
-              "version": "5.0.9",
-              "release": "3.6",
-              "arch": "x86_64",
-              "vendor": "openSUSE",
-              "checksum": "6d5d012b0e8d33cf93e216dfab6b174e"
-            },
-            {
-              "name": "btrfsprogs",
-              "version": "3.16",
-              "release": "4.1",
-              "arch": "x86_64",
-              "vendor": "openSUSE",
-              "checksum": "db96018161193aaa42ee8cd1234247f9"
-            },
-            {
-              "name": "cpio",
-              "version": "2.11",
-              "release": "26.182",
-              "arch": "x86_64",
-              "vendor": "SUSE LLC <https://www.suse.com/>",
-              "checksum": "091d486ab725d7542933b74f9b3204e4"
-            }
-          ]
+          "packages": {
+            "package_system": "rpm",
+            "packages": [
+              {
+                "name": "bash",
+                "version": "4.2",
+                "release": "1.0",
+                "arch": "x86_64",
+                "vendor": "openSUSE",
+                "checksum": "7dfdd742a9b7d60c75bf4844d294716d"
+              },
+              {
+                "name": "kernel-desktop",
+                "version": "3.7.10",
+                "release": "1.0",
+                "arch": "i586",
+                "vendor": "openSUSE",
+                "checksum": "4a87f6b9ceae5d40a411fe52d0f17050"
+              },
+              {
+                "name": "autofs",
+                "version": "5.0.9",
+                "release": "3.6",
+                "arch": "x86_64",
+                "vendor": "openSUSE",
+                "checksum": "6d5d012b0e8d33cf93e216dfab6b174e"
+              },
+              {
+                "name": "btrfsprogs",
+                "version": "3.16",
+                "release": "4.1",
+                "arch": "x86_64",
+                "vendor": "openSUSE",
+                "checksum": "db96018161193aaa42ee8cd1234247f9"
+              },
+              {
+                "name": "cpio",
+                "version": "2.11",
+                "release": "26.182",
+                "arch": "x86_64",
+                "vendor": "SUSE LLC <https://www.suse.com/>",
+                "checksum": "091d486ab725d7542933b74f9b3204e4"
+              }
+            ]
+          }
         }
       EOF
     }
     let(:description2) {
       create_test_description(json: <<-EOF, name: "description2")
         {
-          "packages": [
-            {
-              "name": "bash2",
-              "version": "4.2",
-              "release": "1.0",
-              "arch": "x86_64",
-              "vendor": "openSUSE",
-              "checksum": "7dfdd742a9b7d60c75bf4844d294716d"
-            },
-            {
-              "name": "kernel-desktop",
-              "version": "3.7.11",
-              "release": "1.0",
-              "arch": "i586",
-              "vendor": "openSUSE",
-              "checksum": "4a87f6b9ceae5d40a411fe52d0f17050"
-            },
-            {
-              "name": "autofs",
-              "version": "5.0.9",
-              "release": "3.6",
-              "arch": "x86_64",
-              "vendor": "Packman",
-              "checksum": "6d5d012b0e8d33cf93e216dfab6b174e"
-            },
-            {
-              "name": "btrfsprogs",
-              "version": "3.18",
-              "release": "4.1",
-              "arch": "x86_64",
-              "vendor": "Packman",
-              "checksum": "db96018161193aaa42ee8cd1234247f9"
-            },
-            {
-              "name": "cpio",
-              "version": "2.11",
-              "release": "26.184",
-              "arch": "x86_64",
-              "vendor": "SUSE LLC <https://www.suse.com/>",
-              "checksum": "091d486ab725d7542933b74f9b3204e4"
-            }
-          ]
+          "packages": {
+            "package_system": "rpm",
+            "packages": [
+              {
+                "name": "bash2",
+                "version": "4.2",
+                "release": "1.0",
+                "arch": "x86_64",
+                "vendor": "openSUSE",
+                "checksum": "7dfdd742a9b7d60c75bf4844d294716d"
+              },
+              {
+                "name": "kernel-desktop",
+                "version": "3.7.11",
+                "release": "1.0",
+                "arch": "i586",
+                "vendor": "openSUSE",
+                "checksum": "4a87f6b9ceae5d40a411fe52d0f17050"
+              },
+              {
+                "name": "autofs",
+                "version": "5.0.9",
+                "release": "3.6",
+                "arch": "x86_64",
+                "vendor": "Packman",
+                "checksum": "6d5d012b0e8d33cf93e216dfab6b174e"
+              },
+              {
+                "name": "btrfsprogs",
+                "version": "3.18",
+                "release": "4.1",
+                "arch": "x86_64",
+                "vendor": "Packman",
+                "checksum": "db96018161193aaa42ee8cd1234247f9"
+              },
+              {
+                "name": "cpio",
+                "version": "2.11",
+                "release": "26.184",
+                "arch": "x86_64",
+                "vendor": "SUSE LLC <https://www.suse.com/>",
+                "checksum": "091d486ab725d7542933b74f9b3204e4"
+              }
+            ]
+          }
         }
       EOF
     }

--- a/spec/unit/packages_scope_spec.rb
+++ b/spec/unit/packages_scope_spec.rb
@@ -21,22 +21,21 @@ require_relative "spec_helper"
 # tests.
 
 describe PackagesScope do
-
   it "keeps values" do
-    packages_scope = PackagesScope.new(packages: PackageList.new)
-    packages_scope.packages << Package.new(name: "PACK1", version: "1.0")
-    packages_scope.packages << Package.new(name: "PACK2", version: "2.1")
+    packages_scope = PackagesScope.new
+    packages_scope << Package.new(name: "PACK1", version: "1.0")
+    packages_scope << Package.new(name: "PACK2", version: "2.1")
 
-    expect(packages_scope.packages.size).to eq(2)
-    expect(packages_scope.packages[0].name).to eq("PACK1")
-    expect(packages_scope.packages[0].version).to eq("1.0")
-    expect(packages_scope.packages[1].name).to eq("PACK2")
-    expect(packages_scope.packages[1].version).to eq("2.1")
+    expect(packages_scope.size).to eq(2)
+    expect(packages_scope[0].name).to eq("PACK1")
+    expect(packages_scope[0].version).to eq("1.0")
+    expect(packages_scope[1].name).to eq("PACK2")
+    expect(packages_scope[1].version).to eq("2.1")
   end
 
   it "keeps meta data" do
     date = DateTime.now
-    packages_scope = PackagesScope.new(packages: PackageList.new)
+    packages_scope = PackagesScope.new
     packages_scope.set_metadata(date, "SOMEHOST")
 
     expect(packages_scope.meta.modified).to eq(date)
@@ -51,14 +50,14 @@ describe PackagesScope do
       @package4_1 = Package.new(name: "PACK4", version: "4.5.6")
       @package4_2 = Package.new(name: "PACK4", version: "4.5.7")
 
-      @packages_scope1 = PackagesScope.new(packages: PackageList.new)
-      @packages_scope1.packages << @package1 << @package2 << @package4_1
+      @packages_scope1 = PackagesScope.new
+      @packages_scope1 << @package1 << @package2 << @package4_1
 
-      @packages_scope2 = PackagesScope.new(packages: PackageList.new)
-      @packages_scope2.packages << @package1 << @package2 << @package4_1
+      @packages_scope2 = PackagesScope.new
+      @packages_scope2 << @package1 << @package2 << @package4_1
 
-      @packages_scope3 = PackagesScope.new(packages: PackageList.new)
-      @packages_scope3.packages << @package1 << @package3 << @package4_2
+      @packages_scope3 = PackagesScope.new
+      @packages_scope3 << @package1 << @package3 << @package4_2
     end
 
     it "equal objects" do
@@ -71,10 +70,10 @@ describe PackagesScope do
       expect(only_scope2).to be(nil)
       expect(changed).to be(nil)
 
-      expect(common.packages.size).to eq(3)
-      expect(common.packages[0]).to eq(@package1)
-      expect(common.packages[1]).to eq(@package2)
-      expect(common.packages[2]).to eq(@package4_1)
+      expect(common.size).to eq(3)
+      expect(common[0]).to eq(@package1)
+      expect(common[1]).to eq(@package2)
+      expect(common[2]).to eq(@package4_1)
     end
 
     it "unequal objects" do
@@ -83,19 +82,18 @@ describe PackagesScope do
 
       only_scope1, only_scope2, changed, common = @packages_scope1.compare_with(@packages_scope3)
 
-      expect(only_scope1.packages.size).to eq(1)
-      expect(only_scope1.packages[0]).to eq(@package2)
+      expect(only_scope1.size).to eq(1)
+      expect(only_scope1[0]).to eq(@package2)
 
-      expect(only_scope2.packages.size).to eq(1)
-      expect(only_scope2.packages[0]).to eq(@package3)
+      expect(only_scope2.size).to eq(1)
+      expect(only_scope2[0]).to eq(@package3)
 
-      expect(common.packages.size).to eq(1)
-      expect(common.packages[0]).to eq(@package1)
+      expect(common.size).to eq(1)
+      expect(common[0]).to eq(@package1)
 
       expect(changed.size).to eq(1)
       expect(changed[0][0]).to eq(@package4_1)
       expect(changed[0][1]).to eq(@package4_2)
     end
   end
-
 end

--- a/spec/unit/packages_scope_spec.rb
+++ b/spec/unit/packages_scope_spec.rb
@@ -23,20 +23,20 @@ require_relative "spec_helper"
 describe PackagesScope do
 
   it "keeps values" do
-    packages_scope = PackagesScope.new
-    packages_scope << Package.new(name: "PACK1", version: "1.0")
-    packages_scope << Package.new(name: "PACK2", version: "2.1")
+    packages_scope = PackagesScope.new(packages: PackageList.new)
+    packages_scope.packages << Package.new(name: "PACK1", version: "1.0")
+    packages_scope.packages << Package.new(name: "PACK2", version: "2.1")
 
-    expect(packages_scope.size).to eq(2)
-    expect(packages_scope[0].name).to eq("PACK1")
-    expect(packages_scope[0].version).to eq("1.0")
-    expect(packages_scope[1].name).to eq("PACK2")
-    expect(packages_scope[1].version).to eq("2.1")
+    expect(packages_scope.packages.size).to eq(2)
+    expect(packages_scope.packages[0].name).to eq("PACK1")
+    expect(packages_scope.packages[0].version).to eq("1.0")
+    expect(packages_scope.packages[1].name).to eq("PACK2")
+    expect(packages_scope.packages[1].version).to eq("2.1")
   end
 
   it "keeps meta data" do
     date = DateTime.now
-    packages_scope = PackagesScope.new
+    packages_scope = PackagesScope.new(packages: PackageList.new)
     packages_scope.set_metadata(date, "SOMEHOST")
 
     expect(packages_scope.meta.modified).to eq(date)
@@ -51,14 +51,14 @@ describe PackagesScope do
       @package4_1 = Package.new(name: "PACK4", version: "4.5.6")
       @package4_2 = Package.new(name: "PACK4", version: "4.5.7")
 
-      @packages_scope1 = PackagesScope.new
-      @packages_scope1 << @package1 << @package2 << @package4_1
+      @packages_scope1 = PackagesScope.new(packages: PackageList.new)
+      @packages_scope1.packages << @package1 << @package2 << @package4_1
 
-      @packages_scope2 = PackagesScope.new
-      @packages_scope2 << @package1 << @package2 << @package4_1
+      @packages_scope2 = PackagesScope.new(packages: PackageList.new)
+      @packages_scope2.packages << @package1 << @package2 << @package4_1
 
-      @packages_scope3 = PackagesScope.new
-      @packages_scope3 << @package1 << @package3 << @package4_2
+      @packages_scope3 = PackagesScope.new(packages: PackageList.new)
+      @packages_scope3.packages << @package1 << @package3 << @package4_2
     end
 
     it "equal objects" do
@@ -71,10 +71,10 @@ describe PackagesScope do
       expect(only_scope2).to be(nil)
       expect(changed).to be(nil)
 
-      expect(common.size).to eq(3)
-      expect(common[0]).to eq(@package1)
-      expect(common[1]).to eq(@package2)
-      expect(common[2]).to eq(@package4_1)
+      expect(common.packages.size).to eq(3)
+      expect(common.packages[0]).to eq(@package1)
+      expect(common.packages[1]).to eq(@package2)
+      expect(common.packages[2]).to eq(@package4_1)
     end
 
     it "unequal objects" do
@@ -83,14 +83,14 @@ describe PackagesScope do
 
       only_scope1, only_scope2, changed, common = @packages_scope1.compare_with(@packages_scope3)
 
-      expect(only_scope1.size).to eq(1)
-      expect(only_scope1[0]).to eq(@package2)
+      expect(only_scope1.packages.size).to eq(1)
+      expect(only_scope1.packages[0]).to eq(@package2)
 
-      expect(only_scope2.size).to eq(1)
-      expect(only_scope2[0]).to eq(@package3)
+      expect(only_scope2.packages.size).to eq(1)
+      expect(only_scope2.packages[0]).to eq(@package3)
 
-      expect(common.size).to eq(1)
-      expect(common[0]).to eq(@package1)
+      expect(common.packages.size).to eq(1)
+      expect(common.packages[0]).to eq(@package1)
 
       expect(changed.size).to eq(1)
       expect(changed[0][0]).to eq(@package4_1)

--- a/spec/unit/show_task_spec.rb
+++ b/spec/unit/show_task_spec.rb
@@ -26,11 +26,7 @@ describe ShowTask, "#show" do
     SystemDescription.new("foo", SystemDescriptionMemoryStore.new)
   }
   let(:description_with_packages) {
-    create_test_description(json: <<-EOF)
-      {
-        "packages": []
-      }
-    EOF
+    create_test_description(scopes: ["empty_packages"])
   }
 
   it "runs the proper renderer when a scope is given" do

--- a/spec/unit/system_description_factory_spec.rb
+++ b/spec/unit/system_description_factory_spec.rb
@@ -48,16 +48,19 @@ describe SystemDescriptionFactory do
     it "creates minimal description from JSON" do
       description = create_test_description(json: <<-EOT
         {
-          "packages": [
-            {
-              "name": "foo"
-            }
-          ]
+          "packages": {
+            "package_system": "rpm",
+            "packages": [
+              {
+                "name": "foo"
+              }
+            ]
+          }
         }
         EOT
       )
 
-      expect(description.packages.first.name).to eq("foo")
+      expect(description.packages.packages.first.name).to eq("foo")
     end
 
     it "creates description with example scope" do

--- a/spec/unit/system_description_spec.rb
+++ b/spec/unit/system_description_spec.rb
@@ -33,7 +33,7 @@ describe SystemDescription do
         }
       },
       "meta": {
-        "format_version": 5
+        "format_version": 6
       }
     }'
   end

--- a/spec/unit/validate_task_spec.rb
+++ b/spec/unit/validate_task_spec.rb
@@ -25,7 +25,7 @@ describe ValidateTask, "#validate" do
 
   it "raises an error when encountering fauly description" do
     expected = <<EOF
-In scope packages: The property #0 (checksum) value "Invalid Checksum" did not match the regex '^[a-f0-9]+$'.
+In scope packages: The property #0 (packages/checksum) value "Invalid Checksum" did not match the regex '^[a-f0-9]+$'.
 
 EOF
     expected.chomp!


### PR DESCRIPTION
Please review the following changes:
  * 451e1ac Migrate fixture system descriptions with adapted migration
  * 3bbb3e5 Make use of the new Machinery::Array attributes in the packages scope
  * 346bb8e Extend Machinery::Arrays so that they can also store attributes
  * 4802858 Fix hound issues
  * 7cf54df Migrate fixture system descriptions
  * 29e10f9 Adapt packages data model for v6 (to add support for dpkg packages)
  * 4326ecb Add unchanged schema files for v6
  * e6166ea Add migration for format version 6
  * 6112791 Merge pull request #1703 from SUSE/better_warn_message_6
  * b50552e Add new unit test for the Html class
  * 0773c51 Changelog: Rephrase startup and warn messages for HTTP server
  * e541c26 Add new integration tests for the HTTP server warn messages
  * 34a351b Remove old unit test code
  * 94097f5 Clean up CLI code for `serve`
  * ba11b68 Clean up HTTP server code and its messages