### PR TITLE
Remove unnecessary scopes from alert message test

### DIFF
--- a/spec/features/alert_message_spec.rb
+++ b/spec/features/alert_message_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe "Alert Message", type: :feature do
 
     let(:description) {
       create_test_description(
-        scopes:        ["os", "packages", "repositories", "services"],
         name:          "name",
         store:         store,
         store_on_disk: true,


### PR DESCRIPTION
For this tests it's only important that an alert message is raised so no
scopes are required but just the fact that the version of the schema is
an old one.