### PR TITLE
Add missing package to Tumbleweed images

### DIFF
--- a/spec/definitions/boxes/definitions/base_opensuse_tumbleweed_kvm/config.xml
+++ b/spec/definitions/boxes/definitions/base_opensuse_tumbleweed_kvm/config.xml
@@ -61,6 +61,7 @@
         <package name="cronie"/>
         <package name="nfs-kernel-server"/>
         <package name="autofs"/>
+        <package name="sysconfig"/>
     </packages>
     <packages type="bootstrap">
         <package name="udev"/>

--- a/spec/definitions/boxes/definitions/machinery_opensuse_tumbleweed_kvm/config.xml
+++ b/spec/definitions/boxes/definitions/machinery_opensuse_tumbleweed_kvm/config.xml
@@ -80,6 +80,7 @@
         <package name="db-utils"/>
         <package name="man"/>
         <package name="curl"/>
+        <package name="sysconfig"/>
     </packages>
     <packages type="bootstrap">
         <package name="udev"/>


### PR DESCRIPTION
The network can not be initiated without the package sysconfig. It seems
that the packaging dependencies were changed in Tumbleweed so it was not
pulled in automatically anymore.