### PR TITLE
Implementation: SSH Key and Port Option

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,9 @@
 
 * Allow closing file dialog (in WebUI) by pressing ESC
 * Support inspection of Ubuntu 14.04 systems
+* New `--ssh-identity-file` option to specify a SSH private key when inspecting
+  a remote system
+* New `--ssh-port` option to specify an SSH port when inspecting a remote system
 
 ## Version 1.16.4 - Thu Jan 14 18:35:47 CET 2016 - thardeck@suse.de
 

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -585,10 +585,17 @@ class Cli
     c.flag ["remote-user", :r], type: String, required: false, default_value: @config.remote_user,
       desc: "Defines the user which is used to access the inspected system via SSH."\
         "This user needs sudo access on the remote machine or be root.", arg_name: "USER"
+    c.flag ["ssh-port", :p], type: Integer, required: false,
+      desc: "The SSH port of the remote server.",
+      arg_name: "SSH-PORT"
+    c.flag ["ssh-identity-file", :i], type: String, required: false,
+      desc: "The private SSH key location what can be used to authenticate with the remote system.",
+      arg_name: "SSH-KEY"
 
     c.action do |_global_options, options, args|
       host = shift_arg(args, "HOSTNAME")
-      system = System.for(host, options["remote-user"])
+      system = System.for(host, remote_user: options["remote-user"], ssh_port: options["ssh-port"],
+        ssh_identity_file: options["ssh-identity-file"])
       inspector_task = InspectTask.new
 
       name, scope_list, inspect_options, filter = parse_inspect_command_options(host, options)

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -30,20 +30,20 @@ module Machinery
         default: true,
         description: "Show hints about usage of Machinery in the context of the commands ran by" \
           " the user"
-      )
+           )
       entry("remote-user",
         default: "root",
         description: "Defines the user which is used to access the inspected system via SSH"
-      )
+           )
       entry("experimental-features",
         default: false,
         description: "Enable experimental features. See " \
           "https://github.com/SUSE/machinery/wiki/Experimental-Features for more details"
-      )
+           )
       entry("http_server_port",
         default: 7585,
         description: "TCP port used by the HTTP server for the HTML view"
-      )
+           )
     end
 
     def deprecated_entries

--- a/lib/system.rb
+++ b/lib/system.rb
@@ -33,9 +33,9 @@ class System
 
   attr_writer :locale
 
-  def self.for(host, remote_user = "root")
+  def self.for(host, opts = {})
     if host && host != "localhost"
-      RemoteSystem.new(host, remote_user)
+      RemoteSystem.new(host, opts)
     else
       LocalSystem.new
     end

--- a/man/machinery-inspect.1.md
+++ b/man/machinery-inspect.1.md
@@ -48,6 +48,14 @@ trigger errors.
     PREREQUISITES for more information).
     To change the default-user use `machinery config remote-user=USER`
 
+  * `-p SSH-PORT`, `--ssh-port SSH-PORT` (optional):
+    Specifies the SSH port of the remote SSH server.
+
+  * `-i SSH-IDENTITY-FILE`, `--ssh-identity-file SSH-IDENTITY-FILE` (optional):
+    Specifies the SSH private key what should be used to authenticate with the
+    remote SSH server. Keys with a passphrase are not allowed here. Use the ssh-agent
+    instead.
+
   * `-x`, `--extract-files` (optional):
     Extract changed configuration and unmanaged files from the inspected system.
     Shortcut for the combination of `--extract-changed-config-files`,

--- a/spec/unit/remote_system_spec.rb
+++ b/spec/unit/remote_system_spec.rb
@@ -18,7 +18,8 @@
 require_relative "spec_helper"
 
 describe RemoteSystem do
-  let(:remote_system) { RemoteSystem.new("remotehost") }
+  let(:remote_system) { RemoteSystem.new("remotehost", options) }
+  let(:options) { {} }
 
   describe "#initialize" do
     it "raises ConnectionFailed when it can't connect" do
@@ -27,8 +28,32 @@ describe RemoteSystem do
       ).and_raise(Cheetah::ExecutionFailed.new(nil, nil, nil, nil))
 
       expect {
-        RemoteSystem.new("example.com")
+        remote_system
       }.to raise_error(Machinery::Errors::SshConnectionFailed, /SSH/)
