### PR TITLE
Issue #1940: machinery serve with an old format version triggers exception

### DIFF
--- a/html/upgrade.html.haml
+++ b/html/upgrade.html.haml
@@ -1,0 +1,49 @@
+!!!
+%html
+  %head
+    %title
+      Machinery Error: incompatible system description
+    %meta{ :charset => 'utf-8' }
+    %link{ :href => "assets/machinery-base.css", :rel => "stylesheet", :type => "text/css" }
+    %link{ :href => "assets/machinery.css", :rel => "stylesheet", :type => "text/css" }
+    %script{ :src => "assets/jquery-2.1.1.min.js" }
+    %script{ :src => "assets/transition.js" }
+    %script{ :src => "assets/collapse.js" }
+    %script{ :src => "assets/modal.js" }
+    %script{ :src => "assets/jquery.searcher.min.js" }
+    %script{ :src => "assets/machinery-base.js" }
+    %script{ :src => "assets/show/machinery.js" }
+    %script{ :src => "assets/bootstrap-tooltip.js" }
+    %script{ :src => "assets/bootstrap-popover.js" }
+
+  %body
+    .container-fluid
+      #nav-bar
+        .row
+          .col-xs-1
+          .col-xs-10
+            %h1
+              System Description incompatible!
+        .row
+          .col-xs-1
+          .col-xs-4
+            Incompatible format version of system description
+          .col-xs-10.nav-buttons
+            %small.pull-right
+              created by
+              %a{ :href => "http://machinery-project.org", :target => "_blank" }
+                Machinery
+              %br
+              %a{ :href => "/site/docs/", :target => "_blank" }
+                Machinery documentation
+      #content_container
+        .row
+          .col-xs-11
+            - if @error
+              .scope#alert_container
+                .row
+                  .col-xs-10.col-xs-offset-1
+                    .well
+                      %span
+                        %p
+                          = @error

--- a/spec/unit/server_spec.rb
+++ b/spec/unit/server_spec.rb
@@ -60,13 +60,49 @@ describe Server do
   end
 
   describe "show" do
-    describe "GET /:id" do
-      it "returns the page" do
-        get "/#{description_a.name}"
+    context "description with incompatible format version" do
+      describe "GET /:id" do
+        let(:old_format_version) {
+          create_test_description(
+            name: "old_format_version",
+            store_on_disk: true,
+            scopes: ["os"],
+            format_version: 7
+          )
+        }
+        let(:unknown_format_version) {
+          create_test_description(
+            name: "unknown_format_version",
+            store_on_disk: true,
+            scopes: ["os"],
+            format_version: 12
+          )
+        }
 
-        expect(last_response).to be_ok
-        expect(last_response.body).
-          to include("#{description_a.name} - Machinery System Description")
+        it "returns update instructions for lower format versions" do
+          get "/#{old_format_version.name}"
+          expect(last_response).to be_ok
+          expect(last_response.body).
+            to include("Machinery Error: incompatible system description")
+        end
+
+        it "returns update instructions for higher format versions" do
+          get "/#{unknown_format_version.name}"
+          expect(last_response).to be_ok
+          expect(last_response.body).
+            to include("Machinery Error: incompatible system description")
+        end
+      end
+    end
+
+    context "compatible format version" do
+      describe "GET /:id" do
+        it "returns the page" do
+          get "/#{description_a.name}"
+          expect(last_response).to be_ok
+          expect(last_response.body).
+            to include("#{description_a.name} - Machinery System Description")
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #1940, in which an outdated format of a description throws an exception when pasted directly into the browser after calling machinery serve.
The suggested fix was catching the error and displaying an HTML view with instructions on how to upgrade.

Supersedes #2043 