### PR TITLE
Only search inside the Machinery namespace

### DIFF
--- a/lib/inspector.rb
+++ b/lib/inspector.rb
@@ -51,9 +51,9 @@ class Machinery::Inspector
     end
 
     def for(scope)
-      class_name = "Machinery::#{scope.split("_").map(&:capitalize).join}Inspector"
+      class_name = "#{scope.split("_").map(&:capitalize).join}Inspector"
 
-      Object.const_get(class_name) if Object.const_defined?(class_name)
+      Machinery.const_get(class_name) if Machinery.const_defined?(class_name)
     end
 
     def all


### PR DESCRIPTION
Make sure that we only search for our scope classes inside of our
namespace.
This fixes a regression on 13.1 systems.