### PR TITLE
Handle unextracted unmanaged files as extracted

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 # Machinery Release Notes
 
-* Prevent machinery-helper from crashing when files are removed during inspection
+* Prevent machinery-helper from crashing when files are inaccessible during
+  inspection (bnc#1009774)
 * Fix analyze of changed-config-files when NFS or SMB repositories are
   used (gh#SUSE/machinery#2132)
 * Do not add repositories which require registration to built images (bnc#1004697)

--- a/machinery-helper/machinery_helper.go
+++ b/machinery-helper/machinery_helper.go
@@ -357,7 +357,7 @@ func getUnmanagedFilesList(files []string, unmanagedFiles map[string]string, ext
 	i := 0
 	for j := range files {
 		// only add accessible files
-		if _, err := os.Lstat(files[j]); err == nil || (os.IsNotExist(err) == false && os.IsPermission(err) == false && strings.Contains(err.Error(), "no such device") == false) {
+		if _, err := os.Lstat(files[j]); isAccessible(err) {
 			entry := UnmanagedFile{}
 			entry.Name = files[j]
 			entry.Type = unmanagedFiles[files[j]]
@@ -373,6 +373,13 @@ func getUnmanagedFilesList(files []string, unmanagedFiles map[string]string, ext
 		}
 	}
 	return unmanagedFilesList[0:i]
+}
+
+func isAccessible(err error) bool {
+	return err == nil ||
+		(os.IsNotExist(err) == false &&
+			os.IsPermission(err) == false &&
+			strings.Contains(err.Error(), "no such device") == false)
 }
 
 // IgnoreList includes mounts and any other file type that will be ignored when

--- a/machinery-helper/machinery_helper.go
+++ b/machinery-helper/machinery_helper.go
@@ -299,7 +299,7 @@ func dirInfo(path string) (size int64, fileCount int, dirCount int) {
 		if f.IsDir() {
 			dirCount++
 			fileCount--
-			if _, ok := IgnoreList[path + f.Name()]; !ok {
+			if _, ok := IgnoreList[path+f.Name()]; !ok {
 				subSize, subFiles, subDirs := dirInfo(path + f.Name() + "/")
 				size += subSize
 				fileCount += subFiles


### PR DESCRIPTION
Fixed regression where the machinery-helper reported different number of
files when extraction was used or not used.

Additionally Lstat was used to make sure that the check happens for the
actual link and not the referred file.