### PR TITLE
Remove Ruby 2.1 required keyword argument

### DIFF
--- a/lib/static_html.rb
+++ b/lib/static_html.rb
@@ -28,8 +28,8 @@ class StaticHtml < Exporter
   end
   attr_reader :description
 
-  def haml(source, locals:)
-    Haml::Engine.new(source).render(binding, locals)
+  def haml(source, options = {})
+    Haml::Engine.new(source).render(binding, options.delete(:locals))
   end
 
   def write


### PR DESCRIPTION
The gemspec allows Ruby 2.0, which does not support required
keyword arguments. However 2.0 is end of live.

This PR removes the keyword argument. I'd prefer to bump the Ruby requirement, though.