### PR TITLE
Filter .dockerinit in integration tests

### DIFF
--- a/spec/data/docker/unmanaged-files/base_opensuse13.2
+++ b/spec/data/docker/unmanaged-files/base_opensuse13.2
@@ -6,11 +6,6 @@
     Mode: 755
     Size: 0 B
 
-  * /.dockerinit (file)
-    User/Group: root:root
-    Mode: 755
-    Size: 0 B
-
   * /etc/.pwd.lock (file)
     User/Group: root:root
     Mode: 600

--- a/spec/data/docker/unmanaged-files/base_opensuse13.2_files_tgz_content
+++ b/spec/data/docker/unmanaged-files/base_opensuse13.2_files_tgz_content
@@ -1,5 +1,4 @@
 .dockerenv
-.dockerinit
 etc/.pwd.lock
 etc/ImageVersion
 etc/fstab

--- a/spec/integration/support/inspect_unmanaged_files_examples.rb
+++ b/spec/integration/support/inspect_unmanaged_files_examples.rb
@@ -29,7 +29,8 @@ shared_examples "inspect unmanaged files" do |base, skip_remote_mounts_test|
         "/var/lib/dpkg",
         "/var/lib/apt",
         "/var/lib/ureadahead",
-        "/var/log/upstart"
+        "/var/log/upstart",
+        "/.dockerinit"
       ]
     }
 


### PR DESCRIPTION
because the new Docker version does not seem to create this file
anymore.