### PR TITLE
Show remote url when using serve --public

### DIFF
--- a/lib/html.rb
+++ b/lib/html.rb
@@ -30,17 +30,17 @@ class Html
 
         Machinery::Ui.warn <<-EOF.chomp
 Warning:
-The --public option makes the HTTP server listen on all configured IP addresses. Everyone who has access to one of those IP addresses can access all of your system descriptions stored in '~/.machinery'. Be careful if there are sensible information (such as private keys) stored in one of your descriptions.
+The --public option makes the HTTP server listen on all configured IP addresses. Everyone who has access to one of those IP addresses can access all of your system descriptions stored in '~/.machinery'. Be careful if there is sensitive information (such as private keys) stored in one of your descriptions.
 EOF
       elsif opts[:ip] == "0.0.0.0"
         Machinery::Ui.warn <<-EOF.chomp
 Warning:
-The server is listening on all configured IP addresses. Everyone who has access to one of those IP addresses can access all of your system descriptions stored in '~/.machinery'. Be careful if there are sensible information (such as private keys) stored in one of your descriptions.
+The server is listening on all configured IP addresses. Everyone who has access to one of those IP addresses can access all of your system descriptions stored in '~/.machinery'. Be careful if there is sensitive information (such as private keys) stored in one of your descriptions.
 EOF
       elsif opts[:ip] && opts[:ip] != "localhost" && opts[:ip] != "127.0.0.1"
         Machinery::Ui.warn <<-EOF.chomp
 Warning:
-You specified an IP address other than '127.0.0.1', your server may be reachable from the network. Everyone who can access that network can access your system descriptions stored in '~/.machinery'. Be careful if there are sensible information (such as private keys) stored in one of your descriptions.
+You specified an IP address other than '127.0.0.1', your server may be reachable from the network. Everyone who can access that network can access your system descriptions stored in '~/.machinery'. Be careful if there is sensitive information (such as private keys) stored in one of your descriptions.
 EOF
       elsif !opts[:ip]
         opts[:ip] = "127.0.0.1"

--- a/lib/serve_html_task.rb
+++ b/lib/serve_html_task.rb
@@ -17,7 +17,12 @@
 
 class ServeHtmlTask
   def serve(system_description_store, opts)
-    url = "http://127.0.0.1:#{opts[:port]}/"
+    hostname = Socket.gethostbyname(Socket.gethostname).first
+    url = "http://#{hostname}:#{opts[:port]}/"
+    if opts[:public]
+      remote_ip = Socket.ip_address_list.find { |ip| ip.ipv4? && !ip.ipv4_loopback? }.ip_address
+      remote_url = "http://#{remote_ip}:#{opts[:port]}/"
+    end
     Machinery::Ui.use_pager = false
     Machinery::Ui.puts <<EOF
 Trying to start a web server for serving a view on all system descriptions.
@@ -25,8 +30,9 @@ Trying to start a web server for serving a view on all system descriptions.
 The overview of all descriptions is accessible at:
 
     #{url}
+    #{remote_url}
 
-A specific descriptions with the name NAME is accessible at:
+A specific description with the name NAME is accessible at:
 
     #{url}NAME
 


### PR DESCRIPTION
Fixes #1699, in which the enhancement of showing the remote url for ```serve --public``` was suggested.