### PR TITLE
Allow installation of machinery test package in Tumbleweed

### DIFF
--- a/spec/definitions/vagrant/machinery_rpm_provisioner.rb
+++ b/spec/definitions/vagrant/machinery_rpm_provisioner.rb
@@ -101,7 +101,7 @@ module MachineryRpm
     def install
       machine.ui.detail("Installing Machinery...")
 
-      cmd = "zypper --non-interactive in /tmp/#{@rpm}"
+      cmd = "zypper --no-gpg-checks --non-interactive in /tmp/#{@rpm}"
       machine.communicate.execute(cmd, sudo: true)
     end
   end


### PR DESCRIPTION
Zypper in Tumbleweed does not allow to install unsigned packages anymore
with the non-interactive tag. Disabling the gpg-checks fixes the issue.

The RPMs are installed in a vm which is resetted all the time so it
should be not a significant problem from a security point of view.