+    end
+
+    context "when an ssh port is given" do
+      let(:options) { { ssh_port: 5000 } }
+
+      it "builds a correct command line" do
+        expect(Cheetah).to receive(:run).with(
+          "ssh", "-p", "5000", any_args
+        )
+
+        remote_system
+      end
+    end
+
+    context "when an ssh key is given" do
+      let(:options) { { ssh_identity_file: "/tmp/private_ssh_key" } }
+
+      it "builds a correct command line" do
+        expect(Cheetah).to receive(:run).with(
+          "ssh", "-i", "/tmp/private_ssh_key", any_args
+        )
+
+        remote_system
+      end
     end
   end
 
@@ -74,64 +99,125 @@ describe RemoteSystem do
         remote_system.run_command("ls", disable_logging: true)
       end
 
-      it "adheres to the remote_user option" do
-        expect(Cheetah).to receive(:run).with(
-          "ssh", "machinery@remotehost", any_args, "ls", "/tmp", {}
-        )
+      context "when accessing as a remote user" do
+        let(:options) { { remote_user: "machinery" } }
 
-        remote_system.remote_user = "machinery"
-        remote_system.run_command("ls", "/tmp")
-      end
+        it "builds a correct command line" do
+          expect(Cheetah).to receive(:run).with(
+            "ssh", "machinery@remotehost", any_args, "ls", "/tmp", {}
+          )
 
-      it "uses sudo when necessary" do
-        expect(Cheetah).to receive(:run).with(
-          "ssh", any_args, "sudo", "-n", "LANGUAGE=", "LC_ALL=C", "ls", "/tmp", privileged: true
-        )
+          remote_system.run_command("ls", "/tmp")
+        end
 
-        remote_system.remote_user = "machinery"
-        remote_system.run_command("ls", "/tmp", privileged: true)
-      end
+        it "uses sudo when necessary" do
+          expect(Cheetah).to receive(:run).with(
+            "ssh", any_args, "sudo", "-n", "LANGUAGE=", "LC_ALL=C", "ls", "/tmp", privileged: true
+          )
 
-      it "raises an exception if the user is not allowed to run sudo" do
-        expect(Cheetah).to receive(:run).with(
-          "ssh", any_args
-        ).and_raise(Cheetah::ExecutionFailed.new(nil, 1, "", "sudo: a password is required"))
-
-        remote_system.remote_user = "machinery"
-        expect {
           remote_system.run_command("ls", "/tmp", privileged: true)
-        }.to raise_error(Machinery::Errors::InsufficientPrivileges,
-          /sudo isn't configured on the inspected host/
-        )
+        end
+
+        it "raises an exception if the user is not allowed to run sudo" do
+          expect(Cheetah).to receive(:run).with(
+            "ssh", any_args
+          ).and_raise(Cheetah::ExecutionFailed.new(nil, 1, "", "sudo: a password is required"))
+
+          expect {
+            remote_system.run_command("ls", "/tmp", privileged: true)
+          }.to raise_error(
+            Machinery::Errors::InsufficientPrivileges,
+            /sudo isn't configured on the inspected host/
+          )
+        end
+      end
+
+      context "when running a command with a different ssh port" do
+        let(:options) { { ssh_port: 5000 } }
+
+        it "builds a correct command line" do
+          expect(Cheetah).to receive(:run).with(
+            "ssh", "-p", "5000", any_args, privileged: true
+          )
+
+          remote_system.run_command("ls", "/tmp", privileged: true)
+        end
+      end
+
+      context "when running a command with an ssh key" do
+        let(:options) { { ssh_identity_file: "/tmp/private_ssh_key" } }
+
+        it "builds a correct command line" do
+          expect(Cheetah).to receive(:run).with(
+            "ssh", "-i", "/tmp/private_ssh_key", any_args, privileged: true
+          )
+
+          remote_system.run_command("ls", "/tmp", privileged: true)
+        end
       end
     end
 
     describe "#retrieve_files" do
