### PR TITLE
Use sudo when analyze smb repos

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,6 @@
 # Machinery Release Notes
 
-* Fix analyze of changed-config-files when NFS repositories are
+* Fix analyze of changed-config-files when NFS or SMB repositories are
   used (gh#SUSE/machinery#2132)
 
 ## Version 1.22.1 - Fri Oct 14 16:13:50 CEST 2016 - thardeck@suse.de

--- a/lib/zypper.rb
+++ b/lib/zypper.rb
@@ -53,7 +53,7 @@ class Zypper
         raise("The zypper base directory is not inside of '/tmp'. Aborting...")
       end
       cmd = ["rm", "-rf", zypper.zypp_base]
-      cmd = cmd.insert(0, "sudo") if zypper.contains_nfs_repos?
+      cmd = cmd.insert(0, "sudo") if zypper.contains_mountable_repos?
       LoggedCheetah.run(*cmd)
     end
 
@@ -81,7 +81,7 @@ class Zypper
   end
 
   def refresh
-    call_zypper "refresh", sudo: contains_nfs_repos?
+    call_zypper "refresh", sudo: contains_mountable_repos?
   end
 
   def download_package(package)
@@ -97,10 +97,10 @@ class Zypper
     [found[1].to_i, found[2].to_i, found[3].to_i] if found
   end
 
-  def contains_nfs_repos?
+  def contains_mountable_repos?
     files = Dir.glob(File.join(@zypp_base, "etc/zypp/repos.d", "*"))
     files.any? do |file|
-      File.readlines(file).any? { |line| line.start_with?("baseurl=nfs://") }
+      File.readlines(file).any? { |line| line.start_with?("baseurl=nfs://", "baseurl=smb://") }
     end
   end
 

--- a/spec/unit/zypper_spec.rb
+++ b/spec/unit/zypper_spec.rb
@@ -93,6 +93,32 @@ EOF
         end
       end
 
+      context "with smb repos" do
+        let(:base_url) { "smb://download.opensuse.org/distribution/leap/42.2/repo/oss/" }
+
+        it "calls refresh with sudo" do
+          Zypper.isolated(arch: :x86_64) do |zypper|
+            allow(LoggedCheetah).to receive(:run)
+            expect(LoggedCheetah).to receive(:run) do |*args|
+              expect(args).to include("sudo", "refresh")
+            end
+
+            zypper.refresh
+          end
+        end
+
+        it "cleans up with sudo" do
+          expect(LoggedCheetah).to receive(:run).with(
+            "sudo", "rm", "-rf", tmp_path
+          )
+
+          Zypper.isolated(arch: :x86_64) do |zypper|
+            allow(LoggedCheetah).to receive(:run)
+            zypper.refresh
+          end
+        end
+      end
+
       context "without nfs repos" do
         it "calls refresh without sudo" do
           Zypper.isolated(arch: :x86_64) do |zypper|


### PR DESCRIPTION
Because smb repos are also mounted, which requires root
permissions.