### PR TITLE
Support Sinatra version 2

### DIFF
--- a/RPM_CHANGES
+++ b/RPM_CHANGES
@@ -1,6 +1,7 @@
 # Machinery RPM Changelog
 
 * add support for HAML gems >= 5.0 (bnc#1043785)
+* add support for Sinatra gems >= 2.0
 
 ## Version 1.22.2 - Wed Nov 16 16:44:00 CET 2016 - thardeck@suse.de
 

--- a/machinery.gemspec
+++ b/machinery.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.add_dependency "haml", ">= 4.0"
   s.add_dependency "kramdown", "~> 1.3"
   s.add_dependency "tilt", "~> 2.0"
-  s.add_dependency "sinatra", "~> 1.4"
+  s.add_dependency "sinatra", ">= 1.4"
   s.add_dependency "mimemagic", "~> 0.3"
   s.add_dependency "diffy", "~> 3.0"
 


### PR DESCRIPTION
`bundle --standalone` seems to have an issue with multiple version
requirements, that's why we allow all versions >= 1.4.