### PR TITLE
Use proper check for btrfs subvolume check

### DIFF
--- a/plugins/unmanaged_files/unmanaged_files_inspector.rb
+++ b/plugins/unmanaged_files/unmanaged_files_inspector.rb
@@ -536,12 +536,14 @@ class UnmanagedFilesInspector < Inspector
   end
 
   def btrfs_subvolumes
-    @system.run_command(
-      ["btrfs", "subvolume", "list", "/"],
-      ["awk", "{print $NF}"],
-      stdout: :capture
-    ).split
-  rescue Cheetah::ExecutionFailed
-    []
+    if @system.has_command?("/sbin/btrfs")
+      @system.run_command(
+        ["/sbin/btrfs", "subvolume", "list", "/"],
+        ["awk", "{print $NF}"],
+        stdout: :capture
+      ).split
+    else
+      []
+    end
   end
 end


### PR DESCRIPTION
/sbin/btrfs is needed because btrfs can't be called by the remote user
without it since /sbin is usually not in the PATH variable for regular
users.