### PR TITLE
Remove machinery mailing list entry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,5 @@ one particular case would be ok, just don't do it.
 
 # Additional Information
 
-If you have any question, feel free to ask on the [Machinery mailing
-list](http://lists.suse.com/mailman/listinfo/machinery). We'll do our best to
-provide a timely and accurate answer.
+If you have any question, feel free to open an issue on our
+[GitHub page](https://github.com/SUSE/machinery/issues).

--- a/README.md
+++ b/README.md
@@ -100,9 +100,5 @@ distributions than SUSE look also
 
 ## Contact
 
-You can subscribe to our
-[mailing list](http://lists.suse.com/mailman/listinfo/machinery)
-([archive](http://lists.suse.com/pipermail/machinery/)) if you would like to
-discuss using or contributing to Machinery. If you have any questions or
-feedback please feel free to
-[send them to the mailing list](mailto:machinery@lists.suse.com) as well.
+If you have any question, feel free to open an issue on our
+[GitHub page](https://github.com/SUSE/machinery/issues).

--- a/docs/Development-Work-Flow.md
+++ b/docs/Development-Work-Flow.md
@@ -82,9 +82,7 @@ implemented, so it's clear when things are done and released.
 There is a team at SUSE which is working on Machinery. We try to do as much as
 possible in the open. All code goes through the
 [public patch review workflow](https://github.com/SUSE/machinery/pulls)
-into the [public repository](http://github.com/SUSE/machinery). We have a
-[public mailing list](machinery@lists.suse.com) to discuss everything
-Machinery.
+into the [public repository](http://github.com/SUSE/machinery).
 
 That said, we do use the privilege of sitting together in the same office and
 sometimes there are things we can't discuss publicly. But we try hard to not let

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,7 @@
 
 This directory contains documentation targeted at developers and contributors of
 Machinery. Together with the source code you should have everything you need to
-know to work on Machinery. If this is not the case please let us know at
-machinery@lists.suse.com.
+know to work on Machinery.
 
 Documentation for users of Machinery is provided as part of the tool in the
 [documentation](http://machinery-project.org/docs) and in the

--- a/machinery.gemspec
+++ b/machinery.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.license     = "GPL-3.0"
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["SUSE"]
-  s.email       = ["machinery@lists.suse.com"]
   s.homepage    = "http://machinery-project.org"
   s.summary     = "Systems management toolkit"
   s.description = "Machinery is a systems management toolkit for Linux. It supports configuration discovery, system validation, and service migration. It's based on the idea of a universal system description."

--- a/manual/docs/index.html
+++ b/manual/docs/index.html
@@ -364,8 +364,8 @@
         </div>
 
         <div class="col-md-offset-3 col-md-6 footer">
-          <a href="mailto:machinery@lists.suse.com">Questions, Feedback, Suggestions</a>
-          <div class="credit">© <a href="http://suse.com">SUSE</a> 2014-2016</div>
+          <a href="https://github.com/SUSE/machinery/issues">Questions, Feedback, Suggestions</a>
+          <div class="credit">© <a href="http://suse.com">SUSE</a> 2014-2018</div>
         </div>
 
 

--- a/spec/definitions/boxes/definitions/base_opensuse_leap_kvm/config.xml
+++ b/spec/definitions/boxes/definitions/base_opensuse_leap_kvm/config.xml
@@ -3,7 +3,7 @@
 <image schemaversion="6.1" name="Base-openSUSE-Leap">
     <description type="system">
         <author>Machinery-Team</author>
-        <contact>machinery@lists.suse.com</contact>
+        <contact></contact>
         <specification>
             Base openSUSE Leap box
         </specification>

--- a/spec/definitions/boxes/definitions/base_opensuse_tumbleweed_kvm/config.xml
+++ b/spec/definitions/boxes/definitions/base_opensuse_tumbleweed_kvm/config.xml
@@ -3,7 +3,7 @@
 <image schemaversion="6.1" name="Base-openSUSE-Tumbleweed">
     <description type="system">
         <author>Machinery-Team</author>
-        <contact>machinery@lists.suse.com</contact>
+        <contact></contact>
         <specification>
             Base openSUSE Tumbleweed box
         </specification>

--- a/spec/definitions/boxes/definitions/machinery_opensuse_leap_kvm/config.xml
+++ b/spec/definitions/boxes/definitions/machinery_opensuse_leap_kvm/config.xml
@@ -3,7 +3,7 @@
 <image schemaversion="6.1" name="Machinery-openSUSE-Leap">
     <description type="system">
         <author>Machinery-Team</author>
-        <contact>machinery@lists.suse.com</contact>
+        <contact></contact>
         <specification>
             Machinery openSUSE Leap box
         </specification>

--- a/spec/definitions/boxes/definitions/machinery_opensuse_tumbleweed_kvm/config.xml
+++ b/spec/definitions/boxes/definitions/machinery_opensuse_tumbleweed_kvm/config.xml
@@ -3,7 +3,7 @@
 <image schemaversion="6.1" name="Machinery-openSUSE-Tumbleweed">
     <description type="system">
         <author>Machinery-Team</author>
-        <contact>machinery@lists.suse.com</contact>
+        <contact></contact>
         <specification>
             Machinery openSUSE Tumbleweed box
         </specification>


### PR DESCRIPTION
because it is deprecated.

Signed-off-by: Tim Hardeck <thardeck@suse.de>