### PR TITLE
Issue #1820: wording of patterns on Debian-like systems

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,8 @@
   intuitive
 * Following the previous change the analyze operation was also renamed to
   changed-config-files-diffs
+* Add explanation for patterns-tasks relationship for Debian based
+  systems (gh#SUSE/machinery#1820)
 * Public serve task now prints hostname for sharing (gh#SUSE/machinery#1699)
 * Fix export of description with no repositories scope to Autoyast (gh#SUSE/machinery#2024)
 * Only use required packages for bootstrap in Kiwi export

--- a/html/partials/patterns.html.haml
+++ b/html/partials/patterns.html.haml
@@ -6,6 +6,11 @@
         :scope => "patterns",
         :title => "Patterns",
         :count => "#{patterns.length} #{Machinery.pluralize(patterns.length, "pattern")}"
+      - if @description.packages && @description.packages.package_system == "dpkg"
+        .row
+          .col-xs-1
+          .col-xs-11
+            Note: Tasks on Debian-like systems are treated as patterns.
       .row.scope_content.collapse.in
         .col-xs-1
         .col-xs-11

--- a/lib/server.rb
+++ b/lib/server.rb
@@ -347,6 +347,7 @@ class Server < Sinatra::Base
           file.diff = diff_to_object(File.read(path)) if File.exist?(path)
         end
       end
+
       haml File.read(File.join(Machinery::ROOT, "html/index.html.haml"))
     end
   end

--- a/manual/docs/machinery-inspect.1.md
+++ b/manual/docs/machinery-inspect.1.md
@@ -20,6 +20,9 @@ The system data is structured into scopes, controlled by the
 Machinery will always inspect all specified scopes, and skip scopes which
 trigger errors.
 
+**Note**:
+Tasks on Debian-like systems are treated as patterns.
+
 
 ## ARGUMENTS
 

--- a/plugins/patterns/patterns.yml
+++ b/plugins/patterns/patterns.yml
@@ -2,8 +2,10 @@
 :name: Patterns
 :initials: pt
 :description: |
-  Contains all patterns installed on the inspected system. A pattern is a
-  collection of software packages.
+  Contains all patterns or tasks installed on the inspected system. A pattern is a
+  collection of software packages, similar to the idea of tasks on Debian/Ubuntu-
+  like systems.
   The meaning of software patterns depends on the package manager of the
   distribution. Therefore, the pattern scope on SUSE based systems uses the
-  `zypper` command to obtain the information about installed pattern names.
+  `zypper` command to obtain the information about installed pattern names, whereas
+  on Debian based systems the `tasksel` tool is necessary to list installed tasks.

--- a/plugins/patterns/patterns_inspector.rb
+++ b/plugins/patterns/patterns_inspector.rb
@@ -28,17 +28,18 @@ class PatternsInspector < Inspector
       inspect_with_zypper
     elsif @system.has_command?("dpkg")
       if @system.has_command?("tasksel")
+        Machinery::Ui.puts "Note: Tasks on Debian-like systems are treated as patterns."
         @patterns_supported = true
         inspect_with_tasksel
       else
         @patterns_supported = false
-        @status = "For a patterns inspection please install the package tasksel " \
+        @status = "For a patterns (tasks) inspection please install the package tasksel " \
           "on the inspected system."
         @description.patterns = PatternsScope.new
       end
     else
       @patterns_supported = false
-      @status = "Patterns are not supported on this system."
+      @status = "Patterns or tasks are not supported on this system."
       @description.patterns = PatternsScope.new
     end
   end

--- a/plugins/patterns/patterns_renderer.rb
+++ b/plugins/patterns/patterns_renderer.rb
@@ -20,7 +20,11 @@ class PatternsRenderer < Renderer
     return unless description.patterns
 
     if description.patterns.empty?
-      puts "There are no patterns."
+      puts "There are no patterns or tasks."
+    end
+
+    if description.packages && description.packages.package_system == "dpkg"
+      puts "Note: Tasks on Debian-like systems are treated as patterns."
     end
 
     list do

--- a/spec/data/autoyast/simple.xml
+++ b/spec/data/autoyast/simple.xml
@@ -42,6 +42,7 @@
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>
+      <pattern>Minimal</pattern>
     </patterns>
   </software>
   <users config:type="list">

--- a/spec/data/docker/patterns/base_opensuse13.2
+++ b/spec/data/docker/patterns/base_opensuse13.2
@@ -1,3 +1,3 @@
 # Patterns [192.168.121.194] (2014-11-25 18:38:32)
 
-  There are no patterns.
+  There are no patterns or tasks.

--- a/spec/support/system_description_factory.rb
+++ b/spec/support/system_description_factory.rb
@@ -418,6 +418,23 @@ module SystemDescriptionFactory
       ]
     }
   EOF
+  EXAMPLE_SCOPES["dpkg_packages"] = <<-EOF.chomp
+    "packages": {
+      "_attributes": {
+        "package_system": "dpkg"
+      },
+      "_elements": [
+        {
+          "name": "zlib1g:amd64",
+          "version": "1:1.2.8.dfsg",
+          "release": "1ubuntu1",
+          "arch": "amd64",
+          "checksum": "468af3913970b3264a2525959e37a871",
+          "vendor": "Ubuntu"
+        }
+      ]
+    }
+  EOF
   EXAMPLE_SCOPES["empty_patterns"] = <<-EOF.chomp
     "patterns": {
       "_elements": []

--- a/spec/support/system_description_factory.rb
+++ b/spec/support/system_description_factory.rb
@@ -430,6 +430,11 @@ module SystemDescriptionFactory
           "name": "base",
           "version": "13.1",
           "release": "13.6.1"
+        },
+        {
+          "name": "Minimal",
+          "version": "11",
+          "release": "38.44.33"
         }
       ]
     }

