### PR TITLE
[Review] Request from 'aduffeck' @ 'SUSE/machinery/review_160209_fix_files_reported_multiple_times'

### DIFF
--- a/lib/managed_files_database.rb
+++ b/lib/managed_files_database.rb
@@ -46,23 +46,28 @@ class ManagedFilesDatabase
     return @changed_files if @changed_files
     check_requirements
 
-    result = managed_files_list(&block).each_line.map do |line|
+    result = managed_files_list(&block).lines.inject({}) do |hash, line|
       line.chomp!
-      next unless line =~ /^[^ ]+[ ]+. \/.*$/
+      next(hash) unless line =~ /^[^ ]+[ ]+. \/.*$/
 
       file, changes, type = parse_changes_line(line)
 
-      package_name, package_version = package_for_file_path(file)
+      unless hash[file]
+        package_name, package_version = package_for_file_path(file)
 
-      ChangedFile.new(
-        type,
-        name:            file,
-        package_name:    package_name,
-        package_version: package_version,
-        status:          "changed",
-        changes:         changes
-      )
-    end.compact.uniq
+        hash[file] = ChangedFile.new(
+          type,
+          name:            file,
+          package_name:    package_name,
+          package_version: package_version,
+          status:          "changed",
+          changes:         []
+        )
+      end
+
+      hash[file].changes |= changes
+      hash
+    end.values
 
     paths = result.reject { |f| f.changes == ["deleted"] }.map(&:name)
     path_data = get_path_data(paths)

--- a/spec/unit/managed_files_database_spec.rb
+++ b/spec/unit/managed_files_database_spec.rb
@@ -52,12 +52,9 @@ describe ManagedFilesDatabase do
 
   describe "#changed_files" do
     before(:each) do
-      allow_any_instance_of(ManagedFilesDatabase).to receive(:check_requirements)
-      allow_any_instance_of(ManagedFilesDatabase).to receive(:managed_files_list).
-        and_return(changed_files_sh_result)
-      allow_any_instance_of(ManagedFilesDatabase).to receive(:package_for_file_path).
-        and_return(["zypper", "1.6.311"])
-
+      allow(subject).to receive(:check_requirements)
+      allow(subject).to receive(:managed_files_list).and_return(changed_files_sh_result)
+      allow(subject).to receive(:package_for_file_path).and_return(["zypper", "1.6.311"])
       allow(system).to receive(:run_command).with("stat", any_args).and_return(
         File.read(File.join(Machinery::ROOT, "spec/data/rpm_managed_files_database/stat_result"))
       )

--- a/spec/unit/managed_files_database_spec.rb
+++ b/spec/unit/managed_files_database_spec.rb
@@ -83,6 +83,18 @@ describe ManagedFilesDatabase do
       expect(subject.changed_files.first).to eq(expected)
       expect(subject.changed_files.length).to eq(7)
     end
+
+    it "merges lines that refer to the same file" do
+      expect(subject).to receive(:managed_files_list).and_return(<<EOF
+missing     /lib/modules/3.16.7-29-desktop/updates/vboxpci.ko (replaced)
+missing     /lib/modules/3.16.7-29-desktop/updates/vboxpci.ko
+EOF
+      )
+
+      files = subject.changed_files
+      expect(files.count).to eq(1)
+      expect(files.first.changes).to match_array(["deleted", "replaced"])
+    end
   end
 
   describe "parse_changes_line" do


### PR DESCRIPTION
Please review the following changes:
  * 119e627 Get rid of superfluous allow_any_instance_of usage
  * 9c86fe1 Handle cases where "rpm -V" returns multiple lines for the same file