### PR TITLE
Fix check_retrieve_files_dependencies for remote system

### DIFF
--- a/lib/remote_system.rb
+++ b/lib/remote_system.rb
@@ -145,6 +145,10 @@ class RemoteSystem < System
     end
   end
 
+  def check_retrieve_files_dependencies
+    LocalSystem.new.check_requirement("rsync", "--version")
+  end
+
   # Reads a file from the System. Returns nil if it does not exist.
   def read_file(file)
     run_command("cat", file, stdout: :capture, privileged: true)

--- a/spec/unit/remote_system_spec.rb
+++ b/spec/unit/remote_system_spec.rb
@@ -157,6 +157,15 @@ describe RemoteSystem do
       end
     end
 
+    describe "#check_retrieve_files_dependencies" do
+      it "checks for the availabilty of rsync on the local system" do
+        expect_any_instance_of(LocalSystem).to receive(:check_requirement).with(
+          "rsync", "--version"
+        )
+        remote_system.check_retrieve_files_dependencies
+      end
+    end
+
     describe "#retrieve_files" do
       context "when retrieving files via rsync" do
         it "builds the correct command" do


### PR DESCRIPTION
Remote files are transferred using the local rsync so the check needs to
happen on the local system.

Fixes #2118 
Supersedes #2129