### PR TITLE
 Issue #2101 Show file_objects/subdirs/files in comparison view

### DIFF
--- a/html/partials/compare/unmanaged_file_list.html.haml
+++ b/html/partials/compare/unmanaged_file_list.html.haml
@@ -7,20 +7,28 @@
       %tr
         %th Name
         %th.small Type
-        - if list.has_metadata
+        - if list.contains_metadata?
           %th.medium Mode
           %th.medium User
           %th.medium Group
           %th.medium Size
-          %th.medium Files in dir.
+          - if list.has_subdir_counts?
+            %th.medium Subdir.
+            %th.medium Files in dir.
+          - else
+            %th.medium File Objects
     %tbody
       - list.each do |file|
         %tr
           %td= file.name
           %td= file.type
-          - if list.has_metadata
+          - if list.contains_metadata?
             %td= file.mode
             %td= file.user
             %td= file.group
             %td= number_to_human_size(file.size)
-            %td= file.files
+            - if list.has_subdir_counts?
+              %td= file.dirs
+              %td= file.files
+            - else
+              %td= file.file_objects

--- a/html/partials/unmanaged_files.html.haml
+++ b/html/partials/unmanaged_files.html.haml
@@ -20,16 +20,16 @@
                 %tr
                   %th Name
                   %th.medium Type
-                  - if unmanaged_files.has_metadata
+                  - if unmanaged_files.contains_metadata?
                     %th.medium Mode
                     %th.medium User
                     %th.medium Group
                     %th.medium Size
-                  - if unmanaged_files.any?(&:file_objects)
-                    %th.medium File Objects
-                  - else
-                    %th.medium Subdirectories
-                    %th.medium Files in Directory
+                    - if unmanaged_files.has_subdir_counts?
+                      %th.medium Subdirectories
+                      %th.medium Files in Directory
+                    - else
+                      %th.medium File Objects
               %tbody
                 - unmanaged_files.each do |file|
                   %tr
@@ -41,16 +41,13 @@
                         %span
                           = file.name
                     %td= file.type
-                    - if unmanaged_files.has_metadata
+                    - if unmanaged_files.contains_metadata?
                       %td= file.mode
                       %td= file.user
                       %td= file.group
                       %td= number_to_human_size(file.size)
-                      - if unmanaged_files.any?(&:file_objects)
-                        %td
-                          = file.file_objects if file.file_objects
-                      - else
-                        %td
-                          = file.dirs if file.dirs
-                        %td
-                          = file.files if file.files
+                    - if unmanaged_files.has_subdir_counts?
+                      %td= file.dirs
+                      %td= file.files
+                    - else
+                      %td= file.file_objects

--- a/plugins/unmanaged_files/unmanaged_files_model.rb
+++ b/plugins/unmanaged_files/unmanaged_files_model.rb
@@ -73,6 +73,14 @@ class UnmanagedFilesScope < FileScope
     comparison.push(common)
   end
 
+  def contains_metadata?
+    @metadata ||= has_metadata || elements.any?(&:user)
+  end
+
+  def has_subdir_counts?
+    @has_subdirs ||= elements.any?(&:files)
+  end
+
   private
 
   def files_match(a, b)

--- a/plugins/unmanaged_files/unmanaged_files_renderer.rb
+++ b/plugins/unmanaged_files/unmanaged_files_renderer.rb
@@ -30,7 +30,7 @@ class UnmanagedFilesRenderer < Renderer
 
       if description["unmanaged_files"]
         description["unmanaged_files"].each do |p|
-          if description["unmanaged_files"].has_metadata
+          if description["unmanaged_files"].contains_metadata?
             item "#{p.name} (#{p.type})" do
               puts "User/Group: #{p.user}:#{p.group}" if p.user || p.group
               puts "Mode: #{p.mode}" if p.mode

--- a/spec/unit/models/unmanaged_files_model_spec.rb
+++ b/spec/unit/models/unmanaged_files_model_spec.rb
@@ -53,6 +53,75 @@ describe "unmanaged_files model" do
         scope_a.compare_with(scope_b)
       end
     end
+
+    describe "check for attributes for rendering" do
+      let(:extracted_unmanaged_files) {
+        UnmanagedFilesScope.new(
+          [
+            UnmanagedFile.new(
+              name:    "/foo",
+              type:    "file",
+              mode:    "777",
+              user:    "user",
+              group:   "group",
+              size:    1,
+              files:   2,
+              dirs:    3
+            )
+          ]
+        )
+      }
+      let(:unextracted_unmanaged_files) {
+        UnmanagedFilesScope.new(
+          [
+            UnmanagedFile.new(
+              name: "/foo",
+              type:    "file"
+            )
+          ],
+          has_metadata: false
+        )
+      }
+      let(:extracted_unmanaged_files_file_objects) {
+        UnmanagedFilesScope.new(
+          [
+            UnmanagedFile.new(
+              name:    "/foo",
+              type:    "file",
+              mode:    "777",
+              user:    "user",
+              group:   "group",
+              size:    1,
+              file_objects: 4
+            )
+          ]
+        )
+      }
+      describe "#has_metadata?" do
+        it "returns true if the attribute has_metadata is true" do
+          object = UnmanagedFilesScope.new([], has_metadata: true)
+          expect(object.contains_metadata?).to be(true)
+        end
+
+        it "returns true if has_metadata is missing but the first element has a user attribute" do
+          expect(extracted_unmanaged_files.contains_metadata?).to be(true)
+        end
+
+        it "returns false if the attribute has_metadata is false and there is no user attribute" do
+          expect(unextracted_unmanaged_files.contains_metadata?).to be(false)
+        end
+      end
+
+      describe "#has_subdir_counts?" do
+        it "returns false if file_objects exist" do
+          expect(extracted_unmanaged_files_file_objects.has_subdir_counts?).to be(false)
+        end
+
+        it "returns true if subdirectories exist" do
+          expect(extracted_unmanaged_files.has_subdir_counts?).to be(true)
+        end
+      end
+    end
   end
 
   describe UnmanagedFilesScope do


### PR DESCRIPTION
Workaround for showing number of file objects and/or number of files and
subdirectories in unmanaged file comparison.

Fixes #2101