### PR TITLE
Make package build filter generic

### DIFF
--- a/filters/filter-packages-for-build.yaml
+++ b/filters/filter-packages-for-build.yaml
@@ -1,8 +1,3 @@
-# check lib/os.rb for the distribution names
-"openSUSE 13.2 (Harlequin)":
-  - openSUSE-release-dvd
-"openSUSE 13.1 (Bottle)":
-  - openSUSE-release-dvd
-"SUSE Linux Enterprise Server 12":
-  - sle-sdk-release-DVD
-  - sles-release-DVD
+- openSUSE-release-dvd
+- sle-sdk-release-DVD
+- sles-release-DVD

--- a/lib/kiwi_config.rb
+++ b/lib/kiwi_config.rb
@@ -227,10 +227,9 @@ EOF
   end
 
   def apply_packages(xml)
-    build_filter = YAML.load_file(
+    filter = YAML.load_file(
       File.join(Machinery::ROOT, "filters", "filter-packages-for-build.yaml")
-    )
-    filter = build_filter[@system_description.os.canonical_name] || []
+    ) || []
 
     xml.packages(type: "bootstrap") do
       if @system_description.packages


### PR DESCRIPTION
Since we are allowing any system to run the build task so we don't have
to keep track of them then we need a generic way to filter files from
OSs that we don't keep track of.

In general there doesn't seem to be a need of filtering a package in one
OS and not in another and therefore we just made it generic.

Fixes #1830
Supersedes #1831 