### PR TITLE
Use /etc/sudo for Tumbleweed integration test

### DIFF
--- a/spec/integration/machinery_opensuse_tumbleweed_spec.rb
+++ b/spec/integration/machinery_opensuse_tumbleweed_spec.rb
@@ -65,7 +65,7 @@ describe "machinery@Tumbleweed" do
       "changed-config-files" =>
         [
           /Files extracted: yes$/,
-          /\* \/etc\/auto\.master \(autofs-\d+.*, size, md5\)$/
+          /\* \/etc\/sudoers \(sudo-\d+.*, size, md5\)$/
         ],
       "changed-managed-files" =>
         [


### PR DESCRIPTION
because /etc/auto.master is not available if remote fs mounts are
disabled.