### PR TITLE
Support Kiwi Next Generation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 # Machinery Release Notes
 
+* Switch image building support from legacy Kiwi to Kiwi Next Generation
 * Allow newer json-schema releases then 2.2.5. Newer versions slow down parsing
   of manifests but newer Ruby versions have issues with old json schema releases.
   The performance issue is known upstream: (gh#ruby-json-schema/json-schema#261)

--- a/export_helpers/kiwi_export_readme.md
+++ b/export_helpers/kiwi_export_readme.md
@@ -5,18 +5,18 @@ Machinery.
 
 The user is expected to be familiar with using Kiwi, otherwise
 `machinery build` is recommended.
-Details on Kiwi can be found at http://opensuse.github.com/kiwi
+Details on Kiwi can be found at https://suse.github.com/kiwi
 
 
 ## Creating the image
 
 The following command builds the image:
 
-`sudo /usr/sbin/kiwi --build EXPORTED_DIRECTORY --destdir OUTPUT_DIRECTORY`
+`sudo kiwi-ng system build --description EXPORTED_DIRECTORY --target-dir OUTPUT_DIRECTORY`
 
 
 For example if the exported kiwi description is stored under "/tmp/export"
 and the image should be saved under "/tmp/image" the command would look like
 this:
 
-`sudo /usr/sbin/kiwi --build  /tmp/export --destdir /tmp/image`
+`sudo kiwi-ng system build --description  /tmp/export --target-dir /tmp/image`

--- a/lib/build_task.rb
+++ b/lib/build_task.rb
@@ -18,8 +18,9 @@
 class Machinery::BuildTask
   def build(system_description, output_path, options = {})
     Machinery::LocalSystem.validate_architecture("x86_64")
-    Machinery::LocalSystem.validate_existence_of_packages(["kiwi", "kiwi-desc-vmxboot"])
-    system_description.validate_build_compatibility
+    Machinery::LocalSystem.validate_existence_of_packages(
+      ["python3-kiwi", "kiwi-image-vmx-requires"]
+    )
 
     tmp_config_dir = Dir.mktmpdir("machinery-config", "/tmp")
     tmp_image_dir = Dir.mktmpdir("machinery-image", "/tmp")
@@ -110,7 +111,8 @@ class Machinery::BuildTask
 
   def kiwi_wrapper(tmp_config_dir, tmp_image_dir, output_path, image_extension)
     script = "#!/bin/bash\n"
-    script << "/usr/sbin/kiwi --build '#{tmp_config_dir}' --destdir '#{tmp_image_dir}' --logfile '#{tmp_image_dir}/kiwi-terminal-output.log'\n"
+    script << "/usr/bin/kiwi-ng --logfile='#{tmp_image_dir}/kiwi-terminal-output.log' system"
+    script << " build --description='#{tmp_config_dir}' --target-dir='#{tmp_image_dir}'\n"
     script << "if [ $? -eq 0 ]; then\n"
     script << "  mv '#{tmp_image_dir}/'*.#{image_extension} '#{output_path}'\n"
     script << "  rm -rf '#{tmp_image_dir}'\n"

--- a/lib/deploy_task.rb
+++ b/lib/deploy_task.rb
@@ -21,7 +21,6 @@ class Machinery::DeployTask
     Machinery::LocalSystem.validate_existence_of_packages(
       ["python-glanceclient", "kiwi", "kiwi-desc-vmxboot"]
     )
-    description.validate_build_compatibility
 
     unless File.exist?(cloud_config)
       raise(Machinery::Errors::DeployFailed,

--- a/lib/kiwi_config.rb
+++ b/lib/kiwi_config.rb
@@ -233,7 +233,7 @@ EOF
         xml.type(
           image: "vmx",
           filesystem: "ext3",
-          format: "qcow2", bootloader: @system_description.os.kiwi_bootloader
+          format: "qcow2"
         )
       end
 
@@ -375,12 +375,8 @@ EOF
   end
 
   def enable_dhcp(output_location)
-    if @system_description.os.is_a?(Machinery::OsSles11)
-      write_dhcp_network_config(output_location, "eth0")
-    else
-      write_dhcp_network_config(output_location, "lan0")
-      write_persistent_net_rules(output_location)
-    end
+    write_dhcp_network_config(output_location, "lan0")
+    write_persistent_net_rules(output_location)
     puts "DHCP in built image will be enabled for the first device"
   end
 

--- a/lib/kiwi_config.rb
+++ b/lib/kiwi_config.rb
@@ -233,8 +233,6 @@ EOF
         xml.type(
           image: "vmx",
           filesystem: "ext3",
-          installiso: "true",
-          boot: @system_description.os.kiwi_boot,
           format: "qcow2", bootloader: @system_description.os.kiwi_bootloader
         )
       end

--- a/lib/system_description.rb
+++ b/lib/system_description.rb
@@ -166,15 +166,6 @@ class Machinery::SystemDescription < Machinery::Object
     end
   end
 
-  def validate_build_compatibility
-    kiwi_template_path = "/usr/share/kiwi/image/#{os.kiwi_boot}"
-    unless Dir.exist?(kiwi_template_path)
-      raise Machinery::Errors::BuildFailed.new("The execution of the build script failed. " \
-        "Building of operating system '#{os.display_name}' can't be accomplished because the " \
-        "kiwi template file in `#{kiwi_template_path}` does not exist.")
-    end
-  end
-
   def to_hash
     meta = {}
     meta["format_version"] = self.format_version if self.format_version

--- a/plugins/os/os_model.rb
+++ b/plugins/os/os_model.rb
@@ -95,23 +95,6 @@ module Machinery
     def self.canonical_name
       "SUSE OS"
     end
-
-    def kiwi_bootloader
-      "grub2"
-    end
-
-    def kiwi_boot
-      os_version = version.match(/(\d+)+\.?(\d+)?/)
-      os_id = case name
-              when /SUSE Linux Enterprise Server/
-                "SLES#{os_version[1]}"
-              when /SUSE Linux Enterprise Desktop/
-                "SLED#{os_version[1]}"
-              when /openSUSE/
-                "#{os_version[1]}.#{os_version[2]}"
-      end
-      "vmxboot/suse-#{os_id}"
-    end
   end
 
   class OsSles11 < OsSuse
@@ -127,10 +110,6 @@ module Machinery
       version =~ /11 (.*)/
       sp = $1
       "#{name} #{sp} (#{architecture})"
-    end
-
-    def kiwi_bootloader
-      "grub"
     end
   end
 
@@ -180,10 +159,6 @@ module Machinery
     def self.canonical_name
       "openSUSE Tumbleweed"
     end
-
-    def kiwi_boot
-      "vmxboot/suse-tumbleweed"
-    end
   end
 
   class OsOpenSuseLeap < OsSuse
@@ -193,10 +168,6 @@ module Machinery
 
     def self.canonical_name
       "openSUSE Leap"
-    end
-
-    def kiwi_boot
-      "vmxboot/suse-leap42.1"
     end
   end
 

--- a/spec/unit/build_task_spec.rb
+++ b/spec/unit/build_task_spec.rb
@@ -40,7 +40,6 @@ describe Machinery::BuildTask do
       with("machinery-config", "/tmp").and_return(tmp_config_dir)
     allow(Dir).to receive(:mktmpdir).
       with("machinery-image", "/tmp").and_return(tmp_image_dir)
-    allow_any_instance_of(Machinery::SystemDescription).to receive(:validate_build_compatibility)
 
     FileUtils.touch(File.join(output_path, image_file))
   }
@@ -52,8 +51,8 @@ describe Machinery::BuildTask do
     end
 
     it "calls the kiwi wrapper script with sudo to build the image" do
-      expect(Cheetah).to receive(:run).with("rpm", "-q", "kiwi")
-      expect(Cheetah).to receive(:run).with("rpm", "-q", "kiwi-desc-vmxboot")
+      expect(Cheetah).to receive(:run).with("rpm", "-q", "python3-kiwi")
+      expect(Cheetah).to receive(:run).with("rpm", "-q", "kiwi-image-vmx-requires")
       expect(Cheetah).to receive(:run) { |*cmd_array|
         expect(cmd_array).to include("sudo")
         expect(cmd_array.index{ |s|
@@ -65,8 +64,8 @@ describe Machinery::BuildTask do
     end
 
     it "handles execution errors gracefully" do
-      expect(Cheetah).to receive(:run).with("rpm", "-q", "kiwi")
-      expect(Cheetah).to receive(:run).with("rpm", "-q", "kiwi-desc-vmxboot")
+      expect(Cheetah).to receive(:run).with("rpm", "-q", "python3-kiwi")
+      expect(Cheetah).to receive(:run).with("rpm", "-q", "kiwi-image-vmx-requires")
       expect(Cheetah).to receive(:run) { |*cmd_array|
         expect(cmd_array).to include("sudo")
         expect(cmd_array.index { |s|

--- a/spec/unit/deploy_task_spec.rb
+++ b/spec/unit/deploy_task_spec.rb
@@ -41,7 +41,6 @@ describe Machinery::DeployTask do
     allow(Dir).to receive(:mktmpdir).and_return(tmp_image_dir)
     allow(Machinery::JsonValidator).to receive(:new).and_return(double(validate: []))
     FakeFS::FileSystem.clone("spec/data/deploy/", "/")
-    allow(system_description).to receive(:validate_build_compatibility).and_return(true)
   end
 
   describe "#deploy" do

--- a/spec/unit/kiwi_config_spec.rb
+++ b/spec/unit/kiwi_config_spec.rb
@@ -89,7 +89,7 @@ describe Machinery::KiwiConfig do
   <preferences>
     <packagemanager>zypper</packagemanager>
     <version>0.0.1</version>
-    <type image="vmx" filesystem="ext3" installiso="true" boot="vmxboot/suse-13.1" format="qcow2" bootloader="grub2"/>
+    <type image="vmx" filesystem="ext3" format="qcow2" bootloader="grub2"/>
   </preferences>
   <users group="root">
     <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
@@ -190,52 +190,6 @@ EOT
       expect(config.sh).to include("Alias With Spaces")
     end
 
-    it "generates kiwi config with sysvinit services" do
-      config = Machinery::KiwiConfig.new(system_description_with_sysvinit_services)
-
-      expected_xml = <<EOT
-<?xml version="1.0" encoding="UTF-8"?>
-<image schemaversion="5.8" name="name">
-  <description type="system">
-    <author>Machinery</author>
-    <contact></contact>
-    <specification>Description of system 'name' exported by Machinery</specification>
-  </description>
-  <preferences>
-    <packagemanager>zypper</packagemanager>
-    <version>0.0.1</version>
-    <type image="vmx" filesystem="ext3" installiso="true" boot="vmxboot/suse-SLES11" format="qcow2" bootloader="grub"/>
-  </preferences>
-  <users group="root">
-    <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
-  </users>
-  <repository alias="nodejs_alias" type="rpm-md" priority="1">
-    <source path="http://download.opensuse.org/repositories/devel:/languages:/nodejs/openSUSE_13.1/"/>
-  </repository>
-  <repository alias="NCCRepo" type="yast2" priority="2" username="usernameusernameusernameusername" password="passwordpassword">
-    <source path="https://nu.novell.com/repo/$RCE/SLES11-SP3-Pool/sle-11-x86_64?credentials=NCCcredentials"/>
-  </repository>
-  <repository alias="SUSE_Linux_Enterprise_Server_12_SP1_x86_64:SLES12-SP1-Pool" type="rpm-md" priority="99" username="SCC_usernameusernameusernameusername" password="passwordpassword">
-    <source path="https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP1/x86_64/product?randomrandomrandomrandomrandomrandomrandomrandorandomrandomrandomrandorandomrandomrandomrandorandomrandomrandomrandorandomrandomrandomrandomrandom"/>
-  </repository>
-  <repository alias="Alias-With-Spaces" type="rpm-md" priority="1">
-    <source path="http://download.opensuse.org/repositories/devel:/languages:/nodejs/openSUSE_13.1/"/>
-  </repository>
-  <packages type="bootstrap">
-    <package name="filesystem"/>
-  </packages>
-  <packages type="image">
-    <package name="bash"/>
-    <package name="autofs"/>
-  </packages>
-</image>
-EOT
-      expect(config.xml_text).to eq(expected_xml)
-
-      expect(config.sh).to include("chkconfig sshd on\n")
-      expect(config.sh).to include("chkconfig rsyncd off\n")
-    end
-
     it "generates kiwi config with systemd services" do
       config = Machinery::KiwiConfig.new(system_description_with_systemd_services)
 
@@ -269,7 +223,6 @@ EOT
       config = Machinery::KiwiConfig.new(system_description_with_content)
 
       type_node = REXML::Document.new(config.xml_text).get_elements("/image/preferences/type").first
-      expect(type_node.attributes["boot"]).to eq("vmxboot/suse-13.1")
       expect(type_node.attributes["bootloader"]).to eq("grub2")
     end
 
@@ -302,7 +255,6 @@ EOT
       )
 
       type_node = REXML::Document.new(config.xml_text).get_elements("/image/preferences/type").first
-      expect(type_node.attributes["boot"]).to eq("vmxboot/suse-SLES12")
       expect(type_node.attributes["bootloader"]).to eq("grub2")
     end
 

--- a/spec/unit/models/os_model_spec.rb
+++ b/spec/unit/models/os_model_spec.rb
@@ -38,10 +38,4 @@ describe Machinery::Os do
       expect(Machinery::OsSles12.new.scope_name).to eq("os")
     end
   end
-
-  describe "#kiwi_boot" do
-    it "finds the kiwi boot in a SUSE system" do
-      expect(scope.kiwi_boot).to eq("vmxboot/suse-13.1")
-    end
-  end
 end


### PR DESCRIPTION
Even SLES 12 SP4 ships Kiwi NG and openSUSE 42.3 is almost EOL so it should be ok for us to switch completely to Kiwi NG. This would finally allow building of images on Tumbleweed again.