### PR TITLE
Replace click with JS based trigger click to close modal dialog in specs

### DIFF
--- a/spec/features/navigation_bar_spec.rb
+++ b/spec/features/navigation_bar_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe "Navigation Bar Buttons", type: :feature do
       expect(page).not_to have_content("Select a description to show its details.")
       expect(page).to have_link("description_b", href: /\/description_b/)
 
-      click_on("Close")
+      find_button("Close").trigger("click")
       expect(page).not_to have_content("Select a description from the list below")
     end
 
@@ -158,7 +158,7 @@ RSpec.describe "Navigation Bar Buttons", type: :feature do
       )
       expect(page).to have_link("description_c", href: /\/compare\/description_c\/description_b/)
 
-      click_on("Close")
+      find_button("Close").trigger("click")
       expect(page).not_to have_content("Select a description from the list below")
     end
 
@@ -173,7 +173,7 @@ RSpec.describe "Navigation Bar Buttons", type: :feature do
       )
 
       expect(page).to have_link("description_c", href: /\/compare\/name\/description_c/)
-      click_on("Close")
+      find_button("Close").trigger("click")
       expect(page).not_to have_content("Select a description from the list below")
     end
   end


### PR DESCRIPTION
Using `click()` in the feature spec fails about one in ten times. 

Pressing the button to close the modal dialog triggers a fade animation. Due to some timing issue poltergeist does not always close the dialog and the spec fails.

While trigger("Click") is different from a real users action it reliably closes the modal dialog.

Alternatively it may be possible to disable CSS animations altogether while testing. However this is not easy to implement, as it would involve injecting JS for tests, or manipulating CSS classes, without affecting the functionality of the dialog.