### PR TITLE
Remove repositories scope from check in autoyast-export to avoid missing scope error

### DIFF
--- a/lib/autoyast.rb
+++ b/lib/autoyast.rb
@@ -24,7 +24,6 @@ class Autoyast < Exporter
     @system_description = description
     @system_description.assert_scopes(
       "os",
-      "repositories",
       "packages"
     )
     check_exported_os


### PR DESCRIPTION
Fixes #2024, in which exporting a description with no 'repositories scope' to autoyast does not work, although it's supposed to work nevertheless.