### PR TITLE
Do not extract Metadata for missing unmanaged files

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 # Machinery Release Notes
 
+* Prevent machinery-helper from crashing when files are removed during inspection
 * Fix analyze of changed-config-files when NFS or SMB repositories are
   used (gh#SUSE/machinery#2132)
 * Do not add repositories which require registration to built images (bnc#1004697)

--- a/machinery-helper/machinery_helper.go
+++ b/machinery-helper/machinery_helper.go
@@ -199,8 +199,8 @@ func getManagedFiles() (map[string]string, map[string]bool) {
 	return files, dirs
 }
 
-func assembleJSON(unmanagedFilesMap interface{}) string {
-	jsonMap := map[string]interface{}{"extracted": false, "files": unmanagedFilesMap}
+func assembleJSON(unmanagedFilesList interface{}) string {
+	jsonMap := map[string]interface{}{"extracted": false, "files": unmanagedFilesList}
 	json, _ := json.MarshalIndent(jsonMap, " ", "  ")
 	return string(json)
 }
@@ -352,6 +352,23 @@ func printVersion() {
 	os.Exit(0)
 }
 
+func getUnmanagedFilesList(files []string, unmanagedFiles map[string]string, extractMetadataFlag *bool) []UnmanagedFile {
+	unmanagedFilesList := make([]UnmanagedFile, len(unmanagedFiles))
+	for j := range files {
+		entry := UnmanagedFile{}
+		entry.Name = files[j]
+		entry.Type = unmanagedFiles[files[j]]
+
+		if *extractMetadataFlag {
+			amendPathAttributes(&entry, unmanagedFiles[files[j]])
+		}
+
+		unmanagedFilesList[i] = entry
+		i++
+	}
+	return unmanagedFilesList
+}
+
 // IgnoreList includes mounts and any other file type that will be ignored when
 // evaluating the unmanaged files in a system.
 var IgnoreList = map[string]bool{}
@@ -405,19 +422,8 @@ func main() {
 	}
 	sort.Strings(files)
 
-	unmanagedFilesMap := make([]UnmanagedFile, len(unmanagedFiles))
-	for j := range files {
-		entry := UnmanagedFile{}
-		entry.Name = files[j]
-		entry.Type = unmanagedFiles[files[j]]
+	unmanagedFilesList := getUnmanagedFilesList(files, unmanagedFiles, extractMetadataFlag)
 
-		if *extractMetadataFlag {
-			amendPathAttributes(&entry, unmanagedFiles[files[j]])
-		}
-
-		unmanagedFilesMap[j] = entry
-	}
-
-	json := assembleJSON(unmanagedFilesMap)
+	json := assembleJSON(unmanagedFilesList)
 	fmt.Println(json)
 }

--- a/machinery-helper/machinery_helper.go
+++ b/machinery-helper/machinery_helper.go
@@ -354,19 +354,24 @@ func printVersion() {
 
 func getUnmanagedFilesList(files []string, unmanagedFiles map[string]string, extractMetadataFlag *bool) []UnmanagedFile {
 	unmanagedFilesList := make([]UnmanagedFile, len(unmanagedFiles))
+	i := 0
 	for j := range files {
 		entry := UnmanagedFile{}
 		entry.Name = files[j]
 		entry.Type = unmanagedFiles[files[j]]
 
 		if *extractMetadataFlag {
-			amendPathAttributes(&entry, unmanagedFiles[files[j]])
+			if _, err := os.Stat(entry.Name); err == nil {
+				amendPathAttributes(&entry, unmanagedFiles[files[j]])
+			} else {
+				continue
+			}
 		}
 
 		unmanagedFilesList[i] = entry
 		i++
 	}
-	return unmanagedFilesList
+	return unmanagedFilesList[0:i]
 }
 
 // IgnoreList includes mounts and any other file type that will be ignored when


### PR DESCRIPTION
Make sure that files exist before extracting the metadata and remove
them from the unmanaged-files list if not.

This should allow filtering to work properly because the filters are
applied before extraction so it is possible for the user to filter
directories with changing files.
Before that machinery-helper could crash if a file was removed during
the first phase of inspection and there was no way for the user to
filter these directories because the helper does not support filtering
yet.