### PR TITLE
Add missing release checks

### DIFF
--- a/tools/release_checks.rb
+++ b/tools/release_checks.rb
@@ -23,6 +23,8 @@ module ReleaseChecks
   def check
     check_tag
     check_jenkins_state("https://ci.opensuse.org/job/machinery-unit/lastStableBuild/api/json")
+    check_jenkins_state("https://ci.opensuse.org/job/machinery-integration/lastStableBuild/api/json")
+    check_jenkins_state("https://ci.opensuse.org/job/machinery-helper/lastStableBuild/api/json")
   end
 
   private


### PR DESCRIPTION
The integration test json link did not work in our Jenkins
implementation previously but it seems to be fixed.
So we add the check to make sure that all external tests are green
before release.