### PR TITLE
mention remote-user option in hint

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,7 +6,7 @@
   intuitive
 * Following the previous change the analyze operation was also renamed to
   changed-config-files-diffs
-* Rename --exclude-scope option to --ignore-scope to avoid confusion with global --exclude option (gh#SUSE/machinery#897)
+* Rename --exclude-scope option to --ignore-scope (gh#SUSE/machinery#897)
 
 ## Version 1.18.0 - Tue Mar 01 13:51:39 CET 2016 - thardeck@suse.de
 

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 # Machinery Release Notes
 
+* Hint now mentions remote-user option (gh#SUSE/machinery#1813)
+* Hint is printed when `machinery` is called without options (gh#SUSE/machinery#1286)
 * Rename config-files inspector to changed-config-files inspector to be more
   intuitive
 * Following the previous change the analyze operation was also renamed to

--- a/lib/hint.rb
+++ b/lib/hint.rb
@@ -44,7 +44,9 @@ class Hint
     end
 
     def get_started(_options)
-      "You can get started by inspecting a system. Run:\n#{program_name} inspect HOSTNAME"
+      "You can get started by inspecting a system. Run:\n'#{program_name} inspect HOSTNAME'\n" \
+      "To inspect a system as a user with sudo rights instead of root run:\n" \
+      "'#{program_name} inspect --remote-user USER HOSTNAME'"
     end
 
     def upgrade_format_force(options)

--- a/spec/integration/support/command_line_examples.rb
+++ b/spec/integration/support/command_line_examples.rb
@@ -35,7 +35,10 @@ shared_examples "CLI" do
       expect(
         @machinery.run_command(machinery_command.to_s, as: "vagrant")
       ).to succeed.and include_stdout(
-        "You can get started by inspecting a system. Run:\n#{machinery_command} inspect HOSTNAME"
+        "You can get started by inspecting a system. Run:\n" \
+        "'#{machinery_command} inspect HOSTNAME'" \
+        "\nTo inspect a system as a user with sudo rights instead of root run:\n" \
+        "'#{machinery_command} inspect --remote-user USER HOSTNAME'"
       )
     end
 

--- a/spec/unit/hints_spec.rb
+++ b/spec/unit/hints_spec.rb
@@ -81,7 +81,8 @@ describe Hint do
     it "expands program name in get_started hint" do
       $0 = "machinery"
 
-      expect(Hint.to_string(:get_started)).to eq("\nHint: You can get started" \
+      expect(Hint.to_string(:get_started)).to eq(
+        "\nHint: You can get started" \
         " by inspecting a system. Run:\n'machinery inspect HOSTNAME'\n" \
         "To inspect a system as a user with sudo rights instead of root run:\n" \
         "'machinery inspect --remote-user USER HOSTNAME'\n"

--- a/spec/unit/hints_spec.rb
+++ b/spec/unit/hints_spec.rb
@@ -82,7 +82,10 @@ describe Hint do
       $0 = "machinery"
 
       expect(Hint.to_string(:get_started)).to eq("\nHint: You can get started" \
-       " by inspecting a system. Run:\nmachinery inspect HOSTNAME\n")
+        " by inspecting a system. Run:\n'machinery inspect HOSTNAME'\n" \
+        "To inspect a system as a user with sudo rights instead of root run:\n" \
+        "'machinery inspect --remote-user USER HOSTNAME'\n"
+      )
     end
 
     describe ".program_name" do


### PR DESCRIPTION
Fixes #1813, in which the hint doesn't mention the remote-user option.
Squashed #2015 