### PR TITLE
Issue #2046: HTML View doesn't List Name of a Broken System Description

### DIFF
--- a/lib/system_description.rb
+++ b/lib/system_description.rb
@@ -94,7 +94,9 @@ class SystemDescription < Machinery::Object
         if json_format_version && json_format_version != SystemDescription::CURRENT_FORMAT_VERSION
           raise Machinery::Errors::SystemDescriptionIncompatible.new(name, json_format_version)
         else
-          raise Machinery::Errors::SystemDescriptionError.new
+          raise Machinery::Errors::SystemDescriptionError.new(
+            "#{name}: This description is broken."
+          )
         end
       end
 

--- a/spec/unit/server_spec.rb
+++ b/spec/unit/server_spec.rb
@@ -191,6 +191,32 @@ EOF
         end
       end
     end
+
+    context "broken description" do
+      before do
+        store_raw_description(
+          "foo", <<-EOT
+            {
+              "unmanaged_files": {
+                  "_attributes": {
+                      "has_metadata": false,
+                      "foo": true
+                  }
+              }
+            }
+            EOT
+        )
+      end
+
+      describe "GET /" do
+        it "shows a 'description is broken' error message" do
+          get "/"
+
+          expect(last_response).to be_ok
+          expect(last_response.body).to include("This description is broken.")
+        end
+      end
+    end
   end
 
   describe Server::Helpers do


### PR DESCRIPTION
Fixes #2046
Supersedes #2053 

I've included the same message as the one showed when machinery list is executed in order to keep consistency.