### PR TITLE
shows getting_started hint if 'machinery' is called without arguments

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -41,7 +41,7 @@ class Cli
   end
 
   post do |global_options,command,options,args|
-    if command.is_a?(GLI::Commands::Help) && !global_options[:version] && ARGV == ["help"]
+    if command.is_a?(GLI::Commands::Help) && !global_options[:version] || ARGV == ["help"]
 
       Machinery::Ui.puts "\nFor more detailed information, open the documentation by typing " \
         "'machinery man --html'.\nIf you are unable to find a solution within the man page " \

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -41,7 +41,7 @@ class Cli
   end
 
   post do |global_options,command,options,args|
-    if command.is_a?(GLI::Commands::Help) && !global_options[:version] || ARGV == ["help"]
+    if (command.is_a?(GLI::Commands::Help) && !global_options[:version]) || ARGV == ["help"]
 
       Machinery::Ui.puts "\nFor more detailed information, open the documentation by typing " \
         "'machinery man --html'.\nIf you are unable to find a solution within the man page " \

--- a/spec/integration/support/command_line_examples.rb
+++ b/spec/integration/support/command_line_examples.rb
@@ -31,6 +31,12 @@ shared_examples "CLI" do
         )
     end
 
+    it "offers hint without options" do
+      expect(
+        @machinery.run_command("#{machinery_command}", as: "vagrant")
+      ).to succeed.and have_stdout(/GLOBAL OPTIONS.*COMMANDS.*help/m)
+    end
+
     it "processes help option" do
       expect(
         @machinery.run_command("#{machinery_command} -h", as: "vagrant")

--- a/spec/integration/support/command_line_examples.rb
+++ b/spec/integration/support/command_line_examples.rb
@@ -34,7 +34,9 @@ shared_examples "CLI" do
     it "offers hint without options" do
       expect(
         @machinery.run_command("#{machinery_command}", as: "vagrant")
-      ).to succeed.and have_stdout(/GLOBAL OPTIONS.*COMMANDS.*help/m)
+      ).to succeed.and include_stdout(
+        "You can get started by inspecting a system. Run:\n#{machinery_command} inspect HOSTNAME"
+        )
     end
 
     it "processes help option" do

--- a/spec/integration/support/command_line_examples.rb
+++ b/spec/integration/support/command_line_examples.rb
@@ -36,7 +36,7 @@ shared_examples "CLI" do
         @machinery.run_command("#{machinery_command}", as: "vagrant")
       ).to succeed.and include_stdout(
         "You can get started by inspecting a system. Run:\n#{machinery_command} inspect HOSTNAME"
-        )
+      )
     end
 
     it "processes help option" do

--- a/spec/integration/support/command_line_examples.rb
+++ b/spec/integration/support/command_line_examples.rb
@@ -33,7 +33,7 @@ shared_examples "CLI" do
 
     it "offers hint without options" do
       expect(
-        @machinery.run_command("#{machinery_command}", as: "vagrant")
+        @machinery.run_command(machinery_command.to_s, as: "vagrant")
       ).to succeed.and include_stdout(
         "You can get started by inspecting a system. Run:\n#{machinery_command} inspect HOSTNAME"
       )


### PR DESCRIPTION
Fixes #1286, in which the getting started hint is not printed when calling ```machinery``` without arguments