### PR TITLE
renaming of --exclude-scope option to avoid confusion with global --exclude

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 # Machinery Release Notes
 
+* Rename --exclude-scope option to --ignore-scope to avoid confusion with global --exclude option
 
 ## Version 1.18.0 - Tue Mar 01 13:51:39 CET 2016 - thardeck@suse.de
 

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,6 @@
 # Machinery Release Notes
 
-* Rename --exclude-scope option to --ignore-scope to avoid confusion with global --exclude option
+* Rename --exclude-scope option to --ignore-scope to avoid confusion with global --exclude option (gh#SUSE/machinery#897)
 
 ## Version 1.18.0 - Tue Mar 01 13:51:39 CET 2016 - thardeck@suse.de
 

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -177,19 +177,19 @@ class Cli
   def self.process_scope_option(scopes, exclude_scopes)
     if scopes
       if exclude_scopes
-        # scope and exclude-scope
+        # scope and ignore-scope
         raise Machinery::Errors::InvalidCommandLine.new("You cannot provide the --scope and " \
-          "--exclude-scope option at the same time.")
+          "--ignore-scope option at the same time.")
       else
         # scope only
         scope_list = parse_scopes(scopes)
       end
     else
       if exclude_scopes
-        # exclude-scope only
+        # ignore-scope only
         scope_list = Inspector.all_scopes - parse_scopes(exclude_scopes)
       else
-        # neither scope nor exclude-scope
+        # neither scope nor ignore-scope
         scope_list = Inspector.all_scopes
       end
     end
@@ -341,7 +341,7 @@ class Cli
   command "compare" do |c|
     c.flag [:scope, :s], type: String, required: false,
       desc: "Compare specified scopes", arg_name: "SCOPE_LIST"
-    c.flag ["exclude-scope", :e], type: String, required: false,
+    c.flag ["ignore-scope", :e], type: String, required: false,
       desc: "Exclude specified scopes", arg_name: "SCOPE_LIST"
     c.switch "show-all", required: false, negatable: false,
       desc: "Show also common properties"
@@ -368,7 +368,7 @@ class Cli
       store = system_description_store
       description1 = SystemDescription.load(name1, store)
       description2 = SystemDescription.load(name2, store)
