### PR TITLE
Add Support for ppc64 inspection

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,8 @@
 # Machinery Release Notes
 
 
+* Support inspection of ppc64 systems (bnc#1052877)
+
 ## Version 1.22.3 - Tue Jun 20 10:56:18 CEST 2017 - thardeck@suse.de
 
 * Gracefully handle incorrect filter pathes in the experimental filtering function

--- a/spec/unit/go_spec.rb
+++ b/spec/unit/go_spec.rb
@@ -51,27 +51,27 @@ describe Go do
       it "returns arm, x86_64, i686 and ppc64le" do
         allow(subject).to receive(:version).and_return(1.6)
         expect(subject.archs).to match_array(
-          ["x86_64", "i686", "ppc64le", "armv6l", "armv7l", "aarch64"]
+          ["x86_64", "i686", "ppc64le", "ppc64", "armv6l", "armv7l", "aarch64"]
         )
       end
     end
 
     context "for go-s390x 1.6 (machinery build)" do
-      it "returns arm, x86_64, i686, ppc64le and s390x" do
+      it "returns arm, x86_64, i686, ppc64le, ppc64 and s390x" do
         allow(subject).to receive(:version).and_return(1.6)
         allow(subject).to receive(:suse_package_includes_s390?).and_return(true)
 
         expect(subject.archs).to match_array(
-          ["x86_64", "i686", "ppc64le", "s390x", "armv6l", "armv7l", "aarch64"]
+          ["x86_64", "i686", "ppc64le", "ppc64", "s390x", "armv6l", "armv7l", "aarch64"]
         )
       end
     end
 
     context "for go 1.7 and newer" do
-      it "returns arm, x86_64, i686, ppc64le and s390x" do
+      it "returns arm, x86_64, i686, ppc64le, ppc64 and s390x" do
         allow(subject).to receive(:version).and_return(1.7)
         expect(subject.archs).to match_array(
-          ["x86_64", "i686", "ppc64le", "s390x", "armv6l", "armv7l", "aarch64"]
+          ["x86_64", "i686", "ppc64le", "ppc64", "s390x", "armv6l", "armv7l", "aarch64"]
         )
       end
     end

--- a/tools/go.rb
+++ b/tools/go.rb
@@ -25,11 +25,11 @@ class Go
     when version <= 1.4
       ["i686", "x86_64"].include?(local_arch) ? [local_arch] : []
     when version == 1.6 && suse_package_includes_s390?
-      ["i686", "x86_64", "ppc64le", "s390x", "armv6l", "armv7l", "aarch64"]
+      ["i686", "x86_64", "ppc64le", "ppc64", "s390x", "armv6l", "armv7l", "aarch64"]
     when version <= 1.6
-      ["i686", "x86_64", "ppc64le", "armv6l", "armv7l", "aarch64"]
+      ["i686", "x86_64", "ppc64le", "ppc64", "armv6l", "armv7l", "aarch64"]
     when version >= 1.7
-      ["i686", "x86_64", "ppc64le", "s390x", "armv6l", "armv7l", "aarch64"]
+      ["i686", "x86_64", "ppc64le", "ppc64", "s390x", "armv6l", "armv7l", "aarch64"]
     end
   end
 


### PR DESCRIPTION
We have only compiled the machinery-helper for ppc64le and not for
ppc64.
Now we compile the helper for both ppc architectures.

Fixes bnc#1052877