### PR TITLE
Add an options to skip exporting UID, GID, and package version

### DIFF
--- a/export_helpers/unmanaged_files_salt_excludes
+++ b/export_helpers/unmanaged_files_salt_excludes
@@ -7,6 +7,7 @@ etc/shadow*
 etc/sysconfig/network/*
 etc/group*
 etc/udev/rules.d/70-persistent-net.rules
+etc/zypp/repos.d/*
 lib/mkinitrd
 usr/lib/sysimage/rpm
 var/adm/backup

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -635,7 +635,25 @@ module Machinery
         required: false,
         desc:     "Name of the directory where the Salt states will be " \
                   "stored. By default it is the name of the description.",
-        arg_name: "DIRECTORY"
+        arg_name: "NAME"
+      c.switch ["skip-uid"],
+        default_value: false,
+        required:      false,
+        negatable:     false,
+        desc:          "Do not migrate UIDs for users to avoid potential " \
+                       "UID conflicts. Let source machine re-allocate them"
+      c.switch ["skip-gid"],
+        default_value: false,
+        required:      false,
+        negatable:     false,
+        desc:          "Do not migrate GIDs for groups to avoid potential " \
+                       "GID conflicts. Let source machine re-allocate them"
+      c.switch ["skip-package-version"],
+        default_value: false,
+        required:      false,
+        negatable:     false,
+        desc:          "Do not migrate package version. This is useful in " \
+                       "situations where migration to a higher OS version."
       c.switch :force,
         default_value: false,
         required:      false,
@@ -645,7 +663,7 @@ module Machinery
       c.action do |_global_options, options, args|
         name = shift_arg(args, "NAME")
         description = SystemDescription.load(name, system_description_store)
-        exporter = SaltStates.new(description, options: options)
+        exporter = SaltStates.new(description, options)
         task = ExportTask.new(exporter)
         task.export(
           File.expand_path(options["salt-dir"]),


### PR DESCRIPTION
If a given UID has already been taken by a different user on a target machine,
user creation will fail. Therefore, we need to provide an option to skip
exporting the UIDs from source machine to avoid potential UID conflicts
when recreating the user on the target machine. In this case, a new UID will
be allocated during user creation as per

https://docs.saltproject.io/en/latest/ref/states/all/salt.states.user.html

To skip migrating UID, use '--skip-uid' option.

Likewise, use '--skip-gid' option to skip GID migration.

When migrating to a higher OS version, we may not want to migration to package
version as that would constitutes a package downgrade. Furthermore, the
specific package version may no longer be supported in the higher OS version.
Therefore, we need an option to skip migrating the package version.

To skip migrating package version, use '--skip-package-version' option.
