### PR TITLE
Add package mapping capability

### DIFF
--- a/export_helpers/salt_package_map.sample
+++ b/export_helpers/salt_package_map.sample
@@ -1,0 +1,37 @@
+# One-to-one package map. Source package version match is optional. If
+# specified, the version must match the source package version for the mapping
+# to take effect. If source package version is absent, that means it will
+# match any version. Likewise, target package version is optional.
+# When specified, it will map to a specific target package version. Otherwise,
+# it will map to the latest version.
+<source package name>:
+  version: <source package version match>
+  packages:
+    - name: <target package name>
+      version: <target package version>
+
+# Map a source pattern package.
+<source pattern package name>
+  version: <source pattern package version match>
+  pattern: yes
+  packages:
+    - name: <target pattern package name>
+      version: <target pattern package version>
+      pattern: yes
+
+# One-to-many map. A source package can map to multiple packages and/or
+# patterns. 
+<source package name>:
+  version: <source package version match>
+  packages:
+    - name: <target pattern package name>
+      version: <target pattern package version>
+      pattern: yes
+    - name: <target package name>
+      version: <target pacakge version>
+
+# A package without mapping means there are no target packages to map there.
+# Therefore, it will be excluded from migration.
+<source package name>:
+  version: <source package version match>
+

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -654,6 +654,11 @@ module Machinery
         negatable:     false,
         desc:          "Do not migrate package version. This is useful in " \
                        "situations where migration to a higher OS version."
+      c.flag ["package-map-file"],
+        type:     String,
+        required: false,
+        desc:     "Location of the package mapping YAML file.",
+        arg_name: "PACKAGE_MAP"
       c.switch :force,
         default_value: false,
         required:      false,


### PR DESCRIPTION
If a given package/pattern in the source machine had been
renamed/splitted/removed in the target machine, we need a way to map
those packages/patterns into the new packages/patterns. This functionality
is expecially helpful for cross-OS migration (i.e. CentOS to openSUSE).