### PR TITLE
Fix broken exclude files command with new tar

### DIFF
--- a/lib/system.rb
+++ b/lib/system.rb
@@ -76,8 +76,9 @@ class System
     out = File.open(archive, "w")
     begin
       run_command(
-        "tar", "--create", "--gzip", "--null", "--files-from=-",
+        "tar", "--create", "--gzip",
         *exclude.flat_map { |f| ["--exclude", f]},
+        "--null", "--files-from=-",
         stdout: out,
         stdin: Array(file_list).join("\0"),
         privileged: true,

--- a/spec/unit/system_spec.rb
+++ b/spec/unit/system_spec.rb
@@ -65,7 +65,7 @@ describe System do
 
       filelist = Dir.glob(test_dir + "/*")
 
-      local_system = LocalSystem.new()
+      local_system = LocalSystem.new
       md5sum = local_system.run_command(
         ["find", test_dir, "-type", "f"],
         ["xargs", "md5sum"],
@@ -109,7 +109,7 @@ describe System do
         FileUtils.touch(excluded_file_1)
         FileUtils.touch(excluded_file_2)
 
-        local_system = LocalSystem.new()
+        local_system = LocalSystem.new
         local_system.create_archive(test_dir, archive, [excluded_file_1, excluded_file_2])
 
         file_list = Tarball.new(archive).list


### PR DESCRIPTION
The  system unit spec fails, because the excluded files are not excluded from the tar ball.
OpenSuse Tumbleweed uses tar 1.29, moving the exclude arguments in front of the file list allows tar to actually exclude the files.