### PR TITLE
Allow newer versions of json-schema then 2.2.5

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,8 @@
 # Machinery Release Notes
 
+* Allow newer json-schema releases then 2.2.5. Newer versions slow down parsing
+  of manifests but newer Ruby versions have issues with old json schema releases.
+  The performance issue is known upstream: (gh#ruby-json-schema/json-schema#261)
 * Fix machinery helper go version parsing (bsc#1125785)
 * Allow inspection of old 32-bit systems even when their architecture is
   reported as i586 or i386

--- a/machinery.gemspec
+++ b/machinery.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_dependency "abstract_method", "~>1.2"
   s.add_dependency "builder", "~>3.2"
   s.add_dependency "gli", "~>2.11"
-  s.add_dependency "json-schema", "~> 2.2.4"
+  s.add_dependency "json-schema", "~> 2.2"
   s.add_dependency "haml", ">= 4.0"
   s.add_dependency "kramdown", "~> 1.3"
   s.add_dependency "tilt", "~> 2.0"

--- a/machinery.gemspec
+++ b/machinery.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.add_dependency "gli", "~>2.11"
   s.add_dependency "json-schema", "~> 2.2"
   s.add_dependency "haml", ">= 4.0"
-  s.add_dependency "kramdown", "~> 1.3"
+  s.add_dependency "kramdown", ">= 1.3"
   s.add_dependency "tilt", "~> 2.0"
   s.add_dependency "sinatra", ">= 1.4"
   s.add_dependency "mimemagic", "~> 0.3"

--- a/spec/unit/json_validator_spec.rb
+++ b/spec/unit/json_validator_spec.rb
@@ -81,9 +81,9 @@ describe Machinery::JsonValidator do
     end
 
     it "raises an error when encountering invalid enum values" do
-      expected = <<EOF
-In scope changed_config_files: The property #0 \\(files.*\\) of type .* did not match any of the required schemas
-EOF
+      expected = <<~REGEX
+        In scope changed_config_files: The property #0 \\(files.*\\) of type .* did not match any of the required schemas
+      REGEX
 
       errors = Machinery::JsonValidator.new(JSON.parse(<<-EOT)).validate
         {
@@ -146,9 +146,9 @@ EOF
       let(:path) { "spec/data/schema/validation_error/changed_config_files/" }
 
       it "raises in case of missing package_version" do
-        expected = <<EOF
-In scope changed_config_files: The property #0 (_elements) did not contain a required property of 'package_version'.
-EOF
+        expected = <<~REGEX
+          In scope changed_config_files: The property #0 (_elements) did not contain a required property of 'package_version'.
+        REGEX
         expected.chomp!
         errors = Machinery::JsonValidator.new(
           JSON.parse(File.read("#{path}missing_attribute.json"))
@@ -157,9 +157,9 @@ EOF
       end
 
       it "raises in case of an unknown status" do
-        expected = <<EOF
-In scope changed_config_files: The property #0 \\(_elements.*\\) of type .* did not match any of the required schemas
-EOF
+        expected = <<~REGEX
+          In scope changed_config_files: The property #0 \\(_elements.*\\) of type .* did not match any of the required schemas
+        REGEX
         expected.chomp!
         errors = Machinery::JsonValidator.new(
           JSON.parse(File.read("#{path}unknown_status.json"))
@@ -168,9 +168,9 @@ EOF
       end
 
       it "raises in case of a pattern mismatch" do
-        expected = <<EOF
-In scope changed_config_files: The property #0 \\(_elements.*\\) of type .* did not match any of the required schemas
-EOF
+        expected = <<~REGEX
+          In scope changed_config_files: The property #0 \\(_elements.*\\) of type .* did not match any of the required schemas
+        REGEX
         expected.chomp!
         errors = Machinery::JsonValidator.new(
           JSON.parse(File.read("#{path}pattern_mismatch.json"))
@@ -179,9 +179,9 @@ EOF
       end
 
       it "raises for a deleted file in case of an empty changes array" do
-        expected = <<EOF
-In scope changed_config_files: The property #0 \\(_elements.*\\) of type .* did not match any of the required schemas
-EOF
+        expected = <<~REGEX
+          In scope changed_config_files: The property #0 \\(_elements.*\\) of type .* did not match any of the required schemas
+        REGEX
         expected.chomp!
         errors = Machinery::JsonValidator.new(
           JSON.parse(File.read("#{path}deleted_without_changes.json"))
@@ -194,9 +194,9 @@ EOF
       let(:path) { "spec/data/schema/validation_error/unmanaged_files/" }
 
       it "raises for extracted in case of unknown type" do
-        expected = <<EOF
-In scope unmanaged_files: The property #0 \\(_elements\\) of type .* did not match one or more of the required schemas
-EOF
+        expected = <<~REGEX
+          In scope unmanaged_files: The property #0 \\(_elements\\) of type .* did not match one or more of the required schemas
+        REGEX
         expected.chomp!
         errors = Machinery::JsonValidator.new(
           JSON.parse(File.read("#{path}extracted_unknown_type.json"))

--- a/spec/unit/json_validator_spec.rb
+++ b/spec/unit/json_validator_spec.rb
@@ -82,7 +82,7 @@ describe Machinery::JsonValidator do
 
     it "raises an error when encountering invalid enum values" do
       expected = <<EOF
-In scope changed_config_files: The property #0 (files/changes) of type Hash did not match any of the required schemas.
+In scope changed_config_files: The property #0 \\(files.*\\) of type .* did not match any of the required schemas
 EOF
 
       errors = Machinery::JsonValidator.new(JSON.parse(<<-EOT)).validate
@@ -110,7 +110,7 @@ EOF
         }
       EOT
 
-      expect(errors.first).to eq(expected.chomp)
+      expect(errors.first).to match(/#{expected.chomp}/)
     end
 
     it "does not raise an error when a changed-managed-file is 'replaced'" do
@@ -158,35 +158,35 @@ EOF
 
       it "raises in case of an unknown status" do
         expected = <<EOF
-In scope changed_config_files: The property #0 (_elements/status) of type Hash did not match any of the required schemas.
+In scope changed_config_files: The property #0 \\(_elements.*\\) of type .* did not match any of the required schemas
 EOF
         expected.chomp!
         errors = Machinery::JsonValidator.new(
           JSON.parse(File.read("#{path}unknown_status.json"))
         ).validate
-        expect(errors.first).to eq(expected)
+        expect(errors.first).to match(/#{expected}/)
       end
 
       it "raises in case of a pattern mismatch" do
         expected = <<EOF
-In scope changed_config_files: The property #0 (_elements/mode/changes) of type Hash did not match any of the required schemas.
+In scope changed_config_files: The property #0 \\(_elements.*\\) of type .* did not match any of the required schemas
 EOF
         expected.chomp!
         errors = Machinery::JsonValidator.new(
           JSON.parse(File.read("#{path}pattern_mismatch.json"))
         ).validate
-        expect(errors.first).to eq(expected)
+        expect(errors.first).to match(/#{expected}/)
       end
 
       it "raises for a deleted file in case of an empty changes array" do
         expected = <<EOF
-In scope changed_config_files: The property #0 (_elements/changes) of type Hash did not match any of the required schemas.
+In scope changed_config_files: The property #0 \\(_elements.*\\) of type .* did not match any of the required schemas
 EOF
         expected.chomp!
         errors = Machinery::JsonValidator.new(
           JSON.parse(File.read("#{path}deleted_without_changes.json"))
         ).validate
-        expect(errors.first).to eq(expected)
+        expect(errors.first).to match(/#{expected}/)
       end
     end
 
@@ -195,13 +195,13 @@ EOF
 
       it "raises for extracted in case of unknown type" do
         expected = <<EOF
-In scope unmanaged_files: The property #0 (_elements) of type Hash did not match one or more of the required schemas.
+In scope unmanaged_files: The property #0 \\(_elements\\) of type .* did not match one or more of the required schemas
 EOF
         expected.chomp!
         errors = Machinery::JsonValidator.new(
           JSON.parse(File.read("#{path}extracted_unknown_type.json"))
         ).validate
-        expect(errors.first).to include(expected)
+        expect(errors.first).to match(/#{expected}/)
       end
     end
   end

--- a/spec/unit/manifest_spec.rb
+++ b/spec/unit/manifest_spec.rb
@@ -96,9 +96,9 @@ EOF
       manifest.validate
       expected_output = <<-EOF.chomp
 Warning: System Description validation errors:
-The property '#/meta/os' of type String did not match the following type:
+The property '#/meta/os' of type [Ss]tring did not match the following type:
 EOF
-      expect(captured_machinery_output).to include(expected_output)
+      expect(captured_machinery_output).to match(/#{expected_output}/)
     end
 
     it "doesn't validate incompatible descriptions" do

--- a/spec/unit/validate_task_spec.rb
+++ b/spec/unit/validate_task_spec.rb
@@ -25,13 +25,12 @@ describe Machinery::ValidateTask, "#validate" do
 
   it "raises an error when encountering faulty description" do
     expected = <<EOF
-In scope packages: The property #0 (_elements/checksum/_attributes/package_system) of type Hash did not match any of the required schemas.
-
+In scope packages: The property.* of type .* did not match any of the required schemas
 EOF
     expected.chomp!
     expect {
       validate_task.validate(store, "faulty_description")
-    }.to raise_error(Machinery::Errors::SystemDescriptionValidationFailed, expected)
+    }.to raise_error(Machinery::Errors::SystemDescriptionValidationFailed, /#{expected}/)
   end
 
   it "prints a message in case of successful validation" do

--- a/spec/unit/validate_task_spec.rb
+++ b/spec/unit/validate_task_spec.rb
@@ -24,9 +24,9 @@ describe Machinery::ValidateTask, "#validate" do
   let(:store) { Machinery::SystemDescriptionStore.new("spec/data/schema/") }
 
   it "raises an error when encountering faulty description" do
-    expected = <<EOF
-In scope packages: The property.* of type .* did not match any of the required schemas
-EOF
+    expected = <<~REGEX
+      In scope packages: The property.* of type .* did not match any of the required schemas
+    REGEX
     expected.chomp!
     expect {
       validate_task.validate(store, "faulty_description")


### PR DESCRIPTION
While the performance issue is still not completely fixed
https://github.com/ruby-json-schema/json-schema/issues/261
newer Ruby versions show warnings with the old json-schema versions so
we need to support the newer ones.

Newer json-schema versions have a littel different error messages that's
why the tests needed to be adapted accordingly.