### PR TITLE
Issue #2047: Error for Accessing Broken System Description

### DIFF
--- a/html/exception.html.haml
+++ b/html/exception.html.haml
@@ -2,7 +2,7 @@
 %html
   %head
     %title
-      Machinery Error: incompatible system description
+      Machinery Error
     %meta{ :charset => 'utf-8' }
     %link{ :href => "assets/machinery-base.css", :rel => "stylesheet", :type => "text/css" }
     %link{ :href => "assets/machinery.css", :rel => "stylesheet", :type => "text/css" }
@@ -23,11 +23,7 @@
           .col-xs-1
           .col-xs-10
             %h1
-              System Description incompatible!
-        .row
-          .col-xs-1
-          .col-xs-4
-            Incompatible format version of system description
+              = render_exception_title
           .col-xs-10.nav-buttons
             %small.pull-right
               created by

--- a/lib/server.rb
+++ b/lib/server.rb
@@ -335,9 +335,10 @@ class Server < Sinatra::Base
     rescue Machinery::Errors::SystemDescriptionNotFound => e
       session[:error] = e.to_s
       redirect "/"
-    rescue Machinery::Errors::SystemDescriptionIncompatible => e
+    rescue Machinery::Errors::SystemDescriptionIncompatible, \
+           Machinery::Errors::SystemDescriptionError => e
       @error = e
-      haml File.read(File.join(Machinery::ROOT, "html/upgrade.html.haml"))
+      haml File.read(File.join(Machinery::ROOT, "html/exception.html.haml"))
     else
       diffs_dir = @description.scope_file_store("analyze/changed_config_files_diffs").path
       if @description.changed_config_files && diffs_dir
@@ -359,6 +360,15 @@ class Server < Sinatra::Base
       @errors ||= Array.new
       @errors.push(session[:error])
       session.clear
+    end
+  end
+
+  def render_exception_title
+    case @error
+    when Machinery::Errors::SystemDescriptionIncompatible
+      return "System Description incompatible!"
+    when Machinery::Errors::SystemDescriptionError
+      return "System Description broken!"
     end
   end
 end

--- a/spec/unit/server_spec.rb
+++ b/spec/unit/server_spec.rb
@@ -83,14 +83,14 @@ describe Server do
           get "/#{old_format_version.name}"
           expect(last_response).to be_ok
           expect(last_response.body).
-            to include("Machinery Error: incompatible system description")
+            to include("System Description incompatible!")
         end
 
         it "returns update instructions for higher format versions" do
           get "/#{unknown_format_version.name}"
           expect(last_response).to be_ok
           expect(last_response.body).
-            to include("Machinery Error: incompatible system description")
+            to include("System Description incompatible!")
         end
       end
     end
@@ -193,7 +193,7 @@ EOF
     end
 
     context "broken description" do
-      before do
+      before(:each) do
         store_raw_description(
           "foo", <<-EOT
             {
@@ -204,7 +204,7 @@ EOF
                   }
               }
             }
-            EOT
+          EOT
         )
       end
 
@@ -214,6 +214,14 @@ EOF
 
           expect(last_response).to be_ok
           expect(last_response.body).to include("This description is broken.")
+        end
+      end
+
+      describe "GET /:id" do
+        it "returns error message view" do
+          get "/foo"
+          expect(last_response).to be_ok
+          expect(last_response.body).to include("System Description broken!")
         end
       end
     end


### PR DESCRIPTION
Fixes #2047, in which directly accessing a broken description after calling machinery serve results in an exception page. 
Supersedes #2058