### PR TITLE
Issue #1496: Piping `machinery help` makes machinery crash

### DIFF
--- a/lib/hint.rb
+++ b/lib/hint.rb
@@ -41,6 +41,9 @@ class Hint
 
     def which_machinery
       `which machinery 2>/dev/null`.chomp
+    rescue Errno::EPIPE => e
+      Machinery.logger.debug "Command `which machinery 2>/dev/null` crashed. " \
+                             "Error was #{e.class}: #{e}"
     end
 
     def get_started(_options)


### PR DESCRIPTION
Fixes #1496 

_Follow up to #2023 to make the changes Hound-compliant._ :)

[This](https://github.com/SUSE/machinery/blob/master/lib/hint.rb#L43) is the line causing the crash. Here I catch the error it raises in order to avoid machinery exposing the crash to the user. It might be worth it to investigate further why the execution of `which machinery 2>/dev/null'.chomp` sometimes throw `Errno::EPIPE`.
