### PR TITLE
Fix Tumbleweed expectation in integration test

### DIFF
--- a/spec/integration/machinery_opensuse_tumbleweed_spec.rb
+++ b/spec/integration/machinery_opensuse_tumbleweed_spec.rb
@@ -43,7 +43,7 @@ describe "machinery@Tumbleweed" do
       "services" =>
         [
           /\* sshd.service: enabled$/,
-          /\* rc-local.service: static$/,
+          /\* wickedd-pppd@.service: static$/,
           /\* debug-shell.service: disabled$/
         ],
       "os" =>


### PR DESCRIPTION
rc-local.service is not static anymore but enabled-runtime