### PR TITLE
Remove `show` hint when `--show` is used for `inspect-container`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 # Machinery Release Notes
 
+* Remove hint for `show`, when `inspect-container` is run with `--show` option
 * Rephrase the startup messages and warn messages when starting the HTTP
   server for compare, show, or serve system descriptions.
 

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -663,8 +663,7 @@ class Cli
         system.stop
       end
 
-
-      Hint.print(:show_data, name: name)
+      Hint.print(:show_data, name: name) unless options[:show]
 
       if !options["extract-files"] || Inspector.all_scopes.count != scope_list.count
         Hint.print(:do_complete_inspection, name: name, docker_container: image)

--- a/spec/integration/support/inspect_docker_examples.rb
+++ b/spec/integration/support/inspect_docker_examples.rb
@@ -73,6 +73,26 @@ shared_examples "inspect-container" do |container|
       include_examples("inspect-container simple scope", scope, container)
     end
 
+    it "`show hint` will not be shown when --show is used" do
+      expect(
+        @machinery.run_command(
+          "#{machinery_command} inspect-container machinerytool/#{container} --scope=os " \
+            "--name=test --show",
+          as: "vagrant"
+        )
+      ).to succeed.and not_include_stdout("To show the data of the system you just inspected run")
+    end
+
+    it "`show hint` will be shown when --show is not used" do
+      expect(
+        @machinery.run_command(
+          "#{machinery_command} inspect-container machinerytool/#{container} --scope=os " \
+            "--name=test",
+          as: "vagrant"
+        )
+      ).to succeed.and include_stdout("To show the data of the system you just inspected run")
+    end
+
     context "--scope=config-files" do
       it "extracts the files" do
         ls_command = @machinery.run_command(

--- a/spec/integration/support/inspect_docker_examples.rb
+++ b/spec/integration/support/inspect_docker_examples.rb
@@ -73,7 +73,7 @@ shared_examples "inspect-container" do |container|
       include_examples("inspect-container simple scope", scope, container)
     end
 
-    it "`show hint` will not be shown when --show is used" do
+    it "does not show the 'show' hint when --show is used" do
       expect(
         @machinery.run_command(
           "#{machinery_command} inspect-container machinerytool/#{container} --scope=os " \
@@ -83,7 +83,7 @@ shared_examples "inspect-container" do |container|
       ).to succeed.and not_include_stdout("To show the data of the system you just inspected run")
     end
 
-    it "`show hint` will be shown when --show is not used" do
+    it "shows the 'show' hint when --show is not used" do
       expect(
         @machinery.run_command(
           "#{machinery_command} inspect-container machinerytool/#{container} --scope=os " \

--- a/spec/integration/support/inspect_docker_examples.rb
+++ b/spec/integration/support/inspect_docker_examples.rb
@@ -80,7 +80,7 @@ shared_examples "inspect-container" do |container|
             "--name=test --show",
           as: "vagrant"
         )
-      ).to succeed.and not_include_stdout("To show the data of the system you just inspected run")
+      ).to succeed.and not_include_stdout("Hint: To show")
     end
 
     it "shows the 'show' hint when --show is not used" do
@@ -90,7 +90,7 @@ shared_examples "inspect-container" do |container|
             "--name=test",
           as: "vagrant"
         )
-      ).to succeed.and include_stdout("To show the data of the system you just inspected run")
+      ).to succeed.and include_stdout("Hint: To show")
     end
 
     context "--scope=config-files" do


### PR DESCRIPTION
Supersedes #1738 