### PR TITLE
Set LC_ALL=C for all connection verifications

### DIFF
--- a/lib/remote_system.rb
+++ b/lib/remote_system.rb
@@ -197,7 +197,7 @@ class Machinery::RemoteSystem < Machinery::System
   # and raises an Machinery::Errors::SshConnectionFailed exception when it's not successful.
   def check_connection
     Machinery::LoggedCheetah.run(*build_command(:ssh), "-q", "-o", "BatchMode=yes",
-                      "#{remote_user}@#{host}", ":")
+      "#{remote_user}@#{host}", "LC_ALL=#{locale}", ":")
   rescue Cheetah::ExecutionFailed
     raise Machinery::Errors::SshConnectionFailed.new(
       "Could not establish SSH connection to host '#{host}'. Please make sure that " \
@@ -210,7 +210,7 @@ class Machinery::RemoteSystem < Machinery::System
   def check_sudo
     check_requirement("sudo", "-h")
     Machinery::LoggedCheetah.run(*build_command(:ssh), "-q", "-o", "BatchMode=yes",
-      "#{remote_user}@#{host}", "sudo", "id")
+      "#{remote_user}@#{host}", "LC_ALL=#{locale}", "sudo", "id")
   rescue Cheetah::ExecutionFailed => e
     if e.stderr && e.stderr.include?("password is required")
       raise Machinery::Errors::InsufficientPrivileges.new(remote_user, host)

--- a/spec/unit/remote_system_spec.rb
+++ b/spec/unit/remote_system_spec.rb
@@ -45,6 +45,13 @@ describe Machinery::RemoteSystem do
         remote_system_with_sudo
       end
 
+      it "sets LC_ALL=C to ensure that error messages are as expected" do
+        expect(Machinery::LoggedCheetah).to receive(:run) do |*args|
+          expect(args).to include("LC_ALL=C")
+        end
+        remote_system_with_sudo
+      end
+
       it "raises an exception if the user is not allowed to run sudo" do
         expect(Machinery::LoggedCheetah).to receive(:run).with(
           "ssh", any_args


### PR DESCRIPTION
The LC_ALL environment of all connection verifications is set to "C", so that our error messages can be created accordingly.

Fixes #2257.