### PR TITLE
Use dpkg instead of apt for repository recognition

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 # Machinery Release Notes
 
+* Fix repository recognition on older Debian systems
 * Inspection of unmanaged-files is now also using the faster machinery-helper
   when a remote user is used
 * Show all available information for unmanaged files in HTML view (gh#SUSE/machinery#1905)

--- a/plugins/repositories/repositories_inspector.rb
+++ b/plugins/repositories/repositories_inspector.rb
@@ -27,7 +27,7 @@ class RepositoriesInspector < Inspector
       @description.repositories = inspect_zypp_repositories
     elsif system.has_command?("yum")
       @description.repositories = inspect_yum_repositories
-    elsif system.has_command?("apt")
+    elsif system.has_command?("dpkg")
       @description.repositories = inspect_apt_repositories
     else
       raise Machinery::Errors::MissingRequirement.new(

--- a/spec/unit/repositories_inspector_spec.rb
+++ b/spec/unit/repositories_inspector_spec.rb
@@ -232,7 +232,7 @@ password=2fdcb7499fd46842
     it "raise an error when requirements are not fulfilled" do
       allow(system).to receive(:has_command?).with("zypper").and_return(false)
       allow(system).to receive(:has_command?).with("yum").and_return(false)
-      allow(system).to receive(:has_command?).with("apt").and_return(false)
+      allow(system).to receive(:has_command?).with("dpkg").and_return(false)
 
       expect { inspector.inspect(filter) }.to raise_error(
         Machinery::Errors::MissingRequirement, /Need either the binary 'zypper', 'yum' or 'apt'/
@@ -393,7 +393,7 @@ EOF
     before(:each) do
       allow(system).to receive(:has_command?).with("zypper").and_return(false)
       allow(system).to receive(:has_command?).with("yum").and_return(false)
-      allow(system).to receive(:has_command?).with("apt").and_return(true)
+      allow(system).to receive(:has_command?).with("dpkg").and_return(true)
     end
 
     it "inspects repos" do


### PR DESCRIPTION
because at least on older Debian versions there is no apt
available, only apt-get. Since apt-get is deprecated we
check for dpkg instead, which needs to be installed on
a Debian based system.