### PR TITLE
Rename alert close button on landing page and compare page

### DIFF
--- a/html/partials/compare/alert.html.haml
+++ b/html/partials/compare/alert.html.haml
@@ -3,7 +3,7 @@
     .row
       .col-xs-10.col-xs-offset-1
         .well
-          %span.text-right.dismiss{ title: "Collapse/Expand" }
+          %span.text-right.dismiss{ title: "Dismiss" }
           - if @meta[:uninspected][@description_a.name]
             %p
               Couldn't compare

--- a/html/partials/landing_page/alert.html.haml
+++ b/html/partials/landing_page/alert.html.haml
@@ -3,7 +3,7 @@
     .row
       .col-xs-10.col-xs-offset-1
         .well
-          %span.text-right.dismiss{ title: "Collapse/Expand" }
+          %span.text-right.dismiss{ title: "Dismiss" }
           - @errors.each do |error|
             %p
               = error


### PR DESCRIPTION
Fixes #1914