--- a/spec/unit/kiwi_config_spec.rb
+++ b/spec/unit/kiwi_config_spec.rb
@@ -110,6 +110,7 @@ describe KiwiConfig do
     <package name="bash"/>
     <package name="autofs"/>
     <namedCollection name="base"/>
+    <namedCollection name="Minimal"/>
   </packages>
 </image>
 EOT

--- a/spec/unit/patterns_inspector_spec.rb
+++ b/spec/unit/patterns_inspector_spec.rb
@@ -74,6 +74,7 @@ EOF
     context "on a zypper based OS" do
       before(:each) do
         allow(system).to receive(:has_command?).with("zypper").and_return(true)
+        allow(system).to receive(:has_command?).with("dpkg").and_return(false)
       end
 
       it "parses the patterns list into a Hash" do
@@ -158,7 +159,8 @@ EOF
 
       patterns_inspector.inspect(filter)
       expect(patterns_inspector.summary).to eq(
-        "For a patterns inspection please install the package tasksel on the inspected system."
+        "For a patterns (tasks) inspection please install the package tasksel " \
+        "on the inspected system."
       )
       expect(description.patterns).to eql(PatternsScope.new)
     end
@@ -169,7 +171,9 @@ EOF
       allow(system).to receive(:has_command?).with("dpkg").and_return(false)
 
       patterns_inspector.inspect(filter)
-      expect(patterns_inspector.summary).to eq("Patterns are not supported on this system.")
+      expect(patterns_inspector.summary).to eq(
+        "Patterns or tasks are not supported on this system."
+      )
       expect(description.patterns).to eql(PatternsScope.new)
     end
   end

--- a/spec/unit/patterns_renderer_spec.rb
+++ b/spec/unit/patterns_renderer_spec.rb
@@ -18,33 +18,27 @@
 require_relative "spec_helper"
 
 describe PatternsRenderer do
-  let(:system_description) {
-    create_test_description(json: <<-EOF)
-      {
-        "patterns": {
-          "_elements": [
-            {
-              "name": "base",
-              "version": "11",
-              "release": "38.44.33"
-            },
-            {
-              "name": "Minimal",
-              "version": "11",
-              "release": "38.44.33"
-            }
-          ]
-        }
-      }
-    EOF
-  }
-
   describe "#render" do
-    it "prints a pattern list" do
-      output = PatternsRenderer.new.render(system_description)
+    context "when showing an rpm-based system" do
+      let(:system_description) { create_test_description(scopes: ["patterns"]) }
 
-      expect(output).to include("base\n")
-      expect(output).to include("Minimal\n")
+      it "prints a pattern list" do
+        output = PatternsRenderer.new.render(system_description)
+
+        expect(output).to include("base\n")
+        expect(output).to include("Minimal\n")
+      end
+
+
+      context "when there are no patterns" do
+        let(:system_description) { create_test_description(scopes: ["empty_patterns"]) }
+
+        it "shows a message" do
+          output = subject.render(system_description)
+
+          expect(output).to include("There are no patterns or tasks.")
+        end
+      end
     end
 
     context "when there are no patterns" do

--- a/spec/unit/patterns_renderer_spec.rb
+++ b/spec/unit/patterns_renderer_spec.rb
@@ -29,6 +29,11 @@ describe PatternsRenderer do
         expect(output).to include("Minimal\n")
       end
 
+      it "does not show the dpkg message" do
+        output = subject.render(system_description)
+
+        expect(output).not_to include("Note: Tasks on Debian-like systems are treated as patterns.")
+      end
 
       context "when there are no patterns" do
         let(:system_description) { create_test_description(scopes: ["empty_patterns"]) }
@@ -41,13 +46,13 @@ describe PatternsRenderer do
       end
     end
 
-    context "when there are no patterns" do
-      let(:system_description) { create_test_description(scopes: ["empty_patterns"]) }
+    context "when showing a Debian based system" do
+      let(:system_description) { create_test_description(scopes: ["patterns", "dpkg_packages"]) }
 
-      it "shows a message" do
+      it "shows a note" do
         output = subject.render(system_description)
 
-        expect(output).to include("There are no patterns.")
+        expect(output).to include("Note: Tasks on Debian-like systems are treated as patterns.")
       end
     end
   end


### PR DESCRIPTION
Fixes #1820, where the explanation for the patterns scope for descriptions on Debian-like systems was not clear enough.

Supersedes #2051 
