### PR TITLE
Prevent crash when btrfs is missing for unmanaged-file inspector

### DIFF
--- a/plugins/unmanaged_files/unmanaged_files_inspector.rb
+++ b/plugins/unmanaged_files/unmanaged_files_inspector.rb
@@ -537,5 +537,7 @@ class UnmanagedFilesInspector < Inspector
       ["awk", "{print $NF}"],
       stdout: :capture
     ).split
+  rescue Cheetah::ExecutionFailed
+    []
   end
 end


### PR DESCRIPTION
Fixes #1875