### PR TITLE
Inspection details

### DIFF
--- a/html/index.html.haml
+++ b/html/index.html.haml
@@ -75,7 +75,7 @@
                     :class => nav_class(scope) }
                     %span= scope_initials(scope)
             .col-xs-2
-              %a.btn.btn-default.inspection_details{ :href => "", "data-toggle" => "popover" }
+              %a.btn.btn-default.inspection_details{ "data-toggle" => "popover" }
                 inspection details
             .col-xs-2
               %small.pull-right

--- a/spec/features/inspection_details_spec.rb
+++ b/spec/features/inspection_details_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Inspection Details", type: :feature do
     it "displays all used filters" do
       visit("/description")
 
-      click_on("inspection details")
+      page.find(".inspection_details").click
 
       expect(find("#filters")).to have_content("Filters used during Inspection")
       expect(find("#filters")).to have_content("No filters were used.")
@@ -49,7 +49,7 @@ RSpec.describe "Inspection Details", type: :feature do
 
       visit("/description")
 
-      click_on("inspection details")
+      page.find(".inspection_details").click
 
       expect(find("#filters")).to have_content("Filters used during Inspection")
       expect(find("#filters")).to have_content("/foo=bar")
@@ -62,7 +62,7 @@ RSpec.describe "Inspection Details", type: :feature do
     it "displays docker in the inspection details" do
       visit("/description")
 
-      click_on("inspection details")
+      page.find(".inspection_details").click
 
       expect(find("#container_type")).to have_content(/Type of Inspected Container docker/)
     end


### PR DESCRIPTION
Fixes #1901

Stops an unnecessary reload of the page that also resets the scroll bar.
Adapts the test to look for an element of the class "inspection_details"
instead of an element with a link that's called "inspection details" as
the link was removed to stop the reload.