### PR TITLE
Filter broken utf-8 characters in renderer

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 # Machinery Release Notes
 
+* Fix regression which prevented changed-config-file diffs from being shown
+  in the HTML output
 * Hint now mentions remote-user option (gh#SUSE/machinery#1813)
 * Hint is printed when `machinery` is called without options (gh#SUSE/machinery#1286)
 * Rename config-files inspector to changed-config-files inspector to be more

--- a/lib/renderer.rb
+++ b/lib/renderer.rb
@@ -205,7 +205,7 @@ class Renderer
   end
 
   def puts(s)
-    print_indented "#{s}"
+    print_indented Machinery.scrub(s)
   end
 
   def list(name = nil, options = {}, &block)
@@ -237,7 +237,7 @@ class Renderer
       )
     end
 
-    print_indented "* #{s}"
+    print_indented "* #{Machinery.scrub(s)}"
 
     if block_given?
       @stack << :item

--- a/lib/server.rb
+++ b/lib/server.rb
@@ -330,7 +330,7 @@ class Server < Sinatra::Base
   get "/:id" do
     @description = SystemDescription.load(params[:id], settings.system_description_store)
 
-    diffs_dir = @description.scope_file_store("analyze/config_file_diffs").path
+    diffs_dir = @description.scope_file_store("analyze/changed_config_files_diffs").path
     if @description.changed_config_files && diffs_dir
       # Enrich description with the config file diffs
       @description.changed_config_files.each do |file|

--- a/spec/features/analyze_file_diff_spec.rb
+++ b/spec/features/analyze_file_diff_spec.rb
@@ -36,8 +36,12 @@ RSpec.describe "Analyze File Diff", type: :feature do
       "Other content\n"
     )
 
-    diff_file_path = File.join(description.description_path, "analyze", "config_file_diffs",
-                               File.dirname(file.name))
+    diff_file_path = File.join(
+      description.description_path,
+      "analyze",
+      "changed_config_files_diffs",
+      File.dirname(file.name)
+    )
 
     FileUtils.mkdir_p(diff_file_path)
     crontab_diff = <<EOF

--- a/spec/unit/renderer_spec.rb
+++ b/spec/unit/renderer_spec.rb
@@ -275,6 +275,14 @@ EOF
 
       expect(renderer.render(description)).to include("  line 1\n  line 2")
     end
+
+    it "can handle broken utf-8 characters" do
+      def renderer.content(_description)
+        puts "\255"
+      end
+
+      expect { renderer.render(description) }.not_to raise_error
+    end
   end
 
   describe "#render_comparison" do


### PR DESCRIPTION
The HTML output did already escaped broken utf-8 characters but there was a regression found during testing which still used the old path before migration.