### PR TITLE
Do not try to validate unknown format versions

### DIFF
--- a/lib/manifest.rb
+++ b/lib/manifest.rb
@@ -95,6 +95,7 @@ class Manifest
   end
 
   def compatible_json?
-    @hash && @hash["meta"] && @hash["meta"]["format_version"]
+    @hash && @hash["meta"] && @hash["meta"]["format_version"] &&
+      @hash["meta"]["format_version"] <= SystemDescription::CURRENT_FORMAT_VERSION
   end
 end

--- a/spec/unit/manifest_spec.rb
+++ b/spec/unit/manifest_spec.rb
@@ -117,5 +117,22 @@ EOF
         manifest.validate
       }.not_to raise_error
     end
+
+    it "does not try to validate descriptions with unknown format versions" do
+      manifest = Manifest.new("name", <<-EOT)
+        {
+          "meta": {
+            "format_version": 99999
+          }
+        }
+      EOT
+      expect {
+        manifest.validate!
+      }.not_to raise_error
+
+      expect {
+        manifest.validate
+      }.not_to raise_error
+    end
   end
 end


### PR DESCRIPTION
to prevent issues loading json schemas which are not yet available in
the current release.

Fixes #1926