### PR TITLE
Add new error message for passwordless sudo rights

### DIFF
--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -153,6 +153,18 @@ module Machinery
       end
     end
 
+    class SudoNoPasswordRequired < MachineryError
+      def initialize(host)
+	      @host = host
+      end
+
+      def to_s
+        "'sudo' can be used only on #{host}, when no password is required." \
+        " Make sure that you have the following line in 'etc/sudoers' on #{remote_host}" \
+       	" machinery ALL=(ALL) NOPASSWD: ALL"
+      end
+    end
+
     class MigrationError < MachineryError; end
 
     class InvalidFilter < MachineryError; end

--- a/lib/remote_system.rb
+++ b/lib/remote_system.rb
@@ -216,6 +216,8 @@ class Machinery::RemoteSystem < Machinery::System
       raise Machinery::Errors::InsufficientPrivileges.new(remote_user, host)
     elsif e.stderr && e.stderr.include?("you must have a tty to run sudo")
       raise Machinery::Errors::SudoMissingTTY.new(host)
+    elsif e.stderr && e.stderr.include?("no tty present and no askpass program specified")
+      raise Machinery::Errors::SudoNoPasswordRequired.new(remote_user, host)
     else
       raise e
     end


### PR DESCRIPTION
When a user has no passwordless 'sudo' rights on the remote host, we should return a useful error message instead of throwing a backtrace at the user.

Fixes #2253 