### PR TITLE
Fix file encoding when creating archive files

### DIFF
--- a/lib/system.rb
+++ b/lib/system.rb
@@ -74,7 +74,7 @@ class Machinery::System
       "The following files are packaged in #{archive}: " + Array(file_list).join(", ")
     )
     created = !File.exist?(archive)
-    out = File.open(archive, "w")
+    out = File.open(archive, "wb")
     begin
       run_command(
         "tar", "--create", "--gzip",


### PR DESCRIPTION
When creating the archive files, we need to open them with "wb"
instead of "w" as the underneath cheetah library is doing partial
read, which always result int ASCII-8BIT encoding [1]. Otherwise,
we'll get an ugly error like this.

"\x8B" from ASCII-8BIT to UTF-8"

in cheetah [2] when attempt to do buffer write to the archive file.

[1] https://ruby-doc.org/core-2.7.0/IO.html
[2] https://github.com/openSUSE/cheetah/blob/master/lib/cheetah.rb#L640