### PR TITLE
Add attribute in patterns scope to identify the patterns manager

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 # Machinery Release Notes
 
+* Add attribute in patterns scope to identify the patterns manager
 * Improve navigation in HTML view to connect "list", "show" and "compare"
   functionality
 * Fix service inspector on systemd to include instanciated services

--- a/html/partials/patterns.html.haml
+++ b/html/partials/patterns.html.haml
@@ -6,7 +6,7 @@
         :scope => "patterns",
         :title => "Patterns",
         :count => "#{patterns.length} #{Machinery.pluralize(patterns.length, "pattern")}"
-      - if @description.packages && @description.packages.package_system == "dpkg"
+      - if @description.patterns.patterns_system == "dpkg"
         .row
           .col-xs-1
           .col-xs-11

--- a/plugins/patterns/patterns_inspector.rb
+++ b/plugins/patterns/patterns_inspector.rb
@@ -84,6 +84,7 @@ class PatternsInspector < Inspector
     end.uniq.sort_by(&:name)
 
     @description.patterns = PatternsScope.new(patterns)
+    @description.patterns.attributes["patterns_system"] = "zypper"
   end
 
   def inspect_with_tasksel
@@ -98,5 +99,6 @@ class PatternsInspector < Inspector
     end.uniq.sort_by(&:name)
 
     @description.patterns = PatternsScope.new(patterns)
+    @description.patterns.attributes["patterns_system"] = "tasksel"
   end
 end

--- a/plugins/patterns/patterns_model.rb
+++ b/plugins/patterns/patterns_model.rb
@@ -22,6 +22,7 @@ end
 class PatternsScope < Machinery::Array
   include Machinery::Scope
 
+  has_attributes :patterns_system
   has_elements class: Pattern
 
   def compare_with(other)

--- a/plugins/patterns/patterns_renderer.rb
+++ b/plugins/patterns/patterns_renderer.rb
@@ -23,9 +23,12 @@ class PatternsRenderer < Renderer
       puts "There are no patterns or tasks."
     end
 
-    if description.packages && description.packages.package_system == "dpkg"
+    if description.patterns.patterns_system == "tasksel"
       puts "Note: Tasks on Debian-like systems are treated as patterns."
     end
+
+    puts "Pattern Manager: #{description.patterns.patterns_system}" unless
+      description.patterns.empty?
 
     list do
       description.patterns.each do |p|

--- a/plugins/patterns/schema/system-description-patterns.schema-v10.json
+++ b/plugins/patterns/schema/system-description-patterns.schema-v10.json
@@ -7,7 +7,19 @@
   ],
   "properties": {
     "_attributes": {
-      "type": "object"
+      "type": "object",
+      "required": [
+        "patterns_system"
+      ],
+      "properties": {
+        "patterns_system": {
+          "oneOf": [
+            {
+              "enum": ["zypper", "tasksel"]
+            }
+          ]
+        }
+      }
     },
     "_elements": {
       "oneof": [
@@ -55,4 +67,3 @@
     }
   }
 }
-

