### PR TITLE
Remove RPM spec sanity check

### DIFF
--- a/machinery.spec.erb
+++ b/machinery.spec.erb
@@ -163,8 +163,6 @@ ln -s %{_libdir}/ruby/gems/%{rb_ver}/gems/%{mod_full_name}/NEWS
 %{_bindir}/%{binary_name}
 %{_libdir}/ruby/gems/%{rb_ver}/cache/%{mod_full_name}.gem
 %{_libdir}/ruby/gems/%{rb_ver}/gems/%{mod_full_name}/
-# make sure that the machinery-helper for the local arch was built
-%{_libdir}/ruby/gems/%{rb_ver}/gems/%{mod_full_name}/machinery-helper/machinery-helper-%{_arch}
 
 %if %suse_version > 1310
 %{_libdir}/ruby/gems/%{rb_ver}/extensions/


### PR DESCRIPTION
because if the Go compilation fails the rpm build would raise anyway.