-      it "retrieves files via rsync from a remote host" do
-        expect(Cheetah).to receive(:run).with(
-          "rsync", "-e", "ssh", "--chmod=go-rwx", "--files-from=-", "--rsync-path=rsync",
-          "root@remotehost:/", "/tmp",
-          stdout: :capture,
-          stdin: "/foo\n/bar"
-        )
+      context "when retrieving files via rsync" do
+        it "builds the correct command" do
+          expect(Cheetah).to receive(:run).with(
+            "rsync", "-e", "ssh", "--chmod=go-rwx", "--files-from=-", "--rsync-path=rsync",
+            "root@remotehost:/", "/tmp",
+            stdout: :capture,
+            stdin: "/foo\n/bar"
+          )
 
-        remote_system.retrieve_files(["/foo", "/bar"], "/tmp")
+          remote_system.retrieve_files(["/foo", "/bar"], "/tmp")
+        end
       end
 
-      it "retrieves files via sudo rsync from a remote host when non-root access is used" do
-        expect(Cheetah).to receive(:run) do |*args|
-          expect(args).to include("--rsync-path=sudo -n rsync")
-        end
+      context "when retrieving files via sudo rsync" do
+        let(:options) { { remote_user: "machinery" } }
 
-        remote_system.remote_user = "machinery"
-        remote_system.retrieve_files(["/foo", "/bar"], "/tmp")
+        it "adds sudo to the rsync path" do
+          expect(Cheetah).to receive(:run) do |*args|
+            expect(args).to include("--rsync-path=sudo -n rsync")
+          end
+
+          remote_system.retrieve_files(["/foo", "/bar"], "/tmp")
+        end
+      end
+
+      context "when retrieving files by using a different ssh port" do
+        let(:options) { { ssh_port: 5000 } }
+
+        it "builds a correct command line" do
+          expect(Cheetah).to receive(:run).with(
+            "rsync", "-e", "ssh -p 5000", "--chmod=go-rwx", "--files-from=-", "--rsync-path=rsync",
+            "root@remotehost:/", "/tmp",
+            stdout: :capture,
+            stdin: "/foo\n/bar"
+          )
+
+          remote_system.retrieve_files(["/foo", "/bar"], "/tmp")
+        end
+      end
+
+      context "when retrieving files by using an ssh key" do
+        let(:options) { { ssh_identity_file: "/tmp/private_ssh_key" } }
+
+        it "builds a correct command line" do
+          expect(Cheetah).to receive(:run).with(
+            "rsync", "-e", "ssh -i /tmp/private_ssh_key", "--chmod=go-rwx", "--files-from=-",
+            "--rsync-path=rsync",
+            "root@remotehost:/", "/tmp",
+            stdout: :capture,
+            stdin: "/foo\n/bar"
+          )
+
+          remote_system.retrieve_files(["/foo", "/bar"], "/tmp")
+        end
       end
     end
 
     describe "#read_file" do
       it "retrieves the content of the remote file" do
         expect(remote_system).to receive(:run_command).and_return("foo")
-
         expect(remote_system.read_file("/foo")).to eq("foo")
       end
 
@@ -145,9 +231,27 @@ describe RemoteSystem do
     end
 
     describe "#inject_file" do
-      it "copies a file via scp" do
+      it "builds a correct command line" do
         expect(Cheetah).to receive(:run).with("scp", "/usr/foobar", "root@remotehost:/tmp")
         remote_system.inject_file("/usr/foobar", "/tmp")
+      end
+
+      context "when copying a file via scp by using a different ssh port" do
+        let(:options) { { ssh_port: 5000 } }
+
+        it "builds a correct command line" do
+          expect(Cheetah).to receive(:run).with("scp", "-P", "5000", any_args)
+          remote_system.inject_file("/usr/foobar", "/tmp")
+        end
+      end
+
+      context "when copying a file via scp by using an SSH key" do
+        let(:options) { { ssh_identity_file: "/tmp/private_ssh_key" } }
+
+        it "builds a correct command line" do
+          expect(Cheetah).to receive(:run).with("scp", "-i", "/tmp/private_ssh_key", any_args)
+          remote_system.inject_file("/usr/foobar", "/tmp")
+        end
       end
     end
 