-      scope_list = process_scope_option(options[:scope], options["exclude-scope"])
+      scope_list = process_scope_option(options[:scope], options["ignore-scope"])
 
       task = CompareTask.new
       opts = {
@@ -511,7 +511,7 @@ class Cli
       desc: "Store system description under the specified name"
     c.flag [:scope, :s], type: String, required: false,
       desc: "Show specified scopes", arg_name: "SCOPE_LIST"
-    c.flag ["exclude-scope", :e], type: String, required: false,
+    c.flag ["ignore-scope", :e], type: String, required: false,
       desc: "Exclude specified scopes", arg_name: "SCOPE_LIST"
     c.flag "skip-files", required: false, negatable: false,
       desc: "Do not consider given files or directories during inspection. " \
@@ -535,7 +535,7 @@ class Cli
   end
 
   def self.parse_inspect_command_options(host, options)
-    scope_list = process_scope_option(options[:scope], options["exclude-scope"])
+    scope_list = process_scope_option(options[:scope], options["ignore-scope"])
     name = options[:name] || host
 
 
@@ -773,7 +773,7 @@ class Cli
     supports_filtering(c)
     c.flag [:scope, :s], type: String, required: false,
       desc: "Show specified scopes", arg_name: "SCOPE_LIST"
-    c.flag ["exclude-scope", :e], type: String, required: false,
+    c.flag ["ignore-scope", :e], type: String, required: false,
       desc: "Exclude specified scopes", arg_name: "SCOPE_LIST"
     c.switch "pager", required: false, default_value: true,
       desc: "Pipe output into a pager"
@@ -802,7 +802,7 @@ class Cli
       end
 
       description = SystemDescription.load(name, system_description_store)
-      scope_list = process_scope_option(options[:scope], options["exclude-scope"])
+      scope_list = process_scope_option(options[:scope], options["ignore-scope"])
 
       filter = FilterOptionParser.parse("show", options)
 

--- a/manual/docs/machinery-compare.1.md
+++ b/manual/docs/machinery-compare.1.md
@@ -3,7 +3,7 @@
 
 ## SYNOPSIS
 
-`machinery compare` [-s SCOPE | --scope=SCOPE] [-e ignore-scope | --ignore-scope=ignore-scope] [--no-pager] [--show-all] [--html] NAME1 NAME2
+`machinery compare` [-s SCOPE | --scope=SCOPE] [-e IGNORE-SCOPE | --ignore-scope=IGNORE-SCOPE] [--no-pager] [--show-all] [--html] NAME1 NAME2
 
 `machinery` help compare
 
@@ -29,7 +29,7 @@ be used to limit the output to the given scopes.
     Limit output to the specified scope.
     See the [Scope section](#Scopes) for more information.
 
-  * `-e SCOPE`, `--ignore-scope=ignore-scope` (optional):
+  * `-e SCOPE`, `--ignore-scope=IGNORE-SCOPE` (optional):
     Skip output of the specified scope.
     See the [Scope section](#Scopes) for more information.
 

--- a/manual/docs/machinery-compare.1.md
+++ b/manual/docs/machinery-compare.1.md
@@ -3,7 +3,7 @@
 
 ## SYNOPSIS
 
-`machinery compare` [-s SCOPE | --scope=SCOPE] [-e EXCLUDE-SCOPE | --exclude-scope=EXCLUDE-SCOPE] [--no-pager] [--show-all] [--html] NAME1 NAME2
+`machinery compare` [-s SCOPE | --scope=SCOPE] [-e ignore-scope | --ignore-scope=ignore-scope] [--no-pager] [--show-all] [--html] NAME1 NAME2
 
 `machinery` help compare
 
@@ -29,7 +29,7 @@ be used to limit the output to the given scopes.
     Limit output to the specified scope.
     See the [Scope section](#Scopes) for more information.
 
-  * `-e SCOPE`, `--exclude-scope=EXCLUDE-SCOPE` (optional):
+  * `-e SCOPE`, `--ignore-scope=ignore-scope` (optional):
     Skip output of the specified scope.
     See the [Scope section](#Scopes) for more information.
 

--- a/manual/docs/machinery-inspect-docker.1.md
+++ b/manual/docs/machinery-inspect-docker.1.md
@@ -43,7 +43,7 @@ trigger errors.
     Inspect image for specified scope.
     See the [Scope section](#Scopes) for more information.
 
-  * `-e SCOPE`, `--exclude-scope=EXCLUDE-SCOPE` (optional):
+  * `-e SCOPE`, `--ignore-scope=ignore-scope` (optional):
     Inspect image for all scopes except the specified scope.
     See the [Scope section](#Scopes) for more information.
 

--- a/manual/docs/machinery-inspect-docker.1.md
+++ b/manual/docs/machinery-inspect-docker.1.md
@@ -43,7 +43,7 @@ trigger errors.
     Inspect image for specified scope.
     See the [Scope section](#Scopes) for more information.
 
-  * `-e SCOPE`, `--ignore-scope=ignore-scope` (optional):
+  * `-e SCOPE`, `--ignore-scope=IGNORE-SCOPE` (optional):
     Inspect image for all scopes except the specified scope.
     See the [Scope section](#Scopes) for more information.
 

--- a/manual/docs/machinery-inspect.1.md
+++ b/manual/docs/machinery-inspect.1.md
@@ -38,7 +38,7 @@ trigger errors.
     Inspect system for specified scope.
     See the [Scope section](machinery_main_scopes.1/index.html) for more information.
 
-  * `-e SCOPE`, `--ignore-scope=ignore-scope` (optional):
+  * `-e SCOPE`, `--ignore-scope=IGNORE-SCOPE` (optional):
     Inspect system for all scopes except the specified scope.
     See the [Scope section](machinery_main_scopes.1/index.html) for more information.
 

--- a/manual/docs/machinery-inspect.1.md
+++ b/manual/docs/machinery-inspect.1.md
@@ -38,7 +38,7 @@ trigger errors.
     Inspect system for specified scope.
     See the [Scope section](machinery_main_scopes.1/index.html) for more information.
 
-  * `-e SCOPE`, `--exclude-scope=EXCLUDE-SCOPE` (optional):
+  * `-e SCOPE`, `--ignore-scope=ignore-scope` (optional):
     Inspect system for all scopes except the specified scope.
     See the [Scope section](machinery_main_scopes.1/index.html) for more information.
 

--- a/manual/docs/machinery-show.1.md
+++ b/manual/docs/machinery-show.1.md
@@ -3,7 +3,7 @@
 
 ## SYNOPSIS
 
-`machinery show` [-s SCOPE | --scope=SCOPE] [-e ignore-scope | --ignore-scope=ignore-scope] [--no-pager] [--show-diffs] [--html] NAME
+`machinery show` [-s SCOPE | --scope=SCOPE] [-e IGNORE-SCOPE | --ignore-scope=IGNORE-SCOPE] [--no-pager] [--show-diffs] [--html] NAME
 
 `machinery` help show
 
@@ -30,7 +30,7 @@ in local time are shown in the title of each scope section.
     If displaying information related to a scope fails, `show` will print an error message what has failed.
     In case of an error, no content is displayed.
 
-  * `-e ignore-scope`, `--ignore-scope=ignore-scope` (optional):
+  * `-e IGNORE-SCOPE`, `--ignore-scope=IGNORE-SCOPE` (optional):
     Skip output of the specified scope.
     See the [Scope section](#Scopes) for more information.
 

--- a/manual/docs/machinery-show.1.md
+++ b/manual/docs/machinery-show.1.md
@@ -3,7 +3,7 @@
 
 ## SYNOPSIS
 
-`machinery show` [-s SCOPE | --scope=SCOPE] [-e EXCLUDE-SCOPE | --exclude-scope=EXCLUDE-SCOPE] [--no-pager] [--show-diffs] [--html] NAME
+`machinery show` [-s SCOPE | --scope=SCOPE] [-e ignore-scope | --ignore-scope=ignore-scope] [--no-pager] [--show-diffs] [--html] NAME
 
 `machinery` help show
 
@@ -30,7 +30,7 @@ in local time are shown in the title of each scope section.
     If displaying information related to a scope fails, `show` will print an error message what has failed.
     In case of an error, no content is displayed.
 
-  * `-e EXCLUDE-SCOPE`, `--exclude-scope=EXCLUDE-SCOPE` (optional):
+  * `-e ignore-scope`, `--ignore-scope=ignore-scope` (optional):
     Skip output of the specified scope.
     See the [Scope section](#Scopes) for more information.
 

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -301,7 +301,7 @@ describe Cli do
           ).
           and_return(description)
 
-        run_command(["inspect", "--exclude-scope=packages,repositories", example_host])
+        run_command(["inspect", "--ignore-scope=packages,repositories", example_host])
       end
 
       it "forwards the --skip-files option to the InspectTask as an unmanaged_files filter" do


### PR DESCRIPTION
Referencing #897, in which the coexistence of  ```--exclude-scope``` and the global option ```--exclude``` might result in undesired behaviour.

Thank you for reviewing (: