### PR TITLE
Remove `_attributes` during migration in users, groups, and patterns

### DIFF
--- a/schema/migrations/migrate5to6.rb
+++ b/schema/migrations/migrate5to6.rb
@@ -86,15 +86,12 @@ class Migrate5To6 < Migration
       next unless @hash.key?(scope)
 
       @hash[scope] = {
-        "_attributes" => {},
         "_elements" => @hash[scope]
       }
     end
 
     if @hash.key?("groups")
       @hash["groups"] = {
-        "_attributes" => {
-        },
         "_elements" => @hash["groups"]
       }
     end


### PR DESCRIPTION
We decided that we do not want the `_attributes` element in `users`, `groups`, and `patterns`.

Supersedes #1867 