### PR TITLE
 Allow kramdown version 2.x

### DIFF
--- a/machinery.gemspec
+++ b/machinery.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.add_dependency "gli", "~>2.11"
   s.add_dependency "json-schema", "~> 2.2.4"
   s.add_dependency "haml", ">= 4.0"
-  s.add_dependency "kramdown", "~> 1.3"
+  s.add_dependency "kramdown", ">= 1.3"
   s.add_dependency "tilt", "~> 2.0"
   s.add_dependency "sinatra", ">= 1.4"
   s.add_dependency "mimemagic", "~> 0.3"


### PR DESCRIPTION
and still support the old versions for backward compatibility.

This is required to install machinery without errors on Tumbleweed. https://build.opensuse.org/package/show/openSUSE:Factory/rubygem-kramdown