@@ -157,6 +261,44 @@ describe RemoteSystem do
           "rm", "/tmp/foo", privileged: true
         )
         remote_system.remove_file("/tmp/foo")
+      end
+    end
+
+    describe "#get_cmd_options" do
+      it "returns nothing when no port and no ssh key was set" do
+        expect(rsys.get_cmd_options).to eq([])
+      end
+
+      it "returns the -p option with its value for ssh" do
+        expect(rsys_port.get_cmd_options(:ssh)).to eq(["-p", "5000"])
+      end
+
+      it "returns the -p option with its value for scp" do
+        expect(rsys_port.get_cmd_options(:scp)).to eq(["-P", "5000"])
+      end
+
+      it "returns the -i option with its value" do
+        expect(rsys_key.get_cmd_options(:ssh)).to eq(["-i", "/tmp/private_ssh_key"])
+      end
+
+      it "raises an exception when no :ssh and no :scp flag was set" do
+        expect { rsys_port.get_cmd_options }.to raise_error(Machinery::Errors::MachineryError)
+      end
+    end
+
+    describe "#build_basic_ssh_command" do
+      it "returns a valid command for ssh" do
+        expect(rsys_port_and_key.build_basic_ssh_command).to eq(
+          ["ssh", "-p", "5000", "-i", "/tmp/private_ssh_key"]
+        )
+      end
+    end
+
+    describe "#build_basic_scp_command" do
+      it "returns a valid command for scp" do
+        expect(rsys_port_and_key.build_basic_scp_command).to eq(
+          ["scp", "-P", "5000", "-i", "/tmp/private_ssh_key"]
+        )
       end
     end
   end

--- a/spec/unit/remote_system_spec.rb
+++ b/spec/unit/remote_system_spec.rb
@@ -263,43 +263,5 @@ describe RemoteSystem do
         remote_system.remove_file("/tmp/foo")
       end
     end
-
-    describe "#get_cmd_options" do
-      it "returns nothing when no port and no ssh key was set" do
-        expect(rsys.get_cmd_options).to eq([])
-      end
-
-      it "returns the -p option with its value for ssh" do
-        expect(rsys_port.get_cmd_options(:ssh)).to eq(["-p", "5000"])
-      end
-
-      it "returns the -p option with its value for scp" do
-        expect(rsys_port.get_cmd_options(:scp)).to eq(["-P", "5000"])
-      end
-
-      it "returns the -i option with its value" do
-        expect(rsys_key.get_cmd_options(:ssh)).to eq(["-i", "/tmp/private_ssh_key"])
-      end
-
-      it "raises an exception when no :ssh and no :scp flag was set" do
-        expect { rsys_port.get_cmd_options }.to raise_error(Machinery::Errors::MachineryError)
-      end
-    end
-
-    describe "#build_basic_ssh_command" do
-      it "returns a valid command for ssh" do
-        expect(rsys_port_and_key.build_basic_ssh_command).to eq(
-          ["ssh", "-p", "5000", "-i", "/tmp/private_ssh_key"]
-        )
-      end
-    end
-
-    describe "#build_basic_scp_command" do
-      it "returns a valid command for scp" do
-        expect(rsys_port_and_key.build_basic_scp_command).to eq(
-          ["scp", "-P", "5000", "-i", "/tmp/private_ssh_key"]
-        )
-      end
-    end
   end
 end

--- a/spec/unit/system_spec.rb
+++ b/spec/unit/system_spec.rb
@@ -28,7 +28,7 @@ describe System do
 
     it "returns a RemoteSystem when a hostname is given" do
       allow_any_instance_of(RemoteSystem).to receive(:connect)
-      remote_system = System.for("somehost", "machinery")
+      remote_system = System.for("somehost", remote_user: "machinery")
 
       expect(remote_system).to be_a(RemoteSystem)
       expect(remote_system.host).to eql("somehost")


### PR DESCRIPTION
Supersedes #1898

Difference to the old PR:
* remote_system.rb and its spec file got refactored. I added getters for some member variables of RemoteSystem because the full access doesn't make any sense.
* I implemented a function to better build the command line arguments for `ssh`, `scp`, and `rsync`
* Renamed the options to `--ssh-port` and `--ssh-identity-file`
