### PR TITLE
Filter diversions from dpkg output

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,8 @@
 * Add remaining systemd service states in Kiwi export (gh#SUSE/machinery#2122)
 * Add export of system descriptions as HTML page. This provides an offline
   view of descrptions (gh#SUSE/machinery#2119)
+* Fix changed files inspections on dpkg systems in case of diversions
+  (gh#SUSE/machinery#2138)
 
 ## Version 1.21.0 - Tue Jun 21 16:28:31 CEST 2016 - thardeck@suse.de
 

--- a/lib/dpkg_database.rb
+++ b/lib/dpkg_database.rb
@@ -28,7 +28,9 @@ class DpkgDatabase < ManagedFilesDatabase
   end
 
   def package_for_file_path(file)
-    package_name = @system.run_command("dpkg", "-S", file, stdout: :capture).split(":").first
+    package_name = @system.run_command(
+      "dpkg", "-S", file, stdout: :capture
+    ).lines.last.split(":").first.split(",").first
     package_details = @system.run_command("dpkg", "-s", package_name, stdout: :capture)
     package_version = package_details.match(/^Version: (.*)$/)[1]
 


### PR DESCRIPTION
Diversions are files owned by more than one package. The original file
gets renamed.

Fixes #2138