### PR TITLE
Use --non-interactive for zypper commands during patterns inspection

### DIFF
--- a/plugins/patterns/patterns_inspector.rb
+++ b/plugins/patterns/patterns_inspector.rb
@@ -55,7 +55,7 @@ class PatternsInspector < Inspector
 
   def inspect_with_zypper
     begin
-      xml = @system.run_command("zypper", "-xq", "--no-refresh", "patterns",
+      xml = @system.run_command("zypper", "--non-interactive", "-xq", "--no-refresh", "patterns",
         "-i", stdout: :capture)
     rescue Cheetah::ExecutionFailed => e
       if e.stdout.include?("locked")

--- a/spec/unit/patterns_inspector_spec.rb
+++ b/spec/unit/patterns_inspector_spec.rb
@@ -78,8 +78,8 @@ EOF
 
       it "parses the patterns list into a Hash" do
         expect(system).to receive(:run_command).
-          with("zypper", "-xq", "--no-refresh", "patterns", "-i", stdout: :capture).
-          and_return(zypper_output)
+          with("zypper", "--non-interactive", "-xq", "--no-refresh", "patterns", "-i",
+            stdout: :capture).and_return(zypper_output)
         patterns_inspector.inspect(filter)
 
         expect(description.patterns.size).to eql(2)
@@ -111,7 +111,7 @@ EOF
 
       it "raises an error if zypper is locked" do
         expect(system).to receive(:run_command).
-          with("zypper", "-xq", "--no-refresh", "patterns", "-i",
+          with("zypper", "--non-interactive", "-xq", "--no-refresh", "patterns", "-i",
             stdout: :capture).
           and_raise(
             Cheetah::ExecutionFailed.new(


### PR DESCRIPTION
This provides the patterns list without a return code unequal zero.

Amended commit message from #1956

Fixes #1955