--- a/spec/data/descriptions/jeos/opensuse131/manifest.json
+++ b/spec/data/descriptions/jeos/opensuse131/manifest.json
@@ -3110,6 +3110,7 @@
   },
   "patterns": {
     "_attributes": {
+      "patterns_system": "zypper"
     },
     "_elements": [
       {

--- a/spec/data/descriptions/jeos/opensuse132/manifest.json
+++ b/spec/data/descriptions/jeos/opensuse132/manifest.json
@@ -1773,6 +1773,7 @@
   },
   "patterns": {
     "_attributes": {
+      "patterns_system": "zypper"
     },
     "_elements": [
       {

--- a/spec/data/descriptions/jeos/opensuse_leap/manifest.json
+++ b/spec/data/descriptions/jeos/opensuse_leap/manifest.json
@@ -1761,6 +1761,7 @@
   },
   "patterns": {
     "_attributes": {
+      "patterns_system": "zypper"
     },
     "_elements": [
       {

--- a/spec/data/descriptions/opensuse_leap-build/manifest.json
+++ b/spec/data/descriptions/opensuse_leap-build/manifest.json
@@ -1777,6 +1777,7 @@
   },
   "patterns": {
     "_attributes": {
+      "patterns_system" : "zypper"
     },
     "_elements": [
       {

--- a/spec/data/patterns/opensuse131
+++ b/spec/data/patterns/opensuse131
@@ -1,4 +1,4 @@
 # Patterns [192.168.122.238] (2014-05-21 13:59:16)
 
+  Pattern Manager: zypper
   * base
-

--- a/spec/data/patterns/opensuse132
+++ b/spec/data/patterns/opensuse132
@@ -1,4 +1,4 @@
 # Patterns [192.168.121.194] (2014-11-25 18:38:32)
 
+  Pattern Manager: zypper
   * base
-

--- a/spec/data/patterns/opensuse_leap
+++ b/spec/data/patterns/opensuse_leap
@@ -1,5 +1,4 @@
 # Patterns [192.168.121.39] (2015-11-05 17:42:00)
 
+  Pattern Manager: zypper
   * base
-
-

--- a/spec/data/patterns/ubuntu_1404
+++ b/spec/data/patterns/ubuntu_1404
@@ -1,4 +1,5 @@
 # Patterns [192.168.121.176] (2015-12-14 15:10:04)
 
+  Note: Tasks on Debian-like systems are treated as patterns.
+  Pattern Manager: tasksel
   * openssh-server
-

--- a/spec/support/system_description_factory.rb
+++ b/spec/support/system_description_factory.rb
@@ -459,6 +459,10 @@ module SystemDescriptionFactory
   EOF
   EXAMPLE_SCOPES["patterns"] = <<-EOF.chomp
     "patterns": {
+      "_attributes" :
+        {
+          "patterns_system": "zypper"
+        },
       "_elements": [
         {
           "name": "base",
@@ -469,6 +473,19 @@ module SystemDescriptionFactory
           "name": "Minimal",
           "version": "11",
           "release": "38.44.33"
+        }
+      ]
+    }
+  EOF
+  EXAMPLE_SCOPES["patterns_with_dpkg"] = <<-EOF.chomp
+    "patterns": {
+      "_attributes" :
+        {
+          "patterns_system": "tasksel"
+        },
+      "_elements": [
+        {
+          "name": "base"
         }
       ]
     }

--- a/spec/unit/patterns_inspector_spec.rb
+++ b/spec/unit/patterns_inspector_spec.rb
@@ -125,6 +125,13 @@ EOF
         expect { patterns_inspector.inspect(filter) }.to raise_error(
           Machinery::Errors::ZypperFailed, /Zypper is locked./)
       end
+
+      it "returns patterns_system zypper" do
+        expect(system).to receive(:run_command).and_return(zypper_output)
+        patterns_inspector.inspect(filter)
+        patterns_system = description.patterns.attributes["patterns_system"]
+        expect(patterns_system).to eq("zypper")
+      end
     end
 
     context "on a tasksel based OS" do
@@ -148,6 +155,12 @@ EOF
         )
 
         expect(patterns_inspector.summary).to include("Found 5 patterns")
+      end
+
+      it "returns patterns_system tasksel" do
+        expect(system).to receive(:run_command).and_return(tasksel_output)
+        patterns_inspector.inspect(filter)
+        expect(description.patterns.attributes["patterns_system"]).to eq("tasksel")
       end
     end
 

--- a/spec/unit/patterns_renderer_spec.rb
+++ b/spec/unit/patterns_renderer_spec.rb
@@ -35,6 +35,12 @@ describe PatternsRenderer do
         expect(output).not_to include("Note: Tasks on Debian-like systems are treated as patterns.")
       end
 
+      it "does show pattern_sytem zypper" do
+        output = subject.render(system_description)
+
+        expect(output).to include("Pattern Manager: zypper")
+      end
+
       context "when there are no patterns" do
         let(:system_description) { create_test_description(scopes: ["empty_patterns"]) }
 
@@ -47,12 +53,18 @@ describe PatternsRenderer do
     end
 
     context "when showing a Debian based system" do
-      let(:system_description) { create_test_description(scopes: ["patterns", "dpkg_packages"]) }
+      let(:system_description) { create_test_description(scopes: ["patterns_with_dpkg"]) }
 
       it "shows a note" do
         output = subject.render(system_description)
 
         expect(output).to include("Note: Tasks on Debian-like systems are treated as patterns.")
+      end
+
+      it "does show pattern_sytem tasksel" do
+        output = subject.render(system_description)
+
+        expect(output).to include("Pattern Manager: tasksel")
       end
     end
   end


### PR DESCRIPTION
* The patterns scope includes an attribute identifying how patterns are managed (tasksel on Debian systems, zypper on SUSE systems)
* Existing descriptions get the patterns manager flag added based on the information from the packages scope.
* If during the migration the packages scope is not there the flag falls back to zypper and the user is shown a warning about it.

Supersedes #2107

