### PR TITLE
Allow inspection of 32-bit systems which have no SSE

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 # Machinery Release Notes
 
+* Allow inspection of old 32-bit systems which have no
+  SSE instructions (gh#SUSE/machinery#2243)
 
 ## Version 1.23.0 - Mon Aug 28 14:59:52 CEST 2017 - thardeck@suse.de
 

--- a/spec/definitions/add_machinery_user.sh
+++ b/spec/definitions/add_machinery_user.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 /usr/sbin/useradd -m machinery
-echo "machinery:linux" | /usr/sbin/chpasswd
+echo "machinery:zkaenzyx" | /usr/sbin/chpasswd
 echo 'machinery ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers

--- a/spec/definitions/vagrant/machinery_rpm_provisioner.rb
+++ b/spec/definitions/vagrant/machinery_rpm_provisioner.rb
@@ -54,6 +54,7 @@ module MachineryRpm
     def provision
       build
       upload
+      prepare
       install
     end
 
@@ -96,6 +97,13 @@ module MachineryRpm
       machine.ui.detail("Uploading Machinery RPM...")
 
       machine.communicate.upload(File.join(MACHINERY_ROOT, "package", @rpm), "/tmp/#{@rpm}")
+    end
+
+    def prepare
+      machine.ui.detail("Preparing zypp environment...")
+
+      cmd = 'echo -e "gpgcheck=1\npkg_gpgcheck=0" >> /etc/zypp/zypp.conf'
+      machine.communicate.execute(cmd, sudo: true)
     end
 
     def install

--- a/spec/integration/machinery_opensuse_leap_spec.rb
+++ b/spec/integration/machinery_opensuse_leap_spec.rb
@@ -38,7 +38,7 @@ describe "machinery@leap" do
   describe "inspect ubuntu_1404", matrix: "pending" do
     base = "ubuntu_1404"
     username = "machinery"
-    password = "linux"
+    password = "zkaenzyx"
 
     let(:inspect_options) {
       "--remote-user=#{username}" if username != "root"

--- a/spec/integration/machinery_opensuse_tumbleweed_spec.rb
+++ b/spec/integration/machinery_opensuse_tumbleweed_spec.rb
@@ -104,10 +104,10 @@ describe "machinery@Tumbleweed" do
   describe "inspect openSUSE Tumbleweed system", matrix: "pending" do
     before(:all) do
       @subject_system = start_system(
-        box: "opensuse_tumbleweed", username: "machinery", password: "linux"
+        box: "opensuse_tumbleweed", username: "machinery", password: "zkaenzyx"
       )
       prepare_machinery_for_host(
-        @machinery, @subject_system.ip, username: "machinery", password: "linux"
+        @machinery, @subject_system.ip, username: "machinery", password: "zkaenzyx"
       )
     end
 

--- a/spec/integration/support/build_examples.rb
+++ b/spec/integration/support/build_examples.rb
@@ -64,7 +64,7 @@ shared_examples "build" do |distribution|
 
         # Boot built image and extract system description
         @test_system = start_system(image: local_image)
-        prepare_machinery_for_host(@machinery, @test_system.ip, password: "linux")
+        prepare_machinery_for_host(@machinery, @test_system.ip, password: "zkaenzyx")
 
         measure("inspect image") do
           expect(

--- a/spec/integration/support/inspect_and_build_examples.rb
+++ b/spec/integration/support/inspect_and_build_examples.rb
@@ -19,9 +19,9 @@ shared_examples "inspect and build" do |bases|
   bases.each do |base|
     describe "rebuild inspected system", slow: true do
       before(:all) do
-        @subject_system = start_system(box: base, username: "machinery", password: "linux")
+        @subject_system = start_system(box: base, username: "machinery", password: "zkaenzyx")
         prepare_machinery_for_host(
-          @machinery, @subject_system.ip, username: "machinery", password: "linux"
+          @machinery, @subject_system.ip, username: "machinery", password: "zkaenzyx"
         )
 
         # Enabled experimental features so that the --exclude option can be used
@@ -67,7 +67,7 @@ shared_examples "inspect and build" do |bases|
           @machinery.extract_file image, "/tmp"
 
           @test_system = start_system(
-            image: local_image, skip_ssh_setup: true, username: "machinery", password: "linux"
+            image: local_image, skip_ssh_setup: true, username: "machinery", password: "zkaenzyx"
           )
 
           # Run 'ls' via ssh in the built system to verify its booted and accessible.

--- a/spec/unit/go_spec.rb
+++ b/spec/unit/go_spec.rb
@@ -104,7 +104,7 @@ describe Go do
           "env GOOS=linux GOARCH=amd64 go build -o machinery-helper-x86_64"
         )
         expect(subject).to receive(:system).with(
-          "env GOOS=linux GOARCH=386 go build -o machinery-helper-i686"
+          "env GOOS=linux GOARCH=386 GO386=387 go build -o machinery-helper-i686"
         )
         expect(subject).to receive(:system).with(
           "env GOOS=linux GOARCH=ppc64le go build -o machinery-helper-ppc64le"
@@ -120,14 +120,14 @@ describe Go do
         )
         expect($stdout).to receive(:puts).with("Building machinery-helper for architecture i686.")
         allow(subject).to receive(:system).with(
-          "env GOOS=linux GOARCH=386 go build -o machinery-helper-i686"
+          "env GOOS=linux GOARCH=386 GO386=387 go build -o machinery-helper-i686"
         )
         subject.build
       end
 
-      it "compiles arm with the appropriate compiler options" do
+      it "compiles arm and i686 with the appropriate compiler options" do
         expect(subject).to receive(:archs).and_return(
-          ["armv6l", "armv7l", "aarch64"]
+          ["armv6l", "armv7l", "aarch64", "i686"]
         ).at_least(:once)
         expect(subject).to receive(:system).with(
           "env GOOS=linux GOARCH=arm GOARM=6 go build -o machinery-helper-armv6l"
@@ -137,6 +137,9 @@ describe Go do
         )
         expect(subject).to receive(:system).with(
           "env GOOS=linux GOARCH=arm64 go build -o machinery-helper-aarch64"
+        )
+        expect(subject).to receive(:system).with(
+          "env GOOS=linux GOARCH=386 GO386=387 go build -o machinery-helper-i686"
         )
         subject.build
       end

--- a/tools/go.rb
+++ b/tools/go.rb
@@ -77,6 +77,7 @@ class Go
     when "x86_64"
       "amd64"
     when "i686"
+      additional_options = " GO386=387"
       "386"
     when "aarch64"
       "arm64"


### PR DESCRIPTION
SSE processor instructions are used by default when go cross compiles 32-bit on
a modern system.
This prevents the executable from working on older systems so we now compile
explicitly without these instructions.

Fixes #2243