### PR TITLE
Use helper for old architectures

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 # Machinery Release Notes
 
+* Allow inspection of old 32-bit systems even when their architecture is
+  reported as i586 or i386
 
 ## Version 1.23.1 - Fri Nov 24 17:33:39 CET 2017 - thardeck@suse.de
 

--- a/lib/machinery_helper.rb
+++ b/lib/machinery_helper.rb
@@ -34,7 +34,9 @@ class MachineryHelper
   end
 
   def local_helper_path
-    File.join(local_helpers_path, "machinery-helper-#{@system.arch}")
+    File.join(
+      local_helpers_path, "machinery-helper-#{compatible_helper_arch(@system.arch)}"
+    )
   end
 
   def remote_helper_path
@@ -85,5 +87,17 @@ class MachineryHelper
     options = args.last.is_a?(Hash) ? args.pop : {}
     options[:privileged] = true
     @system.run_command(remote_helper_path, subcommand, *args, options)
+  end
+
+  private
+
+  def compatible_helper_arch(system_arch)
+    if ["i586", "i386"].include?(system_arch)
+      "i686"
+    elsif system_arch == "armv6l"
+      "armv7l"
+    else
+      system_arch
+    end
   end
 end

--- a/spec/unit/go_spec.rb
+++ b/spec/unit/go_spec.rb
@@ -51,7 +51,7 @@ describe Go do
       it "returns arm, x86_64, i686 and ppc64le" do
         allow(subject).to receive(:version).and_return(1.6)
         expect(subject.archs).to match_array(
-          ["x86_64", "i686", "ppc64le", "ppc64", "armv6l", "armv7l", "aarch64"]
+          ["x86_64", "i686", "ppc64le", "ppc64", "armv7l", "aarch64"]
         )
       end
     end
@@ -62,7 +62,7 @@ describe Go do
         allow(subject).to receive(:suse_package_includes_s390?).and_return(true)
 
         expect(subject.archs).to match_array(
-          ["x86_64", "i686", "ppc64le", "ppc64", "s390x", "armv6l", "armv7l", "aarch64"]
+          ["x86_64", "i686", "ppc64le", "ppc64", "s390x", "armv7l", "aarch64"]
         )
       end
     end
@@ -71,7 +71,7 @@ describe Go do
       it "returns arm, x86_64, i686, ppc64le, ppc64 and s390x" do
         allow(subject).to receive(:version).and_return(1.7)
         expect(subject.archs).to match_array(
-          ["x86_64", "i686", "ppc64le", "ppc64", "s390x", "armv6l", "armv7l", "aarch64"]
+          ["x86_64", "i686", "ppc64le", "ppc64", "s390x", "armv7l", "aarch64"]
         )
       end
     end
@@ -127,13 +127,10 @@ describe Go do
 
       it "compiles arm and i686 with the appropriate compiler options" do
         expect(subject).to receive(:archs).and_return(
-          ["armv6l", "armv7l", "aarch64", "i686"]
+          ["armv7l", "aarch64", "i686"]
         ).at_least(:once)
         expect(subject).to receive(:system).with(
-          "env GOOS=linux GOARCH=arm GOARM=6 go build -o machinery-helper-armv6l"
-        )
-        expect(subject).to receive(:system).with(
-          "env GOOS=linux GOARCH=arm GOARM=7 go build -o machinery-helper-armv7l"
+          "env GOOS=linux GOARCH=arm GOARM=6 go build -o machinery-helper-armv7l"
         )
         expect(subject).to receive(:system).with(
           "env GOOS=linux GOARCH=arm64 go build -o machinery-helper-aarch64"

--- a/spec/unit/machinery_helper_spec.rb
+++ b/spec/unit/machinery_helper_spec.rb
@@ -43,6 +43,40 @@ describe MachineryHelper do
     end
   end
 
+  describe "#local_helper_path" do
+    it "returns the machinery-helper path for supported system archs" do
+      expect(subject.local_helper_path).to eq(
+        File.join(Machinery::ROOT, "machinery-helper", "machinery-helper-#{dummy_system.arch}")
+      )
+    end
+
+    context "in case of old compatible architectures" do
+      it "returns the i686 binary for i586 systems" do
+        expect(dummy_system).to receive(:arch).and_return("i586")
+
+        expect(subject.local_helper_path).to eq(
+          File.join(Machinery::ROOT, "machinery-helper", "machinery-helper-i686")
+        )
+      end
+
+      it "returns the i686 binary for i386 systems" do
+        expect(dummy_system).to receive(:arch).and_return("i386")
+
+        expect(subject.local_helper_path).to eq(
+          File.join(Machinery::ROOT, "machinery-helper", "machinery-helper-i686")
+        )
+      end
+
+      it "returns the armv7l binary for armv6l systems" do
+        expect(dummy_system).to receive(:arch).and_return("armv6l")
+
+        expect(subject.local_helper_path).to eq(
+          File.join(Machinery::ROOT, "machinery-helper", "machinery-helper-armv7l")
+        )
+      end
+    end
+  end
+
   describe "#inject_helper" do
     it "injects the helper using System#inject_file" do
       expect(dummy_system).to receive(:inject_file)

--- a/tools/go.rb
+++ b/tools/go.rb
@@ -25,11 +25,11 @@ class Go
     when version <= 1.4
       ["i686", "x86_64"].include?(local_arch) ? [local_arch] : []
     when version == 1.6 && suse_package_includes_s390?
-      ["i686", "x86_64", "ppc64le", "ppc64", "s390x", "armv6l", "armv7l", "aarch64"]
+      ["i686", "x86_64", "ppc64le", "ppc64", "s390x", "armv7l", "aarch64"]
     when version <= 1.6
-      ["i686", "x86_64", "ppc64le", "ppc64", "armv6l", "armv7l", "aarch64"]
+      ["i686", "x86_64", "ppc64le", "ppc64", "armv7l", "aarch64"]
     when version >= 1.7
-      ["i686", "x86_64", "ppc64le", "ppc64", "s390x", "armv6l", "armv7l", "aarch64"]
+      ["i686", "x86_64", "ppc64le", "ppc64", "s390x", "armv7l", "aarch64"]
     end
   end
 
@@ -81,11 +81,8 @@ class Go
       "386"
     when "aarch64"
       "arm64"
-    when "armv6l"
-      additional_options = " GOARM=6"
-      "arm"
     when "armv7l"
-      additional_options = " GOARM=7"
+      additional_options = " GOARM=6"
       "arm"
     else
       arch


### PR DESCRIPTION
The last fix did create a helper which can run on old systems but the architecture was reported as i586 instead of i686. This pr addresses this issue.