### PR TITLE
Revert "Allow installation of machinery test package in Tumbleweed"

### DIFF
--- a/spec/definitions/vagrant/machinery_rpm_provisioner.rb
+++ b/spec/definitions/vagrant/machinery_rpm_provisioner.rb
@@ -101,7 +101,7 @@ module MachineryRpm
     def install
       machine.ui.detail("Installing Machinery...")
 
-      cmd = "zypper --no-gpg-checks --non-interactive in /tmp/#{@rpm}"
+      cmd = "zypper --non-interactive in /tmp/#{@rpm}"
       machine.communicate.execute(cmd, sudo: true)
     end
   end


### PR DESCRIPTION
Reverts SUSE/machinery#2238 since we have released and now have time for the proper fix in zypper.
The related issue is: https://bugzilla.suse.com/show_bug.cgi?id=1055533