### PR TITLE
Adjust expecte stderr in testcase to be aligned with changes in code

### DIFF
--- a/spec/integration/support/upgrade_format_examples.rb
+++ b/spec/integration/support/upgrade_format_examples.rb
@@ -27,7 +27,7 @@ shared_examples "upgrade format" do
 
       expect(
         @machinery.run_command("machinery show format_v1", as: "vagrant")
-      ).to fail.and include_stderr("incompatible data format")
+      ).to fail.and include_stderr("needs to be upgraded")
 
       expect(
         @machinery.run_command("machinery upgrade-format format_v1", as: "vagrant")


### PR DESCRIPTION
0041b31fe1f90dd6a7f4a58d5ee24dba3687fb89 changed the output but tests
still expected the old message.
